### PR TITLE
Settings: canonicalize both slot representations in Deserialize

### DIFF
--- a/framework/src/surface/settings.cpp
+++ b/framework/src/surface/settings.cpp
@@ -541,15 +541,47 @@ bool Settings::Deserialize(const uint8_t* in)
                     float v;
                     std::memcpy(&v, in, sizeof(float));
                     in += sizeof(float);
+                    /* Blob passed CRC + schema gates, but a live host
+                     * push can still carry any bytes: NaN-safe clamp to
+                     * the pot-normalized range everything downstream
+                     * assumes. */
+                    if (!(v >= 0.0f)) v = 0.0f;
+                    if (v > 1.0f)     v = 1.0f;
                     s.pot.stored = v;
-                    /* Resolved logical value re-derives on the next Update. */
+                    /* Canonicalize the resolved value NOW.  Update only
+                     * re-derives it while the slot's page is active in
+                     * the menu; consumers polling Value() must see the
+                     * loaded state immediately. */
+                    switch (s.kind)
+                    {
+                        case SettingsKind::Bipolar:
+                            s.value = (v - 0.5f) * 2.0f;
+                            break;
+                        case SettingsKind::Brightness:
+                            s.value = s.range_lo + v * (s.range_hi - s.range_lo);
+                            break;
+                        default:   /* Knob */
+                            s.value = v;
+                            break;
+                    }
                     break;
                 }
                 case PersistKind::Byte:
-                    s.value_idx = in[0];
+                {
+                    uint8_t idx = in[0];
                     in += 1u;
-                    /* Resolved pot.stored re-derives on the next Update. */
+                    if (s.num_zones > 0u && idx >= s.num_zones)
+                        idx = static_cast<uint8_t>(s.num_zones - 1u);
+                    s.value_idx = idx;
+                    /* Canonicalize pot.stored to the zone centre.  The
+                     * active-page tick derives value_idx FROM pot.stored,
+                     * so leaving it stale reverts the loaded selection
+                     * the moment the page is viewed in the menu. */
+                    if (s.num_zones > 0u)
+                        s.pot.stored = (static_cast<float>(idx) + 0.5f)
+                                     / static_cast<float>(s.num_zones);
                     break;
+                }
                 default:
                     break;
             }

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -1629,6 +1629,77 @@ static int EmitGolden(const char* path)
     return 0;
 }
 
+/* ── Settings load canonicalization ────────────────────────────────── */
+
+/* Regression: Settings keeps two representations per slot (pot.stored
+ * and value/value_idx).  Deserialize used to fill only one half per
+ * kind and rely on the active-page Update tick to reconcile — which
+ * (a) never ran for Knob/Bipolar until the page was viewed in the
+ * menu, so loaded values were inaudible, and (b) ran in the WRONG
+ * direction for Selectors (value_idx re-derived from stale pot.stored),
+ * so viewing a page in the menu reverted the loaded selection.
+ * Deserialize must leave BOTH halves canonical, immediately. */
+static void TestSettingsLoadCanonicalization()
+{
+    SurfaceFixture sf;
+    Settings&      st = sf.settings;
+
+    /* Layout (page-major, pot order):
+     *   pg0: selector(4 zones) 1B, knob 4B; pg1: brightness 4B;
+     *   pg3: bipolar 4B — 13 bytes total. */
+    CHECK_EQ(st.SerializedSize(), size_t(13));
+
+    uint8_t blob[13];
+    blob[0] = 3u;                              /* selector: zone 3 (default 2) */
+    const float knob_v = 0.9f;                 /* knob: 0.9 (default 0.5)      */
+    const float bri_t  = 1.0f;                 /* brightness norm 1 → hi=0.35  */
+    const float bip_t  = 0.25f;                /* bipolar norm 0.25 → −0.5     */
+    std::memcpy(blob + 1, &knob_v, 4u);
+    std::memcpy(blob + 5, &bri_t,  4u);
+    std::memcpy(blob + 9, &bip_t,  4u);
+
+    CHECK(st.Deserialize(blob));
+
+    /* Loaded values must be visible through the handles IMMEDIATELY —
+     * no settings-menu visit, no Update tick required. */
+    CHECK_EQ(sf.mode.Value(), uint8_t(3));
+    CHECK(sf.knob.Value() == 0.9f);
+    CHECK(sf.bip.Value()  == -0.5f);
+    {
+        const float b = sf.bright.Value();
+        CHECK(b > 0.3499f && b < 0.3501f);
+    }
+
+    /* Selector pot side must be canonical (zone centre): the active-page
+     * tick derives value_idx FROM pot.stored, so a stale pot side is
+     * exactly the bug that reverted loaded selections in the menu. */
+    CHECK(st.StoredNormAt(0, 0) == 0.875f);    /* (3 + 0.5) / 4 */
+
+    /* Update ticks with the menu INACTIVE (pending re-arm included)
+     * must not disturb the loaded state. */
+    static const float kPhys[kNumPots] = {};
+    for (uint32_t i = 0; i < 3u; i++) st.Update(kPhys, 100u + 16u * i);
+    CHECK_EQ(sf.mode.Value(), uint8_t(3));
+    CHECK(sf.knob.Value() == 0.9f);
+    CHECK(sf.bip.Value()  == -0.5f);
+
+    /* Round-trip idempotence: serialize back → byte-identical blob. */
+    uint8_t out[13] = {};
+    st.Serialize(out);
+    CHECK(std::memcmp(out, blob, sizeof blob) == 0);
+
+    /* Hostile live-push bytes: out-of-range selector index clamps to
+     * the last zone; NaN floats land at 0 instead of poisoning the
+     * catch/render math. */
+    blob[0] = 200u;
+    const uint32_t kQnan = 0x7FC00000u;
+    std::memcpy(blob + 1, &kQnan, 4u);
+    CHECK(st.Deserialize(blob));
+    CHECK_EQ(sf.mode.Value(), uint8_t(3));     /* 4 zones → clamp to 3 */
+    CHECK(sf.knob.Value() == 0.0f);
+    CHECK(st.StoredNormAt(0, 1) == 0.0f);
+}
+
 /* ── Main ──────────────────────────────────────────────────────────── */
 
 int main(int argc, char** argv)
