### PR TITLE
Decouple param-lock playback from gesture handling

### DIFF
--- a/framework/include/alchemy/surface/control_loop.h
+++ b/framework/include/alchemy/surface/control_loop.h
@@ -33,9 +33,10 @@
  *        OnPoll user hook
  *   2. phys[] snapshot
  *   3. settings.Update             (always runs; B2+B3 enter gesture)
+ *      locks.Advance               (always runs; playback survives Settings)
  *   4. while !settings.IsActive():
  *        cv_source.Update          (refresh per-(page, pot) CV delta cache)
- *        locks.Update              (advance play heads; may consume B1)
+ *        locks.Update              (record/disarm gestures; may consume B1)
  *        storage.Update            (Pager: page-advance + pot-catch)
  *        OnPageChange hook
  *        OnFrame user hook

--- a/framework/include/alchemy/surface/lock_source.h
+++ b/framework/include/alchemy/surface/lock_source.h
@@ -41,8 +41,21 @@ class LockSource
      */
     virtual void  PollButtons(uint32_t /*t_ms*/, bool /*gated*/) {}
 
-    /** Process one control-loop frame. Main thread only. */
+    /**
+     * Process one control-loop frame of gesture state (record/disarm).
+     * Main thread only.  Gated by ControlLoop while Settings is active —
+     * playback must NOT live here; that's Advance()'s job.
+     */
     virtual void  Update(const float* phys, uint32_t t_ms) = 0;
+
+    /**
+     * Advance playback by one frame.  Called by ControlLoop every frame,
+     * unconditionally — recorded automation keeps running while Settings
+     * owns the surface.  Touches no gesture state.
+     *
+     * Default: no-op (custom sources that advance elsewhere need nothing).
+     */
+    virtual void  Advance() {}
 
     /**
      * Paint automation-state overlay (e.g. recording/active pips) onto the

--- a/framework/include/alchemy/surface/param_lock.h
+++ b/framework/include/alchemy/surface/param_lock.h
@@ -15,8 +15,10 @@
  *   alchemy::ParamLock<12> locks(hw.buttons[0], pager);     // paged, 12 = 2 × 6
  *
  * The paged form resolves Delta(p) as `pager.Page() * pager.NumPots() + p`.
- * The unpaged form uses `p` directly.  Both advance all kSlots play heads
- * each Update() so automation on inactive pages keeps cycling.
+ * The unpaged form uses `p` directly.  Advance() moves all kSlots play
+ * heads each frame so automation on inactive pages keeps cycling; it is
+ * separate from Update() (gestures) so playback survives modes — like the
+ * Settings menu — that suspend gesture handling.
  *
  * Composition at the user's read site:
  *
@@ -73,8 +75,14 @@ class ParamLock : public Serializable, public LockSource
     }
 
     /**
-     * Process one frame: edge-detect the trigger button, run the
-     * record/disarm gesture if held, and advance every play head.
+     * Process one frame of GESTURE state: consume the trigger edges
+     * PollButtons detected and run the record/disarm gesture if held.
+     *
+     * Playback is NOT advanced here — that's Advance()'s job, split out
+     * so recorded modulation keeps running in modes (e.g. the Settings
+     * menu) that suspend gesture handling.  ControlLoop calls both;
+     * standalone users must now call Advance() every frame themselves
+     * in addition to Update().
      *
      * **Call order (paged form).**  When constructed with a `Pager&`,
      * this method calls `pager.ConsumeButton()` on the trigger's
@@ -94,6 +102,11 @@ class ParamLock : public Serializable, public LockSource
      */
     void PollButtons(uint32_t t_ms, bool gated) override;
     void Update     (const float* phys, uint32_t /*t_ms*/) override;
+
+    /** Advance every active slot's play head by one frame.  Touches no
+     *  gesture state — safe (and required) every frame, even while a
+     *  mode like Settings suspends Update(). */
+    void Advance() override;
 
     /** Modulation delta for pot @p p on the visible page (no advance). */
     float Delta(uint8_t pot) const;
