### PR TITLE
HostLink: expose panel buttons + structured param locks

### DIFF
--- a/docs/hostlink-protocol.md
+++ b/docs/hostlink-protocol.md
@@ -284,6 +284,12 @@ plain editable group labeled by the optional `name` key; its fields omit
 `page`/`pot`.  Unknown kinds **without** fields must be treated as
 opaque.
 
+Custom kinds may also emit per-kind metadata keys (e.g. `slots`,
+`slotSize`, `layout`) between the header and the `fields` array — hosts
+that recognize the kind consume them, others ignore them and fall back
+to the generic field-bearing / opaque rendering.  The `param_locks`
+kind (§5.5) is one example.
+
 ### 5.1 Auto-description
 
 Firmware built on the SDK's surface stack does not hand-write this JSON:
@@ -299,6 +305,102 @@ via `DescriptorBuilder`) remain fully supported and byte-compatible.
 Cross-field references (`maxFrom`, `curveFrom`, `layoutFrom`,
 `alt.layoutFrom`) name field ids **within the same blob**; hosts resolve them
 against current (edited) values so displays stay live during editing.
+
+### 5.2 Buttons
+
+A module may declare its physical push buttons at the descriptor root as
+a `buttons` array (adjacent to `components`).  Buttons are metadata only
+— they are neither addressable nor mutable through the wire protocol.
+Their purpose is to let the host render meaningful chips ("what does B2
+do?  what's it currently set to?") and, for state-controlling buttons,
+back-reference the preset field(s) the button mutates so the current
+value can be shown next to the button and read back consistently.
+
+```jsonc
+"buttons": [
+  { "id": "b1", "name": "Page / Lock", "role": "modal",
+    "actions": [
+      { "gesture": "tap",       "label": "Next Page" },
+      { "gesture": "hold+knob", "label": "Record Param Lock" }
+    ]
+  },
+  { "id": "b2", "name": "Osc Source", "role": "state",
+    "actions": [ { "gesture": "tap", "label": "Cycle Int / Ext / Both" } ],
+    "controls": [ { "field": "source", "action": "cycle" } ]
+  },
+  { "id": "b3", "name": "Sub", "role": "state",
+    "actions": [
+      { "gesture": "tap",  "label": "Cycle Octave −1 / −2 / −3" },
+      { "gesture": "hold", "label": "Toggle Square / Sine" }
+    ],
+    "controls": [
+      { "field": "sub.octave", "action": "cycle"  },
+      { "field": "sub.wave",   "action": "toggle" }
+    ]
+  }
+]
+```
+
+- `id` — stable identifier (hosts key on this; never rename).
+- `role` — `"modal"` (transient gestures — page advance, lock record —
+  no persistent preset relationship) or `"state"` (each press mutates
+  one or more preset fields).  Unknown roles must be shown as a plain
+  chip without control affordances.
+- `actions[]` — labeled gestures (`tap`, `hold`, `hold+knob`,
+  `double_tap`, …); `gesture` values are strings so hosts can
+  forward-tolerate new ones.
+- `controls[]` (state buttons only) — each entry names a preset field
+  by id and the mutation kind (`cycle`, `toggle`, `set`, …).  The named
+  field lives in a normal component; the button entry does not carry
+  the field's value — the host reads it via the usual blob decode.
+
+The array is optional; a module that omits it is rendered without a
+button panel.
+
+### 5.3 Parameter locks (`kind: "param_locks"`)
+
+A `param_locks` component wraps a slot-array of looping-automation
+recordings that live in the preset blob.  The component is opaque at
+the field level — locks are recorded on-device by hardware gesture, not
+edited from the host — but the descriptor exposes the per-slot layout
+so hosts can *view* the recorded envelopes and *delete* individual
+slots by zeroing their `active` byte.
+
+```jsonc
+{ "id": "locks", "kind": "param_locks",
+  "hash": 0xDEADBEEF, "size": 12372, "off": 96,
+  "name": "Param Locks",
+  "slots": 12, "slotSize": 1031, "bufLen": 256,
+  "layout": {
+    "activeOff": 0, "lengthOff": 1, "baseOff": 3, "bufOff": 7
+  }
+}
+```
+
+- `slots` — number of automation slots in this component.
+- `slotSize` — bytes per slot; `size` == `slots * slotSize`.
+- `bufLen` — envelope buffer length in f32 samples (protocol constant;
+  redundantly exposed so hosts don't have to encode it).
+- `layout.*Off` — byte offsets within one slot for the `active`
+  (u8), `length` (u16, LE), `record_base` (f32, LE), and buffer (f32
+  array, LE) fields.
+
+To render slot `i`:
+
+1. Read `blob[c.off + i*slotSize + activeOff]` — skip if zero.
+2. Read `length` (u16) at `bufOff + lengthOff` within the slot.
+3. Read `record_base` (f32) at `bufOff + baseOff`.
+4. Read `length` f32 samples starting at `bufOff + bufOff` — the y-axis
+   is the recorded normalized value; plot at unit spacing.
+
+To delete a slot: write `0` to the slot's `activeOff` byte in the blob
+and push via `SET_LIVE`.  Save-to-slot to persist.
+
+The kind is field-less on purpose: the fields path is for
+knob-shaped edits, and per-lock automation is not that.  Hosts that do
+not recognize `param_locks` must fall back to the generic no-fields
+rendering (an unnamed chip) — the schema hash still guarantees
+byte-exact round-trip.
 
 ## 6. Versioning rules
 

--- a/framework/include/alchemy/host_link/component_writer.h
+++ b/framework/include/alchemy/host_link/component_writer.h
@@ -73,6 +73,18 @@ class ComponentWriter
                FieldType type, float def, const char* disp_json = nullptr,
                uint16_t zones = 0u, int16_t page = -1, int16_t pot = -1);
 
+    /**
+     * Emit `,"<key>":<raw_json>` inside the component object, between the
+     * header (id / kind / hash / size / off / optional name) and the
+     * "fields" array.  Custom kinds (e.g. "param_locks") use this for
+     * per-kind metadata that doesn't fit the pager/settings shape — slot
+     * counts, per-lock layouts, etc.  Call *before* the first Field();
+     * once the fields array is open, further meta would produce
+     * malformed JSON and this call latches the whole build to failure.
+     * @p raw_json must be a syntactically valid JSON value.
+     */
+    bool Meta(const char* key, const char* raw_json);
+
     /* ── Renderer interface ─────────────────────────────────────────── */
 
     /** Emit + close the component (renderer calls this, not describers). */

--- a/framework/include/alchemy/host_link/describe.h
+++ b/framework/include/alchemy/host_link/describe.h
@@ -39,6 +39,7 @@ namespace alchemy {
 class Page;
 class Presets;
 class Serializable;
+class VirtualButton;
 
 namespace hostlink {
 
@@ -61,16 +62,20 @@ struct PageSet
 };
 
 /**
- * Render the full descriptor into @p buf.  @p pages and @p overrides are
- * optional (pass nullptr / 0).  Returns the descriptor length, or 0 on
- * any drift, overflow, or describer failure.
+ * Render the full descriptor into @p buf.  @p pages, @p overrides, and
+ * @p buttons are optional (pass nullptr / 0).  Buttons become the
+ * top-level "buttons" array (protocol §5.5); a zero count omits the key.
+ * Returns the descriptor length, or 0 on any drift, overflow, or
+ * describer failure.
  */
 uint32_t RenderDescriptor(char* buf, size_t cap,
                           const DescriptorBuilder::ModuleInfo& info,
                           const Presets& presets,
                           const PageSet* pages,
                           const DescribeOverride* overrides,
-                          uint8_t num_overrides);
+                          uint8_t num_overrides,
+                          const VirtualButton* buttons = nullptr,
+                          uint8_t num_buttons = 0u);
 
 } // namespace hostlink
 } // namespace alchemy

