### PR TITLE
HostLink: validate descriptor JSON; add uint meta helpers

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -115,6 +115,7 @@ add_library(alchemy_host_link STATIC
     src/host_link/host_link.cpp
     src/host_link/descriptor.cpp
     src/host_link/describe.cpp
+    src/host_link/json_check.cpp
     src/host_link/cdc_transport.cpp
     src/host_link/host.cpp
 )

--- a/framework/include/alchemy/host_link/component_writer.h
+++ b/framework/include/alchemy/host_link/component_writer.h
@@ -85,6 +85,8 @@ class ComponentWriter
      */
     bool Meta(const char* key, const char* raw_json);
 
+    bool MetaUInt(const char* key, uint32_t value);
+
     /* ── Renderer interface ─────────────────────────────────────────── */
 
     /** Emit + close the component (renderer calls this, not describers). */

--- a/framework/include/alchemy/host_link/descriptor.h
+++ b/framework/include/alchemy/host_link/descriptor.h
@@ -156,6 +156,8 @@ class DescriptorBuilder
      * (object, array, string, number, or bool). */
     bool GenericMeta(const char* key, const char* raw_json);
 
+    bool GenericMetaUInt(const char* key, uint32_t value);
+
     /** Close all structures and validate totals.  Returns descriptor
      *  length in bytes, or 0 if anything drifted or overflowed. */
     uint32_t Finish();

--- a/framework/include/alchemy/host_link/json_check.h
+++ b/framework/include/alchemy/host_link/json_check.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstddef>
+
+namespace alchemy {
+namespace hostlink {
+
+bool ValidJsonValue(const char* s, size_t len);
+bool ValidJsonValue(const char* s);
+
+} // namespace hostlink
+} // namespace alchemy

--- a/framework/include/alchemy/host_link/json_writer.h
+++ b/framework/include/alchemy/host_link/json_writer.h
@@ -79,6 +79,7 @@ class JsonWriter
 
     bool   Ok()     const { return !overflow_ && depth_ == 0; }
     size_t Length() const { return len_; }
+    const char* Data() const { return buf_; }
     /** NUL-terminate (not counted in Length()); false on overflow. */
     bool Terminate()
     {

--- a/framework/src/host_link/describe.cpp
+++ b/framework/src/host_link/describe.cpp
@@ -83,6 +83,13 @@ bool ComponentWriter::Meta(const char* key, const char* raw_json)
     return ok_;
 }
 
+bool ComponentWriter::MetaUInt(const char* key, uint32_t value)
+{
+    if (!Open()) return false;
+    ok_ = db_.GenericMetaUInt(key, value) && ok_;
+    return ok_;
+}
+
 bool ComponentWriter::Finalize()
 {
     if (!Open()) return false;

--- a/framework/src/host_link/descriptor.cpp
+++ b/framework/src/host_link/descriptor.cpp
@@ -5,6 +5,7 @@
 
 #include "alchemy/host_link/descriptor.h"
 
+#include "alchemy/host_link/json_check.h"
 #include "alchemy/surface/pager.h"
 #include "alchemy/surface/presets.h"
 #include "alchemy/surface/settings.h"
@@ -319,8 +320,22 @@ bool DescriptorBuilder::GenericMeta(const char* key, const char* raw_json)
         error_ = true;
         return false;
     }
+    if (!ValidJsonValue(raw_json))
+    {
+        error_ = true;
+        return false;
+    }
     w_.Key(key);
     w_.RawValue(raw_json);
+    return !error_;
+}
+
+bool DescriptorBuilder::GenericMetaUInt(const char* key, uint32_t value)
+{
+    if (!generic_open_ || fields_open_) { error_ = true; return false; }
+    if (!key || !key[0]) { error_ = true; return false; }
+    w_.Key(key);
+    w_.UInt(value);
     return !error_;
 }
 