@@ -141,7 +154,13 @@ class ParamLock : public Serializable, public LockSource
     /* ── Serializable ──────────────────────────────────────────────────
      * Round-trips the full SavedEntry array; identical to the existing
      * Save()/Restore() but exposed through the Serializable contract so
-     * Presets can manage this object directly.                       */
+     * Presets can manage this object directly.
+     *
+     * Staged ONE entry at a time: a SavedEntry is ~1 KiB (256-sample
+     * motion buffer), so a whole-array stack local would spike
+     * kSlots × ~1 KiB deep inside the control loop (HostLink live
+     * writes, GET_LIVE, panel save/load).  The byte stream is unchanged
+     * — same entries, same order.                                    */
 
     size_t SerializedSize() const override
     {
@@ -150,16 +169,22 @@ class ParamLock : public Serializable, public LockSource
 
     void Serialize(uint8_t* out) const override
     {
-        SavedEntry entries[kSlots];
-        mgr_.Capture(entries, kSlots, 0);
-        std::memcpy(out, entries, sizeof(entries));
+        SavedEntry e;
+        for (uint8_t i = 0; i < kSlots; i++, out += sizeof(e))
+        {
+            mgr_.Capture(&e, 1, i);
+            std::memcpy(out, &e, sizeof(e));
+        }
     }
 
     bool Deserialize(const uint8_t* in) override
     {
-        SavedEntry entries[kSlots];
-        std::memcpy(entries, in, sizeof(entries));
-        mgr_.Restore(entries, kSlots, 0);
+        SavedEntry e;
+        for (uint8_t i = 0; i < kSlots; i++, in += sizeof(e))
+        {
+            std::memcpy(&e, in, sizeof(e));
+            mgr_.Restore(&e, 1, i);
+        }
         return true;
     }
 

--- a/framework/include/alchemy/surface/param_lock_impl.h
+++ b/framework/include/alchemy/surface/param_lock_impl.h
@@ -44,7 +44,11 @@ void ParamLock<kSlots>::Update(const float* phys, uint32_t /*t_ms*/)
 
     if (mgr_.IsButtonHeld())
         mgr_.ProcessGestures(Offset(), phys);
+}
 
+template<uint8_t kSlots>
+void ParamLock<kSlots>::Advance()
+{
     mgr_.Advance();
 }
 

--- a/framework/include/alchemy/version.h
+++ b/framework/include/alchemy/version.h
@@ -9,4 +9,4 @@
 
 #pragma once
 
-#define ALCHEMY_SDK_VERSION "1.0.0-beta"
+#define ALCHEMY_SDK_VERSION "1.1.0-beta"

--- a/framework/src/surface/control_loop.cpp
+++ b/framework/src/surface/control_loop.cpp
@@ -79,12 +79,22 @@ void ControlLoop::Tick()
     if (settings_) settings_->Update(phys_, now);
     const bool in_settings = settings_ && settings_->IsActive();
 