--- a/framework/include/alchemy/host_link/descriptor.h
+++ b/framework/include/alchemy/host_link/descriptor.h
@@ -40,6 +40,7 @@ class Presets;
 class Pager;
 class Settings;
 class Serializable;
+class VirtualButton;
 
 namespace hostlink {
 
@@ -136,6 +137,25 @@ class DescriptorBuilder
                        const char* disp_json);
     bool EndSettings();
 
+    /* ── Buttons (top-level, optional) ──────────────────────────────
+     * A module's physical push buttons rendered as descriptor metadata
+     * alongside the component list.  The array itself is emitted in
+     * Finish() so it lands after "components" and before the root
+     * close; call this after every EndPager/EndSettings/EndComponent
+     * (and before Finish()) to stash the table.  Passing count == 0 is
+     * a no-op — the key is omitted entirely, preserving descriptor
+     * bytes on modules that expose no button metadata. */
+    bool Buttons(const VirtualButton* buttons, uint8_t count);
+
+    /* ── Generic-component raw key/value ────────────────────────────
+     * Emit `,"<key>":<raw_json>` inside the currently-open generic
+     * component, between the header (id/kind/hash/size/off) and the
+     * "fields" array.  For custom kinds that need per-kind metadata
+     * (slot count, per-lock layout, …) without abusing the fields
+     * path.  @p raw_json must be a syntactically valid JSON value
+     * (object, array, string, number, or bool). */
+    bool GenericMeta(const char* key, const char* raw_json);
+
     /** Close all structures and validate totals.  Returns descriptor
      *  length in bytes, or 0 if anything drifted or overflowed. */
     uint32_t Finish();