@@ -1661,6 +1732,7 @@ int main(int argc, char** argv)
     TestUseNames();
     TestParamLockSerializeRoundTrip();
     TestParamLockAdvanceSplit();
+    TestSettingsLoadCanonicalization();
 
     RunFsTests(g_checks, g_failures);
 


### PR DESCRIPTION
## Problem

`Settings` keeps two representations per control slot: the pot-catch position (`pot.stored`) and the resolved logical value (`value` / `value_idx`). `Deserialize` filled only one half per kind and relied on the active-page `Update` tick to reconcile. That failed in both directions:

- **Knob / Bipolar / Brightness** — `value` was only re-derived while the slot's page was active in the settings menu, so loaded floats were invisible to `Value()` consumers until the user paged to that settings page. Preset loads and HostLink live pushes silently didn't apply.
- **Selector** — the active-page tick derives `value_idx` *from* `pot.stored`, so a loaded index was clobbered back to the stale pot position on the first frame the page was viewed. Preset loads appeared to revert (J4-mode-style selectors flipping audibly on menu entry), and re-saving then baked the reverted values into the slot.

Downstream symptoms in firmware: presets not loading all settings, settings-dependent audio changing on settings-menu entry, and the web editor showing values the device wasn't actually playing (`SerializeLive` reads `pot.stored`/`value_idx` while the engine reads the stale cached `value`).

## Fix

`Deserialize` now leaves **both halves canonical immediately**:

- floats clamp NaN/out-of-range to `[0,1]`, write `pot.stored`, and re-derive `value` per kind (Knob direct, Bipolar `(v-0.5)*2`, Brightness range-mapped);
- selectors clamp out-of-range indices to the last zone (previously an out-of-bounds `zone_colors` read in `Render`), write `value_idx`, and snap `pot.stored` to the zone centre so the active-page tick derives the same index back.

The pending-rearm path is unchanged — catch re-arms against the now-correct stored values, and the Brightness hardware push keeps its existing timing.

## Compatibility

- Serialized layout and `SchemaHash` are byte-for-byte unchanged; presets already in flash (and web-exported presets) remain valid.
- No API changes; only the body of `Settings::Deserialize`.
- Only observable behavior change is the bug fix itself (plus the clamps, which previously passed undefined values through).

## Tests

New `TestSettingsLoadCanonicalization` covers: immediate visibility of loaded values through handles (no menu visit), selector pot-side canonicalization, stability across inactive `Update` ticks, serialize→deserialize→serialize byte idempotence, and the hostile-byte clamps.

Validated against the previous implementation (fix stashed): 9 failures, matching every facet above. With the fix: full host suite green (5040 checks), and the ARM cross-compile builds clean.