+    /* ── Lock playback advances every frame, unconditionally: recorded
+     *    modulation must keep running while Settings owns the surface.
+     *    Only the gesture half (locks_->Update below) stands down. */
+    if (locks_) locks_->Advance();
+
     if (!in_settings)
     {
         /* ── Surface updates in canonical order: cv_source first (refreshes
          *    its delta cache from the per-frame cv[] snapshot), then locks
          *    before storage so consume-button semantics land in the same
-         *    frame as the release. */
+         *    frame as the release.
+         *
+         *    Known gap, same principle as locks: gating cv_source_->Update
+         *    here freezes the CV delta cache while Settings is active.
+         *    Splitting its refresh out of the gesture path is a separate
+         *    change — see LockSource::Advance for the pattern. */
         if (cv_source_) cv_source_->Update(cv_, now);
         if (locks_)   locks_  ->Update(phys_, now);
         if (storage_) storage_->Update(phys_, now);

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(hostlink_tests
     "${SDK_ROOT}/framework/src/surface/presets.cpp"
     "${SDK_ROOT}/framework/src/surface/preset_gesture_ui.cpp"
     "${SDK_ROOT}/framework/src/surface/virtual_knob.cpp"
+    "${SDK_ROOT}/framework/src/control/param_lock_manager.cpp"
     "${SDK_ROOT}/hardware/alchemy-lab/v1/src/ws2812.cpp"
     "${SDK_ROOT}/hardware/alchemy-lab/v1/src/alchemy_lab_v1.cpp"
     "${SDK_ROOT}/hardware/alchemy-lab/v1/src/alchemy_lab_v1_layout.cpp"

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -29,6 +29,7 @@
 #include "alchemy/hw/alchemy_lab.h"
 #include "alchemy/surface/page.h"
 #include "alchemy/surface/pager.h"
+#include "alchemy/surface/param_lock.h"
 #include "alchemy/surface/preset_name.h"
 #include "alchemy/surface/presets.h"
 #include "alchemy/surface/settings.h"
@@ -1239,6 +1240,102 @@ static void TestUseNames()
     CHECK_EQ(p1.LiveSize(), p2.LiveSize());
 }
 
+/* ParamLock's Serializable path stages one ~1 KiB SavedEntry at a time
+ * (not the whole array on the stack); the byte stream must stay exactly
+ * the flat SavedEntry array Restore→Capture reproduces. */
+static void TestParamLockSerializeRoundTrip()
+{
+    struct FakeButton : IButton
+    {
+        bool  Pressed() const override { return false; }
+        bool  RisingEdge() override { return false; }
+        bool  FallingEdge() override { return false; }
+        float TimeHeldMs() const override { return 0.0f; }
+    } button;
+
+    ParamLock<4> locks(button);
+    using Entry = ParamLock<4>::SavedEntry;
+    CHECK_EQ(locks.SerializedSize(), size_t{4} * sizeof(Entry));
+
+    /* Craft an image: slots 0 and 2 active with distinct ramps (zero-
+     * padded past `length`, exactly as Capture emits), slots 1 and 3
+     * inactive (all zeros). */
+    std::vector<uint8_t> image(locks.SerializedSize(), 0u);
+    {
+        Entry e{};
+        e.active      = 1u;
+        e.length      = 5u;
+        e.record_base = 0.25f;
+        for (uint16_t j = 0; j < e.length; j++)
+            e.buf[j] = 0.01f * static_cast<float>(j + 1);
+        std::memcpy(image.data(), &e, sizeof(e));
+    }
+    {
+        Entry e{};
+        e.active      = 1u;
+        e.length      = kParamLockBufferLen; /* full motion buffer */
+        e.record_base = -1.0f;
+        for (uint16_t j = 0; j < e.length; j++)
+            e.buf[j] = (j & 1u) ? 0.5f : -0.5f;
+        std::memcpy(image.data() + 2u * sizeof(Entry), &e, sizeof(e));
+    }
+
+    CHECK(locks.Deserialize(image.data()));
+
+    std::vector<uint8_t> out(locks.SerializedSize(), 0xAAu);
+    locks.Serialize(out.data());
+    CHECK(out == image);
+}
+
+/* Playback lives in Advance(), not Update(): Update() only consumes
+ * gesture edges, so ControlLoop can keep automation running (Advance
+ * every frame) while Settings suspends the gesture path (Update). */
+static void TestParamLockAdvanceSplit()
+{
+    struct FakeButton : IButton
+    {
+        bool  Pressed() const override { return false; }
+        bool  RisingEdge() override { return false; }
+        bool  FallingEdge() override { return false; }
+        float TimeHeldMs() const override { return 0.0f; }
+    } button;
+
+    ParamLock<4> locks(button);
+    using Entry = ParamLock<4>::SavedEntry;
+
+    /* Slot 0: active 3-sample loop around record_base 0.5. */
+    std::vector<uint8_t> image(locks.SerializedSize(), 0u);
+    Entry e{};
+    e.active      = 1u;
+    e.length      = 3u;
+    e.record_base = 0.5f;
+    e.buf[0]      = 0.6f;
+    e.buf[1]      = 0.7f;
+    e.buf[2]      = 0.9f;
+    std::memcpy(image.data(), &e, sizeof(e));
+    CHECK(locks.Deserialize(image.data()));
+
+    const float phys[4] = {};
+    CHECK(locks.Delta(0) == 0.6f - 0.5f);
+
+    /* Update() with no pending edges must not move the play head. */
+    locks.Update(phys, 0u);
+    locks.Update(phys, 1u);
+    CHECK(locks.Delta(0) == 0.6f - 0.5f);
+
+    /* Advance() steps the loop — including through the LockSource base,
+     * which is how ControlLoop drives it. */
+    locks.Advance();
+    CHECK(locks.Delta(0) == 0.7f - 0.5f);
+    static_cast<LockSource&>(locks).Advance();
+    CHECK(locks.Delta(0) == 0.9f - 0.5f);
+    locks.Advance();
+    CHECK(locks.Delta(0) == 0.6f - 0.5f); /* wrapped */
+
+    /* Inactive slots are unaffected either way. */
+    CHECK(locks.Delta(1) == 0.0f);
+}
+
 /* ── Golden vector emission ────────────────────────────────────────── */
 
 static std::string Hex(const uint8_t* p, size_t n)
@@ -1395,6 +1492,8 @@ int main(int argc, char** argv)
     TestButtonsEmission();
     TestComponentMeta();
     TestUseNames();
+    TestParamLockSerializeRoundTrip();
+    TestParamLockAdvanceSplit();
 
     std::printf("%d checks, %d failures\n", g_checks, g_failures);
     return g_failures == 0 ? 0 : 1;


### PR DESCRIPTION
Splits param-lock **playback** out of **gesture handling** so recorded automation keeps running in modes that suspend gesture input (e.g. the Settings menu).

## What changed
- **`LockSource` / `ParamLock`**: new `Advance()` moves every play head one frame and touches no gesture state; `Update()` now handles only record/disarm gestures. `ControlLoop` calls `Advance()` unconditionally every frame and `Update()` only while Settings is inactive — so automation on inactive pages keeps cycling even while Settings owns the surface.
  - Standalone (non-`ControlLoop`) users must now call `Advance()` every frame in addition to `Update()`.
- **`ParamLock::Serialize()`**: stages one `SavedEntry` at a time instead of a whole `kSlots`-sized stack array, avoiding a `kSlots × ~1 KiB` stack spike deep inside the control loop (HostLink live writes, `GET_LIVE`, panel save/load). Byte stream is unchanged.
- Version bump.

## Tests
- Adds host-side coverage in `tests/host/hostlink_tests.cpp` (registered in `tests/host/CMakeLists.txt`).