@@ -167,6 +187,11 @@ class DescriptorBuilder
      * slot persists nothing. */
     const Settings* settings_ = nullptr;
     int16_t         offsets_[kMaxSettingsPages][kMaxPots];
+
+    /* Buttons stashed for emission during Finish().  Pointer is
+     * non-owning — the caller keeps the array alive. */
+    const VirtualButton* buttons_     = nullptr;
+    uint8_t              num_buttons_ = 0u;
 };
 
 } // namespace hostlink

--- a/framework/include/alchemy/host_link/host.h
+++ b/framework/include/alchemy/host_link/host.h
@@ -59,6 +59,7 @@ namespace alchemy {
 class ControlLoop;
 class Page;
 class Presets;
+class VirtualButton;
 
 namespace hostlink {
 
@@ -120,6 +121,16 @@ class Host : public HostService
         return *this;
     }
 
+    /**
+     * Declare the module's physical push buttons — identity, role,
+     * gestures, and (for State-role buttons) the preset fields they
+     * mutate.  Emitted as the descriptor's top-level "buttons" array
+     * (protocol §5.5).  @p buttons must outlive the link (a static
+     * or constexpr file-scope table is the intended pattern).  Pass
+     * count == 0 to omit the key entirely.
+     */
+    Host& Buttons(const VirtualButton* buttons, uint8_t count);
+
     /* ── Lifecycle ───────────────────────────────────────────────────── */
 
     /** Bring the link up (idempotent).  Called automatically from the
@@ -171,6 +182,9 @@ class Host : public HostService
     ControlLoop* loop_                  = nullptr;
     const Page*  pages_[kMaxPageRefs]   = {};
     uint8_t      num_pages_             = 0u;
+
+    const VirtualButton* buttons_       = nullptr;
+    uint8_t              num_buttons_   = 0u;
 
     HostLink* link_    = nullptr;
     bool      started_ = false;

--- a/framework/include/alchemy/surface/virtual_button.h
+++ b/framework/include/alchemy/surface/virtual_button.h
@@ -1,0 +1,155 @@
+/**
+ * @file alchemy/surface/virtual_button.h
+ * @brief alchemy::VirtualButton — declarative button metadata.
+ *
+ * VirtualButton is the twin of VirtualKnob: a small, declarative bundle
+ * that names a physical push button, describes what its gestures do, and
+ * — when the button drives persistent state — points at the preset
+ * field(s) it mutates.
+ *
+ * The button itself is a hardware IButton (or a Pager / ParamLock owner
+ * of one).  VirtualButton adds *nothing* to the runtime path — it is
+ * pure metadata, consumed by the HostLink descriptor so the web tool can
+ * render meaningful button chips, gesture hints, and (for state buttons)
+ * a "controls this field" back-reference.
+ *
+ * Usage:
+ *
+ *   using B = alchemy::VirtualButton;
+ *   constexpr B b_source = B("b2", "Osc Source")
+ *       .Role(B::Role::State)
+ *       .Action("tap", "Cycle Int / Ext / Both")
+ *       .Controls("modes.source", B::Action::Cycle);
+ *
+ *   constexpr B b_pager = B("b1", "Page / Lock")
+ *       .Role(B::Role::Modal)
+ *       .Action("tap",       "Next Page")
+ *       .Action("hold+knob", "Record Param Lock");
+ *
+ * "Modal" buttons drive transient gestures (page advance, lock record) —
+ * they carry no persistent state and their only preset relationship is
+ * *incidental* (e.g. the pot values a locked knob captures).  "State"
+ * buttons cycle or toggle one or more preset fields; the descriptor
+ * points at those fields by id so the host can show the current value
+ * next to the button and read it back consistently.
+ *
+ * All strings are held by pointer (string literals or static lifetime).
+ * No allocation, no destructors — safe as a constexpr file-scope table.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace alchemy {
+
+class VirtualButton
+{
+  public:
+    /** Modal buttons drive gestures; State buttons cycle/toggle fields. */
+    enum class Role : uint8_t { Modal, State };
+
+    /** Semantic mutation kind for a State button's field controls.
+     *  Cycle : each press advances to the next zone (wraps).
+     *  Toggle: each press flips 0 ↔ 1 (or between two zones).
+     *  Set   : the button drives the field to a specific value on press. */
+    enum class Action : uint8_t { Cycle, Toggle, Set };
+
+    /** Capped storage — a real hardware button rarely has more than a
+     *  handful of distinct gestures or fields under it, and we want the
+     *  table to fit in a bare struct with no allocation. */
+    static constexpr uint8_t kMaxActions  = 4;
+    static constexpr uint8_t kMaxControls = 4;
+
+    /**
+     * @param ident  Stable id (e.g. "b1"). Hosts key on this — never rename.
+     * @param name   Display name (e.g. "Page / Lock").
+     */
+    constexpr VirtualButton(const char* ident, const char* name)
+        : ident_(ident), name_(name) {}
+
+    /* ── Configuration (builder, string literals only) ───────────────── */
+
+    constexpr VirtualButton& Role(enum Role r) { role_ = r; return *this; }
+
+    /** Declare a labeled gesture the button performs.  Silently drops
+     *  entries past kMaxActions — a hardware button with more than that
+     *  is a design smell, not a runtime error. */
+    constexpr VirtualButton& Action(const char* gesture, const char* label)
+    {
+        if (num_actions_ < kMaxActions)
+        {
+            actions_[num_actions_].gesture = gesture;
+            actions_[num_actions_].label   = label;
+            ++num_actions_;
+        }
+        return *this;
+    }
+
+    /** For State-role buttons: declare that this button mutates the
+     *  named field with the given action.  Field ids are the same ids
+     *  the field's owning component emits (looked up via fieldById). */
+    constexpr VirtualButton& Controls(const char* field_id, enum Action action)
+    {
+        if (num_controls_ < kMaxControls)
+        {
+            controls_[num_controls_].field  = field_id;
+            controls_[num_controls_].action = action;
+            ++num_controls_;
+        }
+        return *this;
+    }
+
+    /* ── Accessors (used by the descriptor emitter) ──────────────────── */
+
+    constexpr const char* Ident() const { return ident_; }
+    constexpr const char* Name()  const { return name_; }
+    constexpr enum Role   RoleValue() const { return role_; }
+
+    constexpr uint8_t     NumActions() const { return num_actions_; }
+    constexpr const char* ActionGesture(uint8_t i) const { return actions_[i].gesture; }
+    constexpr const char* ActionLabel  (uint8_t i) const { return actions_[i].label;   }
+
+    constexpr uint8_t     NumControls() const { return num_controls_; }
+    constexpr const char* ControlField (uint8_t i) const { return controls_[i].field;  }
+    constexpr enum Action ControlAction(uint8_t i) const { return controls_[i].action; }
+
+    /** Wire-name for a role.  Kept as a string on the wire so hosts can
+     *  forward-tolerate roles this SDK doesn't know yet. */
+    static constexpr const char* RoleName(enum Role r)
+    {
+        switch (r)
+        {
+            case Role::State: return "state";
+            case Role::Modal: /* fall through */
+            default:          return "modal";
+        }
+    }
+
+    /** Wire-name for an action.  Same forward-tolerance rule. */
+    static constexpr const char* ActionName(enum Action a)
+    {
+        switch (a)
+        {
+            case Action::Toggle: return "toggle";
+            case Action::Set:    return "set";
+            case Action::Cycle:  /* fall through */
+            default:             return "cycle";
+        }
+    }
+
+  private:
+    struct ActionEntry  { const char* gesture = nullptr; const char* label = nullptr; };
+    struct ControlEntry { const char* field   = nullptr; enum Action action = Action::Cycle; };
+
+    const char*  ident_;
+    const char*  name_;
+    enum Role    role_          = Role::Modal;
+    ActionEntry  actions_[kMaxActions]   = {};
+    uint8_t      num_actions_   = 0;
+    ControlEntry controls_[kMaxControls] = {};
+    uint8_t      num_controls_  = 0;
+};
+
+} // namespace alchemy