@@ -501,6 +516,7 @@ uint32_t DescriptorBuilder::Finish()
     if (comp_index_ != presets_.NumManaged()) return 0u;
     if (cum_off_ != presets_.LiveSize()) return 0u;
     if (!w_.Ok()) return 0u;
+    if (!ValidJsonValue(w_.Data(), w_.Length())) return 0u;
     return static_cast<uint32_t>(w_.Length());
 }
 

--- a/framework/src/host_link/json_check.cpp
+++ b/framework/src/host_link/json_check.cpp
@@ -1,0 +1,180 @@
+#include "alchemy/host_link/json_check.h"
+
+#include <cstring>
+
+namespace alchemy {
+namespace hostlink {
+
+namespace {
+
+constexpr int kMaxDepth = 16;
+
+struct Cursor
+{
+    const char* p;
+    const char* end;
+};
+
+void SkipWs(Cursor& c)
+{
+    while (c.p < c.end
+           && (*c.p == ' ' || *c.p == '\t' || *c.p == '\n' || *c.p == '\r'))
+        c.p++;
+}
+
+bool ParseValue(Cursor& c, int depth);
+
+bool ParseHex4(Cursor& c)
+{
+    for (int i = 0; i < 4; i++)
+    {
+        if (c.p >= c.end) return false;
+        const char ch = *c.p++;
+        const bool hex = (ch >= '0' && ch <= '9')
+                      || (ch >= 'a' && ch <= 'f')
+                      || (ch >= 'A' && ch <= 'F');
+        if (!hex) return false;
+    }
+    return true;
+}
+
+bool ParseString(Cursor& c)
+{
+    if (c.p >= c.end || *c.p != '"') return false;
+    c.p++;
+    while (c.p < c.end)
+    {
+        const unsigned char ch = static_cast<unsigned char>(*c.p++);
+        if (ch == '"') return true;
+        if (ch == '\\')
+        {
+            if (c.p >= c.end) return false;
+            const char e = *c.p++;
+            switch (e)
+            {
+                case '"': case '\\': case '/': case 'b': case 'f':
+                case 'n': case 'r': case 't':
+                    break;
+                case 'u':
+                    if (!ParseHex4(c)) return false;
+                    break;
+                default:
+                    return false;
+            }
+        }
+        else if (ch < 0x20u)
+        {
+            return false;
+        }
+    }
+    return false;
+}
+
+bool ParseDigits(Cursor& c)
+{
+    if (c.p >= c.end || *c.p < '0' || *c.p > '9') return false;
+    while (c.p < c.end && *c.p >= '0' && *c.p <= '9') c.p++;
+    return true;
+}
+
+bool ParseNumber(Cursor& c)
+{
+    if (c.p < c.end && *c.p == '-') c.p++;
+    if (c.p >= c.end) return false;
+    if (*c.p == '0') c.p++;
+    else if (!ParseDigits(c)) return false;
+    if (c.p < c.end && *c.p == '.')
+    {
+        c.p++;
+        if (!ParseDigits(c)) return false;
+    }
+    if (c.p < c.end && (*c.p == 'e' || *c.p == 'E'))
+    {
+        c.p++;
+        if (c.p < c.end && (*c.p == '+' || *c.p == '-')) c.p++;
+        if (!ParseDigits(c)) return false;
+    }
+    return true;
+}
+
+bool ParseLiteral(Cursor& c, const char* lit)
+{
+    const size_t n = std::strlen(lit);
+    if (static_cast<size_t>(c.end - c.p) < n) return false;
+    if (std::memcmp(c.p, lit, n) != 0) return false;
+    c.p += n;
+    return true;
+}
+
+bool ParseObject(Cursor& c, int depth)
+{
+    c.p++;
+    SkipWs(c);
+    if (c.p < c.end && *c.p == '}') { c.p++; return true; }
+    for (;;)
+    {
+        SkipWs(c);
+        if (!ParseString(c)) return false;
+        SkipWs(c);
+        if (c.p >= c.end || *c.p != ':') return false;
+        c.p++;
+        if (!ParseValue(c, depth)) return false;
+        SkipWs(c);
+        if (c.p >= c.end) return false;
+        if (*c.p == ',') { c.p++; continue; }
+        if (*c.p == '}') { c.p++; return true; }
+        return false;
+    }
+}
+
+bool ParseArray(Cursor& c, int depth)
+{
+    c.p++;
+    SkipWs(c);
+    if (c.p < c.end && *c.p == ']') { c.p++; return true; }
+    for (;;)
+    {
+        if (!ParseValue(c, depth)) return false;
+        SkipWs(c);
+        if (c.p >= c.end) return false;
+        if (*c.p == ',') { c.p++; continue; }
+        if (*c.p == ']') { c.p++; return true; }
+        return false;
+    }
+}
+
+bool ParseValue(Cursor& c, int depth)
+{
+    if (depth >= kMaxDepth) return false;
+    SkipWs(c);
+    if (c.p >= c.end) return false;
+    switch (*c.p)
+    {
+        case '{': return ParseObject(c, depth + 1);
+        case '[': return ParseArray(c, depth + 1);
+        case '"': return ParseString(c);
+        case 't': return ParseLiteral(c, "true");
+        case 'f': return ParseLiteral(c, "false");
+        case 'n': return ParseLiteral(c, "null");
+        default:  return ParseNumber(c);
+    }
+}
+
+} // namespace
+
+bool ValidJsonValue(const char* s, size_t len)
+{
+    if (!s) return false;
+    Cursor c{s, s + len};
+    if (!ParseValue(c, 0)) return false;
+    SkipWs(c);
+    return c.p == c.end;
+}
+
+bool ValidJsonValue(const char* s)
+{
+    return s != nullptr && ValidJsonValue(s, std::strlen(s));
+}
+
+} // namespace hostlink
+} // namespace alchemy

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(hostlink_tests
     "${SDK_ROOT}/framework/src/host_link/host_link.cpp"
     "${SDK_ROOT}/framework/src/host_link/descriptor.cpp"
     "${SDK_ROOT}/framework/src/host_link/describe.cpp"
+    "${SDK_ROOT}/framework/src/host_link/json_check.cpp"
     "${SDK_ROOT}/framework/src/surface/pager.cpp"
     "${SDK_ROOT}/framework/src/surface/settings.cpp"
     "${SDK_ROOT}/framework/src/surface/presets.cpp"

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -24,6 +24,7 @@
 #include "alchemy/host_link/describe.h"
 #include "alchemy/host_link/descriptor.h"
 #include "alchemy/host_link/frame.h"
+#include "alchemy/host_link/json_check.h"
 #include "alchemy/host_link/host_link.h"
 #include "alchemy/host_link/wire.h"
 #include "alchemy/hw/alchemy_lab.h"
@@ -1211,6 +1212,163 @@ static void TestComponentMeta()
              0u);
 }
 