--- a/framework/src/host_link/describe.cpp
+++ b/framework/src/host_link/describe.cpp
@@ -76,6 +76,13 @@ bool ComponentWriter::Field(const char* id, const char* name, uint32_t off,
     return ok_;
 }
 
+bool ComponentWriter::Meta(const char* key, const char* raw_json)
+{
+    if (!Open()) return false;
+    ok_ = db_.GenericMeta(key, raw_json) && ok_;
+    return ok_;
+}
+
 bool ComponentWriter::Finalize()
 {
     if (!Open()) return false;
@@ -273,10 +280,13 @@ uint32_t RenderDescriptor(char* buf, size_t cap,
                           const Presets& presets,
                           const PageSet* pages,
                           const DescribeOverride* overrides,
-                          uint8_t num_overrides)
+                          uint8_t num_overrides,
+                          const VirtualButton* buttons,
+                          uint8_t num_buttons)
 {
     DescriptorBuilder db(buf, cap, presets);
     bool ok = db.Begin(info);
+    if (ok) ok = db.Buttons(buttons, num_buttons);
 
     uint8_t n_opaque = 0u;
     for (uint8_t i = 0; ok && i < presets.NumManaged(); i++)

--- a/framework/src/host_link/descriptor.cpp
+++ b/framework/src/host_link/descriptor.cpp
@@ -9,6 +9,7 @@
 #include "alchemy/surface/presets.h"
 #include "alchemy/surface/settings.h"
 #include "alchemy/surface/serializable.h"
+#include "alchemy/surface/virtual_button.h"
 
 namespace alchemy {
 namespace hostlink {
@@ -303,6 +304,26 @@ bool DescriptorBuilder::EndComponent()
     return !error_;
 }
 
+bool DescriptorBuilder::GenericMeta(const char* key, const char* raw_json)
+{
+    /* Meta lives between the header and the fields array — after the
+     * first Field the writer has already opened "fields":[…] and we
+     * cannot inject a sibling key without producing malformed JSON. */
+    if (!generic_open_ || fields_open_) { error_ = true; return false; }
+    /* Reject empty strings too — an empty raw_json emits `"<key>":`
+     * with no value, which corrupts the object (subsequent siblings
+     * come out with a leading comma).  Callers must pass a full JSON
+     * value; there is no valid empty representation. */
+    if (!key || !key[0] || !raw_json || !raw_json[0])
+    {
+        error_ = true;
+        return false;
+    }
+    w_.Key(key);
+    w_.RawValue(raw_json);
+    return !error_;
+}
+
 /* ── Settings ───────────────────────────────────────────────────────── */
 
 bool DescriptorBuilder::BeginSettings(const char* id, const Settings& settings,
@@ -403,11 +424,77 @@ bool DescriptorBuilder::EndSettings()
     return !error_;
 }
 
+/* ── Buttons (top-level) ───────────────────────────────────────────── */
+
+bool DescriptorBuilder::Buttons(const VirtualButton* buttons, uint8_t count)
+{
+    if (pager_ || settings_ || generic_open_)
+    {
+        error_ = true;
+        return false;
+    }
+    /* Passing a null pointer with a nonzero count would emit dangling
+     * commas in Finish(); reject up front. */
+    if (count > 0u && !buttons) { error_ = true; return false; }
+    buttons_     = buttons;
+    num_buttons_ = count;
+    return !error_;
+}
+
+/* Emit the stashed button table as a top-level "buttons":[...] array.
+ * Called from Finish() between the components array close and the root
+ * object close.  No-op when the caller stashed nothing. */
+static void EmitButtons(JsonWriter& w,
+                        const VirtualButton* buttons, uint8_t count)
+{
+    if (count == 0u || buttons == nullptr) return;
+    w.Key("buttons");
+    w.BeginArr();
+    for (uint8_t i = 0; i < count; i++)
+    {
+        const VirtualButton& b = buttons[i];
+        w.BeginObj();
+        w.Key("id");   w.Str(b.Ident() ? b.Ident() : "");
+        w.Key("name"); w.Str(b.Name()  ? b.Name()  : "");
+        w.Key("role"); w.Str(VirtualButton::RoleName(b.RoleValue()));
+
+        if (b.NumActions() > 0u)
+        {
+            w.Key("actions");
+            w.BeginArr();
+            for (uint8_t j = 0; j < b.NumActions(); j++)
+            {
+                w.BeginObj();
+                w.Key("gesture"); w.Str(b.ActionGesture(j) ? b.ActionGesture(j) : "");
+                w.Key("label");   w.Str(b.ActionLabel  (j) ? b.ActionLabel  (j) : "");
+                w.EndObj();
+            }
+            w.EndArr();
+        }
+        if (b.NumControls() > 0u)
+        {
+            w.Key("controls");
+            w.BeginArr();
+            for (uint8_t j = 0; j < b.NumControls(); j++)
+            {
+                w.BeginObj();
+                w.Key("field");  w.Str(b.ControlField(j) ? b.ControlField(j) : "");
+                w.Key("action"); w.Str(VirtualButton::ActionName(b.ControlAction(j)));
+                w.EndObj();
+            }
+            w.EndArr();
+        }
+        w.EndObj();
+    }
+    w.EndArr();
+}
+
 /* ── Finish ─────────────────────────────────────────────────────────── */
 
 uint32_t DescriptorBuilder::Finish()
 {
     w_.EndArr();   /* components */
+    EmitButtons(w_, buttons_, num_buttons_);
     w_.EndObj();   /* root */
 
     if (error_) return 0u;

--- a/framework/src/host_link/host.cpp
+++ b/framework/src/host_link/host.cpp
@@ -102,6 +102,13 @@ void Host::AddPage(const Page& p)
     if (num_pages_ < kMaxPageRefs) pages_[num_pages_++] = &p;
 }
 
+Host& Host::Buttons(const VirtualButton* buttons, uint8_t count)
+{
+    buttons_     = buttons;
+    num_buttons_ = count;
+    return *this;
+}
+
 void Host::OnAttach(ControlLoop& loop) { loop_ = &loop; }
 
 void Host::Start()
@@ -174,7 +181,8 @@ void Host::Start()
             DescriptorBuilder::ModuleInfo{id_, name_, fw_, git_,
                                           ALCHEMY_SDK_VERSION, board_name},
             presets_, num_pages_ ? &set : nullptr,
-            overrides_, num_overrides_);
+            overrides_, num_overrides_,
+            buttons_, num_buttons_);
         link_->SetDescriptor(desc_buf_, len);
     }
 

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -32,6 +32,7 @@
 #include "alchemy/surface/preset_name.h"
 #include "alchemy/surface/presets.h"
 #include "alchemy/surface/settings.h"
+#include "alchemy/surface/virtual_button.h"
 #include "alchemy/surface/virtual_knob.h"
 
 using namespace alchemy;
@@ -1036,6 +1037,179 @@ static void TestAutoDescribeGenericAndOverrides()
     }
 }
 
+/* ── Buttons + custom-component meta ──────────────────────────────── */
+
+static void TestButtonsEmission()
+{
+    RamFlash    flash;
+    Presets     presets{g_dummy_qspi};
+    TestComp<2> comp{0x77777777u};
+    presets.Manage(comp);
+    presets.Init(flash.Ops(), flash.Base());
+
+    using B = VirtualButton;
+    /* One of each role, plus multiple actions and controls on the
+     * state button — covers every JSON branch. */
+    static constexpr B kButtons[] = {
+        B("b1", "Pager")
+            .Role(B::Role::Modal)
+            .Action("tap", "Next Page")
+            .Action("hold+knob", "Record Lock"),
+        B("b2", "Source")
+            .Role(B::Role::State)
+            .Action("tap", "Cycle")
+            .Controls("mode.source", B::Action::Cycle)
+            .Controls("mode.sub", B::Action::Toggle),
+    };
+
+    static char buf[8192];
+    const uint32_t len = RenderDescriptor(
+        buf, sizeof buf,
+        {"btnmod", "Buttons", "0.0.1", "gitbtn", "0.1.0", "v1"},
+        presets, nullptr, nullptr, 0,
+        kButtons, sizeof(kButtons) / sizeof(kButtons[0]));
+    CHECK(len > 0u);
+    const std::string json(buf, len);
+
+    /* Top-level array present, in declared order. */
+    const auto btn = json.find("\"buttons\":[");
+    CHECK(btn != std::string::npos);
+    /* Components must precede buttons — buttons is a root-level sibling
+     * emitted after "components" closes. */
+    CHECK(json.find("\"components\":") < btn);
+
+    /* Modal button: role wire-name, actions array, no controls key. */
+    CHECK(json.find("\"id\":\"b1\",\"name\":\"Pager\",\"role\":\"modal\"")
+          != std::string::npos);
+    CHECK(json.find("\"gesture\":\"tap\",\"label\":\"Next Page\"")
+          != std::string::npos);
+    CHECK(json.find("\"gesture\":\"hold+knob\",\"label\":\"Record Lock\"")
+          != std::string::npos);
+    const auto b1 = json.find("\"id\":\"b1\"");
+    const auto b2 = json.find("\"id\":\"b2\"");
+    CHECK(b1 != std::string::npos && b2 != std::string::npos && b1 < b2);
+    /* Modal button must NOT emit a controls key. */
+    CHECK(json.find("\"controls\":", b1) > b2);
+
+    /* State button: controls array with cycle/toggle action names. */
+    CHECK(json.find("\"role\":\"state\"") != std::string::npos);
+    CHECK(json.find("\"field\":\"mode.source\",\"action\":\"cycle\"")
+          != std::string::npos);
+    CHECK(json.find("\"field\":\"mode.sub\",\"action\":\"toggle\"")
+          != std::string::npos);
+
+    /* Passing count == 0 must omit the key entirely. */
+    static char buf2[8192];
+    const uint32_t len2 = RenderDescriptor(
+        buf2, sizeof buf2,
+        {"btnmod", "Buttons", "0.0.1", "gitbtn", "0.1.0", "v1"},
+        presets, nullptr, nullptr, 0, kButtons, 0);
+    CHECK(len2 > 0u);
+    CHECK(std::string(buf2, len2).find("\"buttons\"") == std::string::npos);
+
+    /* count > 0 with a null pointer is a misuse — descriptor fails. */
+    static char buf3[8192];
+    const uint32_t len3 = RenderDescriptor(
+        buf3, sizeof buf3,
+        {"btnmod", "Buttons", "0.0.1", "gitbtn", "0.1.0", "v1"},
+        presets, nullptr, nullptr, 0, nullptr, 2);
+    CHECK_EQ(len3, 0u);
+}
+
+/** Custom Serializable that emits per-kind metadata via ComponentWriter::Meta
+ *  — the pattern the ParamLock describer uses. */
+template <size_t N>
+struct MetaComp : TestComp<N>
+{
+    explicit MetaComp(uint32_t hash) : TestComp<N>(hash) {}
+
+    bool Describe(ComponentWriter& w) const override
+    {
+        w.Kind("param_locks").Label("Param Locks");
+        bool ok = w.Meta("slots", "12");
+        ok &= w.Meta("slotSize", "1031");
+        ok &= w.Meta("layout",
+                     "{\"activeOff\":0,\"lengthOff\":1,"
+                     "\"baseOff\":3,\"bufOff\":7}");
+        return ok;
+    }
+};
+
+static void TestComponentMeta()
+{
+    RamFlash    flash;
+    Presets     presets{g_dummy_qspi};
+    MetaComp<4> locks{0x8888ABCDu};
+    presets.Manage(locks);
+    presets.Init(flash.Ops(), flash.Base());
+
+    static char buf[8192];
+    const uint32_t len = RenderDescriptor(
+        buf, sizeof buf,
+        {"metamod", "Meta", "0.0.1", "gitmeta", "0.1.0", "v1"},
+        presets, nullptr, nullptr, 0);
+    CHECK(len > 0u);
+    const std::string json(buf, len);
+
+    /* Meta keys land between the header and (absent) fields array. */
+    CHECK(json.find("\"kind\":\"param_locks\"") != std::string::npos);
+    CHECK(json.find("\"name\":\"Param Locks\"") != std::string::npos);
+    CHECK(json.find("\"slots\":12") != std::string::npos);
+    CHECK(json.find("\"slotSize\":1031") != std::string::npos);
+    CHECK(json.find("\"layout\":{\"activeOff\":0,\"lengthOff\":1,"
+                    "\"baseOff\":3,\"bufOff\":7}") != std::string::npos);
+    /* No fields key emitted — MetaComp writes none. */
+    CHECK(json.find("\"fields\":") == std::string::npos);
+
+    /* An empty raw_json would emit `"key":` with no value — must fail
+     * (not silently ship an invalid descriptor). */
+    struct EmptyMeta : TestComp<4>
+    {
+        EmptyMeta() : TestComp<4>(0xAAAAAAAAu) {}
+        bool Describe(ComponentWriter& w) const override
+        {
+            w.Kind("param_locks");
+            return w.Meta("slots", "");
+        }
+    };
+    {
+        RamFlash flashE;
+        Presets  presetsE{g_dummy_qspi};
+        EmptyMeta em;
+        presetsE.Manage(em);
+        presetsE.Init(flashE.Ops(), flashE.Base());
+        static char bufE[8192];
+        CHECK_EQ(RenderDescriptor(bufE, sizeof bufE,
+                                  {"m", "m", "0", "g", "s", "v1"},
+                                  presetsE, nullptr, nullptr, 0),
+                 0u);
+    }
+
+    /* Meta after a field is malformed JSON — must fail the build. */
+    struct BadOrder : TestComp<4>
+    {
+        BadOrder() : TestComp<4>(0x99999999u) {}
+        bool Describe(ComponentWriter& w) const override
+        {
+            w.Kind("param_locks");
+            bool ok = w.Field("x", "X", 0, FieldType::F32, 0.f);
+            /* Post-Field meta must latch failure, not silently no-op. */
+            w.Meta("slots", "12");
+            return ok && w.Ok();
+        }
+    };
+    RamFlash flash2;
+    Presets  presets2{g_dummy_qspi};
+    BadOrder bad;
+    presets2.Manage(bad);
+    presets2.Init(flash2.Ops(), flash2.Base());
+    static char buf2[8192];
+    CHECK_EQ(RenderDescriptor(buf2, sizeof buf2,
+                              {"m", "m", "0", "g", "s", "v1"},
+                              presets2, nullptr, nullptr, 0),
+             0u);
+}
+
 static void TestUseNames()
 {
     RamFlash    flash;
@@ -1218,6 +1392,8 @@ int main(int argc, char** argv)
     TestDescriptorBuilder();
     TestAutoDescribe();
     TestAutoDescribeGenericAndOverrides();
+    TestButtonsEmission();
+    TestComponentMeta();
     TestUseNames();
 
     std::printf("%d checks, %d failures\n", g_checks, g_failures);


### PR DESCRIPTION
## Summary

Extends the HostLink descriptor so hosts can render a module's push buttons meaningfully and view/delete recorded parameter-lock envelopes. No wire-protocol changes — everything additive.

- **`alchemy::VirtualButton`** — declarative twin of `VirtualKnob`. Carries a button's `ident`, `name`, `role` (Modal / State), labeled `actions` (gesture + label), and — for State-role buttons — `controls` linking to the preset field ids the button mutates.
- **`hostlink::Host::Buttons(table, count)`** — stashes a pointer to a caller-owned `VirtualButton` table (a `constexpr` file-scope array is the intended pattern) and forwards it into `RenderDescriptor`.
- **Top-level `"buttons"` array in the descriptor JSON** — emitted between the components array and the root close in `Finish()`. A zero count omits the key entirely, so older gateways ignore the addition.
- **`ComponentWriter::Meta(key, raw_json)`** — new escape hatch for custom-kind metadata (slot counts, per-lock layouts) that doesn't fit the fields path. Empty and out-of-order calls latch the descriptor build to failure, matching the existing drift-guard model.
- **`param_locks` component kind** — documented in `docs/hostlink-protocol.md` §5.3. Field-less on purpose (recorded automation isn't knob-shaped); hosts render it through the layout metadata (`activeOff` / `lengthOff` / `baseOff` / `bufOff` + `slots` / `slotSize` / `bufLen`) and treat unknown kinds as opaque, so no client changes are forced.

## Test plan

- [x] `cmake --build --preset host` clean.
- [x] `ctest --test-dir build-host` — 2/2 passed.
- [x] `hostlink_tests` — **1077 checks, 0 failures**. New coverage:
  - `TestButtonsEmission` — modal + state buttons, absent-actions branch, missing-controls branch, `count == 0` no-op key omission, `count > 0` with `nullptr` rejection, component-vs-buttons ordering assertion.
  - `TestComponentMeta` — `Meta` happy path, empty-string `raw_json` rejection, meta-after-field ordering failure.
- [x] Golden vectors (`tests/host/golden/hostlink_golden.json`) round-trip byte-identical after `--emit-golden` — no client re-baseline needed.
- [x] Downstream integration (bass-vox firmware) cross-compiles cleanly to `stm32h750xx` with a real `kButtons[]` table; `descriptor_check` emits the new schema and every button-referenced field id resolves.