+static void TestJsonCheck()
+{
+    CHECK(ValidJsonValue("0"));
+    CHECK(ValidJsonValue("12"));
+    CHECK(ValidJsonValue("-1.5e3"));
+    CHECK(ValidJsonValue("1.25"));
+    CHECK(ValidJsonValue("\"str\""));
+    CHECK(ValidJsonValue("\"a\\\"b\\u00ff\\n\""));
+    CHECK(ValidJsonValue("true"));
+    CHECK(ValidJsonValue("false"));
+    CHECK(ValidJsonValue("null"));
+    CHECK(ValidJsonValue("{}"));
+    CHECK(ValidJsonValue("[]"));
+    CHECK(ValidJsonValue("{\"a\":1,\"b\":[1,2,{\"c\":\"d\"}],\"e\":true}"));
+    CHECK(ValidJsonValue(" { \"a\" : [ 1 , 2 ] } "));
+    CHECK(ValidJsonValue("[[[[[[[[1]]]]]]]]"));
+
+    CHECK(!ValidJsonValue(nullptr));
+    CHECK(!ValidJsonValue(""));
+    CHECK(!ValidJsonValue("zu"));
+    CHECK(!ValidJsonValue("{\"activeOff\":zu,\"lengthOff\":zu}"));
+    CHECK(!ValidJsonValue("01"));
+    CHECK(!ValidJsonValue("1."));
+    CHECK(!ValidJsonValue("-"));
+    CHECK(!ValidJsonValue("+1"));
+    CHECK(!ValidJsonValue("1e"));
+    CHECK(!ValidJsonValue("\"unterminated"));
+    CHECK(!ValidJsonValue("\"bad\\x\""));
+    CHECK(!ValidJsonValue("{\"a\":}"));
+    CHECK(!ValidJsonValue("{\"a\":1,}"));
+    CHECK(!ValidJsonValue("{a:1}"));
+    CHECK(!ValidJsonValue("{\"a\":1"));
+    CHECK(!ValidJsonValue("[1,]"));
+    CHECK(!ValidJsonValue("[1 2]"));
+    CHECK(!ValidJsonValue("{}extra"));
+    CHECK(!ValidJsonValue("12 34"));
+    CHECK(!ValidJsonValue("[[[[[[[[[[[[[[[[[[1]]]]]]]]]]]]]]]]]]"));
+}
+
+static void TestDescriptorJsonValidation()
+{
+    struct ZuMeta : TestComp<4>
+    {
+        ZuMeta() : TestComp<4>(0xBBBB0001u) {}
+        bool Describe(ComponentWriter& w) const override
+        {
+            w.Kind("param_locks");
+            return w.Meta("slotSize", "zu");
+        }
+    };
+    {
+        RamFlash flash;
+        Presets  presets{g_dummy_qspi};
+        ZuMeta   c;
+        presets.Manage(c);
+        presets.Init(flash.Ops(), flash.Base());
+        static char buf[8192];
+        CHECK_EQ(RenderDescriptor(buf, sizeof buf,
+                                  {"m", "m", "0", "g", "s", "v1"},
+                                  presets, nullptr, nullptr, 0),
+                 0u);
+    }
+
+    struct TruncMeta : TestComp<4>
+    {
+        TruncMeta() : TestComp<4>(0xBBBB0002u) {}
+        bool Describe(ComponentWriter& w) const override
+        {
+            w.Kind("param_locks");
+            return w.Meta("layout", "{\"activeOff\":0,");
+        }
+    };
+    {
+        RamFlash  flash;
+        Presets   presets{g_dummy_qspi};
+        TruncMeta c;
+        presets.Manage(c);
+        presets.Init(flash.Ops(), flash.Base());
+        static char buf[8192];
+        CHECK_EQ(RenderDescriptor(buf, sizeof buf,
+                                  {"m", "m", "0", "g", "s", "v1"},
+                                  presets, nullptr, nullptr, 0),
+                 0u);
+    }
+
+    struct TrailMeta : TestComp<4>
+    {
+        TrailMeta() : TestComp<4>(0xBBBB0003u) {}
+        bool Describe(ComponentWriter& w) const override
+        {
+            w.Kind("param_locks");
+            return w.Meta("slots", "12 34");
+        }
+    };
+    {
+        RamFlash  flash;
+        Presets   presets{g_dummy_qspi};
+        TrailMeta c;
+        presets.Manage(c);
+        presets.Init(flash.Ops(), flash.Base());
+        static char buf[8192];
+        CHECK_EQ(RenderDescriptor(buf, sizeof buf,
+                                  {"m", "m", "0", "g", "s", "v1"},
+                                  presets, nullptr, nullptr, 0),
+                 0u);
+    }
+
+    struct UIntMeta : TestComp<4>
+    {
+        UIntMeta() : TestComp<4>(0xBBBB0004u) {}
+        bool Describe(ComponentWriter& w) const override
+        {
+            w.Kind("param_locks");
+            bool ok = w.MetaUInt("slots", 12u);
+            ok &= w.MetaUInt("slotSize", 1031u);
+            ok &= w.MetaUInt("bufLen", 256u);
+            return ok;
+        }
+    };
+    {
+        RamFlash flash;
+        Presets  presets{g_dummy_qspi};
+        UIntMeta c;
+        presets.Manage(c);
+        presets.Init(flash.Ops(), flash.Base());
+        static char buf[8192];
+        const uint32_t len = RenderDescriptor(buf, sizeof buf,
+                                              {"m", "m", "0", "g", "s", "v1"},
+                                              presets, nullptr, nullptr, 0);
+        CHECK(len > 0u);
+        const std::string json(buf, len);
+        CHECK(json.find("\"slots\":12") != std::string::npos);
+        CHECK(json.find("\"slotSize\":1031") != std::string::npos);
+        CHECK(json.find("\"bufLen\":256") != std::string::npos);
+    }
+
+    {
+        SurfaceFixture sf;
+        static char buf[8192];
+        DescriptorBuilder db(buf, sizeof buf, sf.presets);
+        bool ok = db.Begin({"x", "x", "1", "g", "s", "v1"});
+        ok &= db.BeginPager("perf", sf.pager);
+        for (uint8_t pg = 0; pg < 3; pg++)
+            for (uint8_t p = 0; p < 6; p++)
+                ok &= db.PagerField(pg, p, "f", "F",
+                                    (pg == 0 && p == 0) ? "{\"kind\":"
+                                                        : nullptr);
+        ok &= db.EndPager();
+        ok &= db.Opaque("motion", sf.motion, "m");
+        ok &= db.BeginSettings("settings", sf.settings);
+        ok &= db.EndSettings();
+        ok &= db.Name("name", sf.name);
+        CHECK(ok);
+        CHECK_EQ(db.Finish(), 0u);
+    }
+}
+
 static void TestUseNames()
 {
     RamFlash    flash;
@@ -1491,6 +1649,8 @@ int main(int argc, char** argv)
     TestAutoDescribeGenericAndOverrides();
     TestButtonsEmission();
     TestComponentMeta();
+    TestJsonCheck();
+    TestDescriptorJsonValidation();
     TestUseNames();
     TestParamLockSerializeRoundTrip();
     TestParamLockAdvanceSplit();


### PR DESCRIPTION
## Motivation

Echoa firmware formatted param-lock meta values with `snprintf("%zu")`. newlib-nano's formatted I/O doesn't implement the `z` length modifier, so the descriptor shipped literal `"slotSize":zu` — invalid JSON. Nothing on the device caught it: `snprintf` succeeded, the drift guards only check sizes/offsets, and the host tests run against a full libc where `%zu` works. The website's `JSON.parse` threw and the connection broke outright.

## Changes

- **`GenericMeta` enforces its documented contract.** `raw_json` is now checked by a new allocation-free JSON-value validator (`json_check.h/.cpp`). An invalid value latches the build error, `Finish()` returns 0, and the module advertises "no descriptor" — hosts degrade to raw backup/restore instead of receiving unparseable JSON.
- **`Finish()` validates the whole rendered document.** One pass over the final buffer catches malformed splices on every `RawValue` path (field `disp` hints included), not just meta values.
- **Typed meta helpers.** `DescriptorBuilder::GenericMetaUInt` / `ComponentWriter::MetaUInt` emit unsigned meta values through `JsonWriter`, removing the caller-side printf formatting footgun entirely.

## Tests

- Validator unit coverage (numbers, strings/escapes, nesting/depth cap, and rejection cases including the literal `zu` regression, truncated objects, trailing garbage).
- `Meta("slotSize", "zu")` and friends now fail the descriptor build (`RenderDescriptor` returns 0).
- `MetaUInt` emission round-trip.
- A truncated `disp` hint on a pager field passes every per-call check but is caught by the `Finish()` document scan.

`ctest` host suite: 1130 checks, 0 failures. ARM `alchemy_host_link` cross-compiles clean.

Descriptor bytes for valid input are unchanged — golden vectors unaffected.