### PR TITLE
Make parameter lock length configurable

### DIFF
--- a/docs/param-locks.md
+++ b/docs/param-locks.md
@@ -1,0 +1,162 @@
+# Parameter locks: length, rate, and what they cost
+
+A parameter lock records a knob gesture and loops it. How long a gesture
+can be is your application's decision, declared once at the ParamLock
+declaration:
+
+```cpp
+alchemy::ParamLock<6>                       locks(hw.buttons[0]);  // 16 s (default)
+alchemy::ParamLock<6,  LockLength<20>>      locks(hw.buttons[0]);  // 20 s
+alchemy::ParamLock<12, LockLength<30, 20>>  locks(hw.buttons[0], pager);
+```
+
+The second template argument is a capacity policy:
+`LockLength<seconds, rate_hz = 30, store = LockStore::Preset>`.
+
+---
+
+## The cost model
+
+```
+samples per slot = seconds × rate_hz
+
+RAM          = slots × samples × 2 B
+preset bytes = slots × (5 + samples × 2 B)
+```
+
+Both are compile-time constants you can read back, print at boot, or
+assert against:
+
+```cpp
+using Locks = alchemy::ParamLock<6, alchemy::LockLength<20>>;
+
+Locks::kMaxSeconds       // 20
+Locks::kSampleRateHz     // 30
+Locks::kFramesPerSlot    // 600
+Locks::kArenaBytes       // 7'200   — motion storage
+Locks::RamBytes()        // 7'440   — arena + the object itself
+Locks::kPresetBytes      // 7'230   — taken from every preset slot
+Locks::kPresetBytesFree  // 13'218  — left for your other components
+```
+
+## The two budgets
+
+**RAM.** Framework statics link into `DTCMRAM` — 128 KiB, shared with
+`.data` and the stack. ParamLock will not silently take a large bite out
+of that: past **16 KiB** of motion arena it refuses to hold its own
+storage and makes you place it (see *Large configurations* below). Raise
+the threshold with `-DALCHEMY_LOCK_INLINE_RAM_LIMIT=32768` if your
+application genuinely has the DTCM to spare.
+
+**Flash.** A preset slot holds **20,448 bytes** for *all* managed
+components combined. This ceiling is hard: the preset region is the top
+640 KiB of the QSPI chip, ending at the last byte of the device, so it
+cannot grow without taking space from firmware or giving up preset slots.
+A ParamLock configured past it is a compile error, not a `Save()` that
+returns `false` on the bench.
+
+## Picking a rate
+
+`kRateHz` is the rate the motion buffer is *stored* at, decoupled from
+the control-loop frame rate. Playback interpolates between stored
+samples and recording box-averages into them, so a low rate costs
+smoothness far more slowly than you would expect — a hand turning a knob
+carries no useful energy above about 8 Hz.
+
+| Rate | Use it when |
+|---|---|
+| 60 Hz | You want the buffer indistinguishable from the control loop. Costs 2× of 30. |
+| 30 Hz | The default. Smooth for anything a hand can do. |
+| 20 Hz | Still fine, and what makes the longest configurations fit in flash. |
+
+**Dropping the rate is almost always cheaper than dropping the length.**
+
+## What fits in a preset slot
+
+Assuming ~1 KiB for your other managed components (Pager, Settings,
+preset names):
+
+| Configuration | 6 slots | 12 slots | 16 slots |
+|---|---|---|---|
+| 16 s @ 30 Hz (default) | 5.8 KB ✅ | 11.6 KB ✅ | 15.4 KB ✅ |
+| 20 s @ 30 Hz | 7.2 KB ✅ | 14.5 KB ✅ | 19.3 KB ✅ |
+| 30 s @ 30 Hz | 10.8 KB ✅ | 21.7 KB ❌ | ❌ |
+| 30 s @ 20 Hz | 7.2 KB ✅ | 14.5 KB ✅ | 19.3 KB ✅ |
+| 30 s @ 60 Hz | 21.6 KB ❌ | ❌ | ❌ |
+
+`LockStore::RamOnly` removes the flash ceiling entirely — see below.
+
+## Locks you don't need to save
+
+If you want long locks and don't need them to survive a power cycle,
+say so and the flash budget stops applying:
+
+```cpp
+using Locks = alchemy::ParamLock<6,
+    alchemy::LockLength<60, 60, alchemy::LockStore::RamOnly>>;
+```
+
+`SerializedSize()` becomes 0, so `presets.Manage(locks)` costs nothing
+and the preset budget ignores them entirely. The raw byte form is still
+available by hand via `Save()` / `Restore()` — that's the route for
+writing locks to an SD card yourself.
+
+## Large configurations
+
+Past `ALCHEMY_LOCK_INLINE_RAM_LIMIT` the arena has to be placed by you.
+The build tells you so, and this is the shape it's asking for:
+
+```cpp
+using Locks = alchemy::ParamLock<12,
+    alchemy::LockLength<60, 60, alchemy::LockStore::RamOnly>>;
+
+static uint16_t ALCHEMY_SDRAM_BSS lock_arena[Locks::kArenaSamples];
+static Locks locks(hw.buttons[0], pager,
+                   alchemy::LockArena{lock_arena, sizeof lock_arena});
+
+int main() {
+    hw.Init();       // brings up the FMC — SDRAM is unusable before this
+    locks.Init();    // clears the arena; .sdram_bss is NOLOAD
+    ...
+}
+```
+
+Two rules:
+
+1. **The arena may live in SDRAM; the ParamLock object may not.** The
+   arena is plain `uint16_t` storage with no constructor, so it is safe
+   in a NOLOAD section that static init never touches. The ParamLock
+   object's constructor runs *before* `hw.Init()`, so it must stay in
+   ordinary `.bss`.
+2. **Call `locks.Init()` from `main()`, after `hw.Init()`.** `.sdram_bss`
+   is NOLOAD.
+
+A short arena is refused at runtime rather than overrun: `IsReady()`
+stays false and every read returns 0.
+
+## Seconds mean seconds
+
+The motion buffer is clocked in milliseconds, not frames. `ControlLoop`
+tells the surface its frame interval every frame, so:
+
+- `LockLength<20>` is twenty seconds at 16 ms frames *and* at 32 ms frames.
+- Changing `ControlLoop::FrameMs` does not rescale existing recordings.
+- A lock replays at the speed it was recorded at.
+
+If you drive `ParamLock` yourself instead of through `ControlLoop`, call
+`SetFrameMs()` once at startup when your loop isn't running at the 16 ms
+default.
+
+## Changing a length later
+
+`SchemaHash()` folds in the slot count, the buffer length, the sample
+rate, and the storage policy. Changing any of them makes existing preset
+slots **invisible** — they are treated as empty rather than replayed at
+the wrong speed or restored into a differently-shaped buffer.
+
+## Sample representation
+
+Samples are stored as `uint16` normalized 0..1. Pot positions arrive
+from a 16-bit ADC, so a 1/65535 grid is finer than the signal and three
+times finer than `kCatchTolerance`; storing `float` would double both
+budgets to represent noise.

--- a/examples/README.md
+++ b/examples/README.md
@@ -77,7 +77,10 @@ What the example demonstrates:
   paint its red-recording / green-active pips on top.
 - **ParamLock without a Pager.**  `ParamLock<6>` in its unpaged form
   records six independent loops — one per pot — that are layered into the
-  pot reads at a single composition site (`Knob()`).
+  pot reads at a single composition site (`Knob()`).  Loop length is the
+  optional second template argument (`ParamLock<6, LockLength<20>>` for
+  twenty seconds); see [docs/param-locks.md](../docs/param-locks.md) for
+  what a longer one costs.
 
 Only `ParamLock` and `LedRender` are linked — `Pager`, `Settings`,
 `Presets`, and `CvRouter` are not in the binary, because a single-page

--- a/examples/stereo_eq/stereo_eq.cpp
+++ b/examples/stereo_eq/stereo_eq.cpp
@@ -115,7 +115,8 @@ static Page right_page = Page(1).Knobs(r_hi_level, r_hi_freq,
 static AlchemyLab                        hw;
 static ControlLoop                       loop    (hw);
 static Pager                             pager   (hw.buttons[0], 2, kNumPots);
-static ParamLock<2 * kNumPots>           locks   (hw.buttons[0], pager);
+static ParamLock<2 * kNumPots, LockLength<30, 20>>
+                                         locks   (hw.buttons[0], pager);
 static Presets                           presets (hw.seed.qspi);
 static Settings                          settings(hw, &pager);
 static CvMatrix                          cv_matrix(kNumCvInputs);

--- a/framework/include/alchemy/control/lock_length.h
+++ b/framework/include/alchemy/control/lock_length.h
@@ -1,0 +1,116 @@
+/**
+ * @file alchemy/control/lock_length.h
+ * @brief Compile-time capacity policy for looping automation (ParamLock).
+ *
+ * See param-locks.md in docs
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#ifndef ALCHEMY_LOCK_INLINE_RAM_LIMIT
+#define ALCHEMY_LOCK_INLINE_RAM_LIMIT (16u * 1024u)
+#endif
+
+namespace alchemy {
+
+inline uint16_t LockQuant(float v)
+{
+    if (!(v > 0.0f)) return 0u;            /* also catches NaN */
+    if (v >= 1.0f)   return 0xFFFFu;
+    return static_cast<uint16_t>(v * 65535.0f + 0.5f);
+}
+
+inline float LockDequant(uint16_t q)
+{
+    return static_cast<float>(q) * (1.0f / 65535.0f);
+}
+
+/* ── Storage policy ───────────────────────────────────────────────────── */
+
+/**
+ * Whether a ParamLock's contents ride along in presets.
+ *
+ *   Preset  — serialized into every preset slot.  Budget-checked at
+ *             compile time against kPresetBlobCapacity.
+ *   RamOnly — never serialized; SerializedSize() is 0 and Manage()ing it
+ *             costs nothing.  No flash ceiling, so this is the policy for
+ *             "I want minute-long locks and I don't need them saved".
+ *             Save()/Restore() still expose the byte form by hand.
+ */
+enum class LockStore : uint8_t
+{
+    Preset,
+    RamOnly,
+};
+
+/* ── LockLength ───────────────────────────────────────────────────────── */
+
+/**
+ * Capacity policy: the second template argument to ParamLock.
+ *
+ * @tparam kSeconds Longest recordable gesture, in real seconds.  Honoured
+ *                  regardless of the control-loop frame rate — ParamLock
+ *                  is told the frame interval and clocks its buffer in
+ *                  milliseconds, so `LockLength<20>` is twenty seconds at
+ *                  16 ms frames and twenty seconds at 32 ms frames.
+ * @tparam kRateHz  Stored motion sample rate (see header notes).
+ * @tparam kStore   Preset participation (see LockStore).
+ */
+template<uint16_t kSecondsArg,
+         uint16_t kRateHzArg = 30u,
+         LockStore kStoreArg = LockStore::Preset>
+struct LockLength
+{
+    static constexpr uint16_t  kMaxSeconds   = kSecondsArg;
+    static constexpr uint16_t  kSampleRateHz = kRateHzArg;
+    static constexpr LockStore kStorage      = kStoreArg;
+
+    /** Motion samples reserved per lock slot. */
+    static constexpr uint32_t kFramesPerSlot =
+        static_cast<uint32_t>(kSecondsArg) * kRateHzArg;
+
+    static_assert(kSecondsArg >= 1u,
+                  "LockLength: kSeconds must be at least 1.");
+    static_assert(kRateHzArg >= 5u,
+                  "LockLength: kRateHz below 5 Hz cannot represent a hand "
+                  "gesture. 20-30 Hz is the useful range.");
+    static_assert(kFramesPerSlot <= 60000u,
+                  "LockLength: kSeconds * kRateHz exceeds the uint16 sample "
+                  "index range. Lower kRateHz (30 s at 20 Hz = 600 samples; "
+                  "even 1000 s at 60 Hz is only 60000).");
+};
+
+using DefaultLockLength = LockLength<16u, 30u, LockStore::Preset>;
+
+/* ── LockArena ────────────────────────────────────────────────────────── */
+
+/**
+ * Externally-placed motion storage for a ParamLock too large to hold its
+ * own arena (see ALCHEMY_LOCK_INLINE_RAM_LIMIT).
+ */
+struct LockArena
+{
+    uint16_t* data  = nullptr;
+    size_t    bytes = 0u;
+};
+
+/* ── Sample clock ─────────────────────────────────────────────────────── */
+
+/**
+ * Motion samples advanced per control frame, in Q16 fixed point.
+ */
+inline uint32_t LockStepQ16(uint16_t rate_hz, uint32_t frame_ms)
+{
+    constexpr uint64_t kMaxStep = 4096ull << 16;
+
+    const uint64_t num = static_cast<uint64_t>(rate_hz)
+                       * static_cast<uint64_t>(frame_ms) * 65536ull;
+    uint64_t step = (num + 500ull) / 1000ull;
+    if (step < 1ull)      step = 1ull;
+    if (step > kMaxStep)  step = kMaxStep;
+    return static_cast<uint32_t>(step);
+}
+
+} // namespace alchemy

--- a/framework/include/alchemy/control/param_lock_manager.h
+++ b/framework/include/alchemy/control/param_lock_manager.h
@@ -3,14 +3,15 @@
  * @brief Internal looping-automation engine used by the ParamLock surface.
  *
  * ParamLockManager is a low-level primitive: it owns nothing, allocates
- * nothing, and is driven by an external array of ParamLockSlot.  The
- * public-facing API for application code is the `alchemy::ParamLock`
- * surface in surface/param_lock.h — this header is the algorithm it
- * delegates to.
+ * nothing, and is driven by an external array of ParamLockSlot headers
+ * plus a flat motion arena.  The public-facing API for application code
+ * is the `alchemy::ParamLock` surface in surface/param_lock.h — this
+ * header is the algorithm it delegates to.
+ *
  *
  * Lifecycle (driven by the surface):
  *
- *   mgr.Init(slots, total_slots, gesture_width);
+ *   mgr.Init(cfg);
  *   on button down:                 mgr.OnButtonDown(phys);
  *   while button held, each tick:   mgr.ProcessGestures(offset, phys);
  *   on button up:                   bool consumed = mgr.OnButtonUp();
@@ -20,7 +21,9 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include "alchemy/control/lock_length.h"
 #include "alchemy/control/pot_catch.h"
 
 namespace alchemy {
@@ -28,37 +31,49 @@ namespace alchemy {
 /** Maximum pots-per-page supported by the gesture engine. */
 constexpr uint8_t kParamLockMaxGestureWidth = 8u;
 
+/**
+ * Per-slot header of the serialized form, followed by `stride` little-
+ * endian uint16 samples.
+ */
+struct ParamLockSavedHeader
+{
+    uint8_t  active;
+    uint16_t length;
+    uint16_t record_base;
+} __attribute__((packed));
+
+static_assert(sizeof(ParamLockSavedHeader) == 5u,
+              "ParamLockSavedHeader must pack to 5 bytes");
+
+/** Configuration handed to ParamLockManager::Init. */
+struct LockConfig
+{
+    ParamLockSlot* slots       = nullptr;  ///< caller-owned header array
+    uint16_t*      arena       = nullptr;  ///< caller-owned sample storage
+    uint16_t       stride      = 0u;       ///< samples reserved per slot
+    uint8_t        total_slots = 0u;       ///< length of @c slots
+    uint8_t        gesture_width = 0u;     ///< pots per gesture frame
+    uint16_t       rate_hz     = 30u;      ///< stored motion sample rate
+    uint32_t       frame_ms    = 16u;      ///< control-frame interval
+    float          gesture_threshold = kParamLockGestureThreshold;
+};
+
 class ParamLockManager
 {
   public:
-
     /**
-     * Serialisable snapshot of one ParamLockSlot.
-     * Packed so its binary layout is unambiguous across a CRC boundary.
-     */
-    struct SavedEntry
-    {
-        uint8_t  active;
-        uint16_t length;
-        float    record_base;
-        float    buf[kParamLockBufferLen];
-    } __attribute__((packed));
-
-    static_assert(sizeof(SavedEntry) == 1u + 2u + 4u + kParamLockBufferLen * 4u,
-                  "ParamLockManager::SavedEntry size mismatch");
-
-    /**
-     * Initialise the manager with an external slot array.
+     * Bind the manager to caller-owned storage.
      *
-     * @param slots             Caller-owned slot array.
-     * @param total_slots       Length of the array.
-     * @param gesture_width     Inputs per gesture frame (≤ kParamLockMaxGestureWidth).
-     * @param gesture_threshold Minimum physical nudge (0..1) required to arm/disarm a lock.
+     * Does not write to @c cfg.arena — safe to call from a static
+     * constructor even when the arena lives in memory that is not yet
+     * usable (SDRAM before the FMC is up).
      */
-    void Init(ParamLockSlot* slots,
-              uint8_t        total_slots,
-              uint8_t        gesture_width,
-              float          gesture_threshold = kParamLockGestureThreshold);
+    void Init(const LockConfig& cfg);
+
+    void SetFrameMs(uint32_t frame_ms);
+
+    /** True once Init() has been given a usable configuration. */
+    bool IsReady() const { return slots_ != nullptr && arena_ != nullptr; }
 
     /** Called when the trigger button goes down.  Snapshots baselines. */
     void OnButtonDown(const float phys[]);
@@ -73,10 +88,8 @@ class ParamLockManager
      */
     void ProcessGestures(uint8_t offset, const float phys[]);
 
-    /** Advance the play head on every active slot by one frame. */
     void Advance();
 
-    /** Read the current modulation delta for one slot without advancing it. */
     float Read(uint8_t index) const;
 
     bool IsActive   (uint8_t index) const;
@@ -84,21 +97,53 @@ class ParamLockManager
     bool IsButtonHeld() const { return button_held_; }
     bool WasConsumed()  const { return consumed_; }
 
-    /** Serialise count slots starting at offset into out[0..count-1]. */
-    void Capture(SavedEntry  out[], uint8_t count, uint8_t offset = 0) const;
+    /* ── Serialized form ─────────────────────────────────────────────── */
 
-    /** Restore count slots starting at offset from in[0..count-1]. */
-    void Restore(const SavedEntry in[], uint8_t count, uint8_t offset = 0);
+    size_t SavedBytesPerSlot() const
+    {
+        return sizeof(ParamLockSavedHeader)
+             + static_cast<size_t>(stride_) * sizeof(uint16_t);
+    }
 
-    /** Reset every slot to its default (inactive) state. */
+    /**
+     * Write slot @p index into @p out as SavedBytesPerSlot() bytes.
+     *
+     * Samples past `length` are zero-filled so the byte image is a pure
+     * function of the slot's musical content — two devices that recorded
+     * the same gesture produce the same CRC.
+     */
+    void CaptureSlot(uint8_t index, uint8_t* out) const;
+
+    void RestoreSlot(uint8_t index, const uint8_t* in);
+
     void Clear();
 
+    /** Zero the motion arena.  Separate from Clear() because an arena in
+     *  a NOLOAD section needs one explicit pass after the memory is up. */
+    void ClearArena();
+
   private:
-    void Finalise();
+    void  Finalise();
+    void  EmitSample(ParamLockSlot& lk, uint16_t* buf);
+    float SampleAt(const ParamLockSlot& lk, const uint16_t* buf) const;
+
+    uint16_t*      Buf(uint8_t index)
+    {
+        return arena_ + static_cast<size_t>(index) * stride_;
+    }
+    const uint16_t* Buf(uint8_t index) const
+    {
+        return arena_ + static_cast<size_t>(index) * stride_;
+    }
 
     ParamLockSlot* slots_            = nullptr;
+    uint16_t*      arena_            = nullptr;
+    uint16_t       stride_           = 0;
     uint8_t        total_slots_      = 0;
     uint8_t        gesture_width_    = 0;
+    uint16_t       rate_hz_          = 30;
+    uint32_t       step_q16_         = 0;
+    uint32_t       rec_phase_q16_    = 0;
     float          gesture_threshold_= kParamLockGestureThreshold;
     float          baseline_   [kParamLockMaxGestureWidth] = {};
     bool           action_taken_[kParamLockMaxGestureWidth] = {};

--- a/framework/include/alchemy/control/pot_catch.h
+++ b/framework/include/alchemy/control/pot_catch.h
@@ -8,13 +8,14 @@
  * (crossover catch) or lands within kCatchTolerance of it (proximity
  * catch).
  *
- * PotState and ParamLock are plain data structs; InitCatch and
+ * PotState and ParamLockSlot are plain data structs; InitCatch and
  * UpdateCatch are stateless algorithms that operate on them.  They
  * carry no hardware or application dependencies.
  */
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 namespace alchemy {
@@ -23,9 +24,6 @@ namespace alchemy {
 
 /** Proximity window: pot is caught immediately if within this distance. */
 constexpr float    kCatchTolerance             = 0.005f;
-
-/** Circular looping-automation buffer length in frames (≈4 s at 60 Hz). */
-constexpr uint16_t kParamLockBufferLen         = 256u;
 
 /** Minimum physical nudge (0..1) required to start / stop param-lock. */
 constexpr float    kParamLockGestureThreshold  = 0.03f;
@@ -47,28 +45,22 @@ struct PotState
     int   sign_at_lock = 0;
 };
 
-/* ── ParamLockSlot ────────────────────────────────────────────────────── */
 
-/**
- * Per-pot looping automation recorder / player.
- *
- * When recording, physical pot values are appended each UI tick.
- * When playing, the recorded delta (buf[play_head] - record_base) is
- * added to (stored + cv_sum) exactly like a CV modulation — the physical
- * pot and its catch state are never modified by this struct.
- *
- * This is the raw data slot.  The user-facing surface is `alchemy::ParamLock`
- * (in surface/param_lock.h), which owns an array of these.
- */
 struct ParamLockSlot
 {
     bool     active      = false;
     bool     recording   = false;
-    float    buf[kParamLockBufferLen] = {};
-    uint16_t length      = 0;
-    uint16_t play_head   = 0;
-    float    record_base = 0.0f;
+    uint16_t length      = 0;      ///< samples recorded (≤ stride)
+    uint32_t play_pos    = 0;      ///< Q16.16 play position (see above)
+    uint16_t record_base = 0;      ///< quantized pot position at arm time
+    float    rec_accum   = 0.0f;   ///< box-average accumulator (record)
+    uint16_t rec_count   = 0;      ///< frames accumulated toward next sample
 };
+
+/* The atomicity argument above requires natural alignment. */
+static_assert(offsetof(ParamLockSlot, play_pos) % alignof(uint32_t) == 0,
+              "ParamLockSlot::play_pos must be 4-byte aligned — the audio "
+              "ISR relies on its store being single-copy atomic");
 
 /* ── Algorithms ───────────────────────────────────────────────────────── */
 

--- a/framework/include/alchemy/control/preset_capacity.h
+++ b/framework/include/alchemy/control/preset_capacity.h
@@ -1,0 +1,39 @@
+/**
+ * @file alchemy/control/preset_capacity.h
+ * @brief How many payload bytes fit in one preset slot.
+ *
+ * Split out of surface/presets.h so components can budget against it
+ * without dragging in `daisy_seed.h`: ParamLock static_asserts its
+ * configuration against `kPresetBlobCapacity` at the declaration site,
+ * and it must stay includable from board-agnostic headers.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace alchemy {
+
+/** Erase granule of the preset region (IS25LP064A sector). */
+constexpr uint32_t kPresetCapacitySectorSize = 4096u;
+
+/** Sectors per ping-pong side of one preset slot. */
+constexpr uint8_t kPresetCapacitySectorsPerSide = 5u;
+
+/**
+ * Bytes available per slot for the concatenated managed-component payload.
+ *
+ * Sector space minus the on-flash record header (20 B), our own blob
+ * preamble (8 B), and a 4-byte safety margin.
+ *
+ * This ceiling is hard.  The preset region occupies the top 640 KiB of
+ * the QSPI chip (16 slots × 2 sides × 5 sectors × 4 KiB, ending at the
+ * last byte of the device), so it cannot be grown without either taking
+ * space from firmware or trading away preset slots.
+ */
+constexpr size_t kPresetBlobCapacity =
+    static_cast<size_t>(kPresetCapacitySectorSize) * kPresetCapacitySectorsPerSide
+    - 32u;
+
+} // namespace alchemy

--- a/framework/include/alchemy/surface/lock_source.h
+++ b/framework/include/alchemy/surface/lock_source.h
@@ -32,30 +32,13 @@ class LockSource
     /** True if the (page, pot) slot is actively playing back. */
     virtual bool  IsActiveAtPage(uint8_t page, uint8_t pot) const = 0;
 
-    /**
-     * Detect trigger-button edges at 1 ms cadence. Called from ControlLoop's
-     * inner poll loop. Sets internal pending flags consumed by Update().
-     * When @p gated, sync prev-pressed state but don't fire actions.
-     *
-     * Default: no-op.
-     */
+
     virtual void  PollButtons(uint32_t /*t_ms*/, bool /*gated*/) {}
 
-    /**
-     * Process one control-loop frame of gesture state (record/disarm).
-     * Main thread only.  Gated by ControlLoop while Settings is active —
-     * playback must NOT live here; that's Advance()'s job.
-     */
     virtual void  Update(const float* phys, uint32_t t_ms) = 0;
 
-    /**
-     * Advance playback by one frame.  Called by ControlLoop every frame,
-     * unconditionally — recorded automation keeps running while Settings
-     * owns the surface.  Touches no gesture state.
-     *
-     * Default: no-op (custom sources that advance elsewhere need nothing).
-     */
     virtual void  Advance() {}
+    virtual void  SetFrameMs(uint32_t /*frame_ms*/) {}
 
     /**
      * Paint automation-state overlay (e.g. recording/active pips) onto the

--- a/framework/include/alchemy/surface/param_lock.h
+++ b/framework/include/alchemy/surface/param_lock.h
@@ -2,23 +2,28 @@
  * @file alchemy/surface/param_lock.h
  * @brief alchemy::ParamLock — opt-in looping-automation surface.
  *
- * A ParamLock surface owns an array of automation slots and the trigger
- * button's gesture state.  Each frame `Update()` advances every slot's
- * play head; `Delta(p)` reads the current modulation amount for pot p on
- * the visible page (resolved via an optional Pager) without advancing.
+ * Owns an array of automation slots and the trigger button's gesture
+ * state.  Advance() moves every slot's play head each frame; Delta(p)
+ * reads the current modulation for pot p on the visible page (resolved
+ * via an optional Pager) without advancing.
  *
  * TODO: Update to use Matthew's sparse sampling, which will be sick.
- * 
- * Two constructors, one template parameter (total slot count):
  *
- *   alchemy::ParamLock<6>  locks(hw.buttons[0]);            // unpaged, 6 slots
- *   alchemy::ParamLock<12> locks(hw.buttons[0], pager);     // paged, 12 = 2 × 6
+ * Two template parameters — how many slots, and how long each one is:
  *
- * The paged form resolves Delta(p) as `pager.Page() * pager.NumPots() + p`.
- * The unpaged form uses `p` directly.  Advance() moves all kSlots play
- * heads each frame so automation on inactive pages keeps cycling; it is
- * separate from Update() (gestures) so playback survives modes — like the
- * Settings menu — that suspend gesture handling.
+ *   alchemy::ParamLock<6>                      locks(hw.buttons[0]);
+ *   alchemy::ParamLock<6, LockLength<20>>      locks(hw.buttons[0]);
+ *   alchemy::ParamLock<12, LockLength<30, 20>> locks(hw.buttons[0], pager);
+ *
+ * Length defaults to DefaultLockLength (16 s at 30 Hz).  Both the RAM
+ * and preset-slot budgets are checked at the declaration site; see
+ * alchemy/control/lock_length.h and docs/param-locks.md.
+ *
+ * The paged form resolves Delta(p) as pager.Page() * pager.NumPots() + p,
+ * and kSlots must equal pager.NumPages() * pager.NumPots().  Advance()
+ * moves all kSlots heads so inactive pages keep cycling; it is separate
+ * from Update() (gestures) so playback survives modes — like the Settings
+ * menu — that suspend gesture handling.
  *
  * Composition at the user's read site:
  *
@@ -26,42 +31,141 @@
  *       return pager.Value(p) + locks.Delta(p) + cv.Delta(p, cv_buf, n);
  *   }
  *
- * Saving locks into a preset:
- *
- *   locks.Save(preset.locks);     // length kSlots
- *   locks.Restore(preset.locks);
+ * Saving into a preset is just presets.Manage(locks).  Save()/Restore()
+ * expose the raw bytes by hand — the only route for LockStore::RamOnly.
  */
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-#include <cstring>
-#include "alchemy/control/pot_catch.h"
+#include "alchemy/control/lock_length.h"
 #include "alchemy/control/param_lock_manager.h"
+#include "alchemy/control/pot_catch.h"
+#include "alchemy/control/preset_capacity.h"
 #include "alchemy/hw/i_button.h"
 #include "alchemy/surface/lock_source.h"
 #include "alchemy/surface/pager.h"
 #include "alchemy/surface/serializable.h"
 
+#define ALCHEMY_LOCK_OVERSIZE_MESSAGE                                          \
+    "ParamLock's motion arena exceeds ALCHEMY_LOCK_INLINE_RAM_LIMIT (16 KiB "  \
+    "by default). Framework statics link into DTCMRAM, which is 128 KiB "      \
+    "shared with the stack, so an arena this size must be placed "             \
+    "deliberately: declare `uint16_t ALCHEMY_SDRAM_BSS "                       \
+    "arena[Locks::kArenaSamples];`, pass `alchemy::LockArena{arena, sizeof "   \
+    "arena}` to the constructor, and call locks.Init() from main() after "     \
+    "hw.Init(). Or reduce kSlots / kSeconds / kRateHz. See "                   \
+    "ParamLock<>::kArenaBytes."
+
+#define ALCHEMY_LOCK_UNDERSIZE_MESSAGE                                         \
+    "This ParamLock configuration holds its motion arena inline "              \
+    "(kArenaBytes is within ALCHEMY_LOCK_INLINE_RAM_LIMIT), so passing a "     \
+    "LockArena would allocate the storage twice. Drop the LockArena "          \
+    "argument. If you need the arena placed outside DTCM anyway, build with "  \
+    "-DALCHEMY_LOCK_INLINE_RAM_LIMIT=0."
+
 namespace alchemy {
 
 class LedPanel;
 
-/* Schema tag for ParamLock — bump if SavedEntry layout changes. */
-inline constexpr uint32_t kParamLockSchemaTag = 0x504C4B30u; /* 'PLK0' */
+/* Schema tag for ParamLock — bump if the saved layout changes shape.
+ * 'PLK1': uint16 motion samples at a configurable rate, variable length. */
+inline constexpr uint32_t kParamLockSchemaTag = 0x504C4B31u; /* 'PLK1' */
 
-template<uint8_t kSlots>
+namespace detail {
+
+/** Conditional inline motion storage — specialised away entirely past
+ *  ALCHEMY_LOCK_INLINE_RAM_LIMIT, so an external arena never pays for a
+ *  shadow copy inside the object. */
+template<uint32_t kSamples, bool kInline>
+struct LockArenaStore;
+
+template<uint32_t kSamples>
+struct LockArenaStore<kSamples, true>
+{
+    uint16_t  data[kSamples] = {};
+    uint16_t* Ptr() { return data; }
+};
+
+template<uint32_t kSamples>
+struct LockArenaStore<kSamples, false>
+{
+    uint16_t* Ptr() { return nullptr; }
+};
+
+} // namespace detail
+
+template<uint8_t kSlots, class Len = DefaultLockLength>
 class ParamLock : public Serializable, public LockSource
 {
   public:
-    using SavedEntry = ParamLockManager::SavedEntry;
-    static constexpr uint8_t kNumSlots = kSlots;
+    /* ── Configuration ───────────────────────────────────────────────
+     * Compile-time constants — print at boot or static_assert against. */
+
+    static constexpr uint8_t   kNumSlots      = kSlots;
+    static constexpr uint16_t  kMaxSeconds    = Len::kMaxSeconds;
+    static constexpr uint16_t  kSampleRateHz  = Len::kSampleRateHz;
+    static constexpr LockStore kStorage       = Len::kStorage;
+
+    /** Motion samples reserved per slot. */
+    static constexpr uint16_t kFramesPerSlot =
+        static_cast<uint16_t>(Len::kFramesPerSlot);
+
+    /** Total motion samples across all slots (the arena length). */
+    static constexpr uint32_t kArenaSamples =
+        static_cast<uint32_t>(kSlots) * kFramesPerSlot;
+
+    /** Motion arena size in bytes. */
+    static constexpr size_t kArenaBytes =
+        static_cast<size_t>(kArenaSamples) * sizeof(uint16_t);
+
+    /** True when the arena lives inside the object (see LockArena). */
+    static constexpr bool kInlineArena =
+        (kArenaBytes <= static_cast<size_t>(ALCHEMY_LOCK_INLINE_RAM_LIMIT));
+
+    /** Bytes one slot occupies in the serialized byte form. */
+    static constexpr size_t kBytesPerSavedSlot =
+        sizeof(ParamLockSavedHeader)
+        + static_cast<size_t>(kFramesPerSlot) * sizeof(uint16_t);
+
+    /** Full serialized byte form (Save()/Restore()), regardless of policy. */
+    static constexpr size_t kSavedBytes =
+        static_cast<size_t>(kSlots) * kBytesPerSavedSlot;
+
+    /** Contribution to every preset slot — 0 for LockStore::RamOnly. */
+    static constexpr size_t kPresetBytes =
+        (kStorage == LockStore::Preset) ? kSavedBytes : size_t{0};
+
+    /** Preset-slot bytes left for every other managed component. */
+    static constexpr size_t kPresetBytesFree =
+        (kPresetBytes < kPresetBlobCapacity)
+            ? (kPresetBlobCapacity - kPresetBytes) : size_t{0};
+
+    /** Total RAM this surface costs, object and arena together. */
+    static constexpr size_t RamBytes();
+
+    /* ── Compile-time budget ─────────────────────────────────────────── */
+
+    static_assert(kSlots > 0u, "ParamLock: kSlots must be at least 1.");
+
+    static_assert(kPresetBytes <= kPresetBlobCapacity,
+        "ParamLock exceeds one preset slot (kPresetBlobCapacity, 20448 B). "
+        "The preset region is the top 640 KiB of the QSPI chip and cannot "
+        "grow. Reduce kSlots, kSeconds, or kRateHz — dropping the rate is "
+        "usually free, since a hand gesture carries nothing above ~8 Hz "
+        "(30 s x 12 slots fits at 20 Hz) — or declare the length with "
+        "LockStore::RamOnly to keep these locks out of presets entirely. "
+        "Compare ParamLock<>::kPresetBytes against alchemy::kPresetBlobCapacity.");
+
+    /* ── Construction ────────────────────────────────────────────────── */
 
     /** Unpaged form: kSlots is the pot count, Delta(p) reads slot p. */
     explicit ParamLock(IButton& trigger)
         : trigger_(&trigger), pager_(nullptr)
     {
-        mgr_.Init(slots_, kSlots, kSlots);
+        static_assert(kInlineArena, ALCHEMY_LOCK_OVERSIZE_MESSAGE);
+        Bind(arena_.Ptr(), kSlots);
     }
 
     /**
@@ -71,8 +175,42 @@ class ParamLock : public Serializable, public LockSource
     ParamLock(IButton& trigger, Pager& pgr)
         : trigger_(&trigger), pager_(&pgr)
     {
-        mgr_.Init(slots_, kSlots, pgr.NumPots());
+        static_assert(kInlineArena, ALCHEMY_LOCK_OVERSIZE_MESSAGE);
+        Bind(arena_.Ptr(), pgr.NumPots());
     }
+
+    /** Unpaged form with application-placed motion storage.  Required
+     *  past ALCHEMY_LOCK_INLINE_RAM_LIMIT; see LockArena for placement
+     *  rules.  A short arena is refused (IsReady() stays false). */
+    ParamLock(IButton& trigger, LockArena arena)
+        : trigger_(&trigger), pager_(nullptr)
+    {
+        static_assert(!kInlineArena, ALCHEMY_LOCK_UNDERSIZE_MESSAGE);
+        Bind(arena.bytes >= kArenaBytes ? arena.data : nullptr, kSlots);
+    }
+
+    /** Paged form with application-placed motion storage. */
+    ParamLock(IButton& trigger, Pager& pgr, LockArena arena)
+        : trigger_(&trigger), pager_(&pgr)
+    {
+        static_assert(!kInlineArena, ALCHEMY_LOCK_UNDERSIZE_MESSAGE);
+        Bind(arena.bytes >= kArenaBytes ? arena.data : nullptr, pgr.NumPots());
+    }
+
+    /** Clear the motion arena and every slot.  Optional for an inline
+     *  arena, REQUIRED for an external one in a NOLOAD section such as
+     *  .sdram_bss.  Call from main() after hw.Init() — never from a
+     *  static constructor. */
+    void Init()
+    {
+        mgr_.Clear();
+        mgr_.ClearArena();
+    }
+
+    /** False when an external arena was too small — the surface is inert. */
+    bool IsReady() const { return mgr_.IsReady(); }
+
+    /* ── Per-frame ───────────────────────────────────────────────────── */
 
     /**
      * Process one frame of GESTURE state: consume the trigger edges
@@ -108,6 +246,12 @@ class ParamLock : public Serializable, public LockSource
      *  mode like Settings suspends Update(). */
     void Advance() override;
 
+    /** Declare the control-frame interval, so kMaxSeconds means seconds
+     *  rather than frames.  ControlLoop calls this every frame. */
+    void SetFrameMs(uint32_t frame_ms) override { mgr_.SetFrameMs(frame_ms); }
+
+    /* ── Reads ───────────────────────────────────────────────────────── */
+
     /** Modulation delta for pot @p p on the visible page (no advance). */
     float Delta(uint8_t pot) const;
 
@@ -139,11 +283,14 @@ class ParamLock : public Serializable, public LockSource
      */
     void Render(LedPanel& panel, uint32_t t_ms) const override;
 
-    /** Serialise every slot into @p out[0..kSlots-1]. */
-    void Save(SavedEntry out[]) const { mgr_.Capture(out, kSlots, 0); }
+    /* ── Raw byte form ───────────────────────────────────────────────── */
 
-    /** Restore every slot from @p in[0..kSlots-1]. */
-    void Restore(const SavedEntry in[]) { mgr_.Restore(in, kSlots, 0); }
+    /** Serialise every slot into @p out[0..kSavedBytes-1].  Always the
+     *  full byte form, independent of the LockStore policy. */
+    void Save(uint8_t* out) const;
+
+    /** Restore every slot from @p in[0..kSavedBytes-1]. */
+    void Restore(const uint8_t* in);
 
     /** Reset every slot to its default (inactive) state. */
     void Clear() { mgr_.Clear(); }
@@ -152,50 +299,57 @@ class ParamLock : public Serializable, public LockSource
     bool IsButtonHeld() const { return mgr_.IsButtonHeld(); }
 
     /* ── Serializable ──────────────────────────────────────────────────
-     * Round-trips the full SavedEntry array; identical to the existing
-     * Save()/Restore() but exposed through the Serializable contract so
-     * Presets can manage this object directly.
-     *
-     * Staged ONE entry at a time: a SavedEntry is ~1 KiB (256-sample
-     * motion buffer), so a whole-array stack local would spike
-     * kSlots × ~1 KiB deep inside the control loop (HostLink live
-     * writes, GET_LIVE, panel save/load).  The byte stream is unchanged
-     * — same entries, same order.                                    */
+     * Full byte form under LockStore::Preset, nothing under RamOnly.
+     * Written straight through — no per-entry stack staging, which at
+     * these buffer sizes would spike the control-loop stack.          */
 
-    size_t SerializedSize() const override
-    {
-        return static_cast<size_t>(kSlots) * sizeof(SavedEntry);
-    }
+    size_t SerializedSize() const override { return kPresetBytes; }
 
     void Serialize(uint8_t* out) const override
     {
-        SavedEntry e;
-        for (uint8_t i = 0; i < kSlots; i++, out += sizeof(e))
-        {
-            mgr_.Capture(&e, 1, i);
-            std::memcpy(out, &e, sizeof(e));
-        }
+        if constexpr (kStorage == LockStore::Preset) Save(out);
+        else                                         (void)out;
     }
 
     bool Deserialize(const uint8_t* in) override
     {
-        SavedEntry e;
-        for (uint8_t i = 0; i < kSlots; i++, in += sizeof(e))
-        {
-            std::memcpy(&e, in, sizeof(e));
-            mgr_.Restore(&e, 1, i);
-        }
+        if constexpr (kStorage == LockStore::Preset) Restore(in);
+        else                                         (void)in;
         return true;
     }
 
+    /** Layout hash.  Folds in everything that changes the byte image or
+     *  its meaning — slot count, length, rate, storage policy — so a
+     *  reconfigured build sees old slots as empty, not as garbage. */
     uint32_t SchemaHash() const override
     {
         return kParamLockSchemaTag
              ^ (static_cast<uint32_t>(kSlots) << 8)
-             ^ static_cast<uint32_t>(sizeof(SavedEntry));
+             ^ (static_cast<uint32_t>(kFramesPerSlot) * 0x9E3779B1u)
+             ^ (static_cast<uint32_t>(kSampleRateHz) * 0x85EBCA6Bu)
+             ^ (static_cast<uint32_t>(kStorage) * 0xC2B2AE35u)
+             ^ static_cast<uint32_t>(kBytesPerSavedSlot);
     }
 
   private:
+    /** Shared constructor tail — binds the manager to slots + arena. */
+    void Bind(uint16_t* arena, uint8_t gesture_width)
+    {
+        LockConfig cfg;
+        cfg.slots         = slots_;
+        cfg.arena         = arena;
+        cfg.stride        = kFramesPerSlot;
+        cfg.total_slots   = kSlots;
+        cfg.gesture_width = gesture_width;
+        cfg.rate_hz       = kSampleRateHz;
+        cfg.frame_ms      = kDefaultLockFrameMs;
+        mgr_.Init(cfg);
+    }
+
+    /** Assumed control-frame interval until SetFrameMs() says otherwise.
+     *  Matches ControlLoop::kDefaultFrameMs. */
+    static constexpr uint32_t kDefaultLockFrameMs = 16u;
+
     IButton*         trigger_;
     Pager*           pager_;
     bool             prev_pressed_    = false;
@@ -204,9 +358,17 @@ class ParamLock : public Serializable, public LockSource
     ParamLockSlot    slots_[kSlots] = {};
     ParamLockManager mgr_;
 
+    detail::LockArenaStore<kArenaSamples, kInlineArena> arena_;
+
     uint8_t Offset() const { return pager_ ? pager_->Page() * pager_->NumPots() : 0u; }
     uint8_t Width()  const { return pager_ ? pager_->NumPots() : kSlots; }
 };
+
+template<uint8_t kSlots, class Len>
+constexpr size_t ParamLock<kSlots, Len>::RamBytes()
+{
+    return sizeof(ParamLock<kSlots, Len>) + (kInlineArena ? size_t{0} : kArenaBytes);
+}
 
 } // namespace alchemy
 

--- a/framework/include/alchemy/surface/param_lock_impl.h
+++ b/framework/include/alchemy/surface/param_lock_impl.h
@@ -5,13 +5,40 @@
 
 #pragma once
 
+#include <cstring>
+
 #include "alchemy/surface/param_lock.h"
 #include "alchemy/led/panel.h"
 
 namespace alchemy {
 
-template<uint8_t kSlots>
-void ParamLock<kSlots>::PollButtons(uint32_t /*t_ms*/, bool gated)
+template<uint8_t kSlots, class Len>
+void ParamLock<kSlots, Len>::Save(uint8_t* out) const
+{
+    /* An inert surface (external arena refused) still owes the caller a
+     * full, well-formed image: SerializedSize() promised kSavedBytes, and
+     * the manager — which has no stride to work from — would write only
+     * the 5-byte headers, leaving the caller's buffer uninitialised in
+     * the gaps and putting stack residue into a preset slot. */
+    if (!mgr_.IsReady())
+    {
+        std::memset(out, 0, kSavedBytes);
+        return;
+    }
+
+    for (uint8_t i = 0; i < kSlots; i++, out += kBytesPerSavedSlot)
+        mgr_.CaptureSlot(i, out);
+}
+
+template<uint8_t kSlots, class Len>
+void ParamLock<kSlots, Len>::Restore(const uint8_t* in)
+{
+    for (uint8_t i = 0; i < kSlots; i++, in += kBytesPerSavedSlot)
+        mgr_.RestoreSlot(i, in);
+}
+
+template<uint8_t kSlots, class Len>
+void ParamLock<kSlots, Len>::PollButtons(uint32_t /*t_ms*/, bool gated)
 {
     const bool pressed = trigger_->Pressed();
     const bool rising  = pressed && !prev_pressed_;
@@ -22,8 +49,8 @@ void ParamLock<kSlots>::PollButtons(uint32_t /*t_ms*/, bool gated)
     if (falling) falling_pending_ = true;
 }
 
-template<uint8_t kSlots>
-void ParamLock<kSlots>::Update(const float* phys, uint32_t /*t_ms*/)
+template<uint8_t kSlots, class Len>
+void ParamLock<kSlots, Len>::Update(const float* phys, uint32_t /*t_ms*/)
 {
     /* Apply edges detected by PollButtons. Rising is processed first so a
      * fast tap (both flags set in the same frame) sees OnButtonDown before
@@ -46,50 +73,50 @@ void ParamLock<kSlots>::Update(const float* phys, uint32_t /*t_ms*/)
         mgr_.ProcessGestures(Offset(), phys);
 }
 
-template<uint8_t kSlots>
-void ParamLock<kSlots>::Advance()
+template<uint8_t kSlots, class Len>
+void ParamLock<kSlots, Len>::Advance()
 {
     mgr_.Advance();
 }
 
-template<uint8_t kSlots>
-float ParamLock<kSlots>::Delta(uint8_t pot) const
+template<uint8_t kSlots, class Len>
+float ParamLock<kSlots, Len>::Delta(uint8_t pot) const
 {
     return mgr_.Read(static_cast<uint8_t>(Offset() + pot));
 }
 
-template<uint8_t kSlots>
-bool ParamLock<kSlots>::IsActive(uint8_t pot) const
+template<uint8_t kSlots, class Len>
+bool ParamLock<kSlots, Len>::IsActive(uint8_t pot) const
 {
     return mgr_.IsActive(static_cast<uint8_t>(Offset() + pot));
 }
 
-template<uint8_t kSlots>
-bool ParamLock<kSlots>::IsRecording(uint8_t pot) const
+template<uint8_t kSlots, class Len>
+bool ParamLock<kSlots, Len>::IsRecording(uint8_t pot) const
 {
     return mgr_.IsRecording(static_cast<uint8_t>(Offset() + pot));
 }
 
-template<uint8_t kSlots>
-float ParamLock<kSlots>::DeltaAtPage(uint8_t page, uint8_t pot) const
+template<uint8_t kSlots, class Len>
+float ParamLock<kSlots, Len>::DeltaAtPage(uint8_t page, uint8_t pot) const
 {
     return mgr_.Read(static_cast<uint8_t>(page * Width() + pot));
 }
 
-template<uint8_t kSlots>
-bool ParamLock<kSlots>::IsActiveAtPage(uint8_t page, uint8_t pot) const
+template<uint8_t kSlots, class Len>
+bool ParamLock<kSlots, Len>::IsActiveAtPage(uint8_t page, uint8_t pot) const
 {
     return mgr_.IsActive(static_cast<uint8_t>(page * Width() + pot));
 }
 
-template<uint8_t kSlots>
-bool ParamLock<kSlots>::IsRecordingAtPage(uint8_t page, uint8_t pot) const
+template<uint8_t kSlots, class Len>
+bool ParamLock<kSlots, Len>::IsRecordingAtPage(uint8_t page, uint8_t pot) const
 {
     return mgr_.IsRecording(static_cast<uint8_t>(page * Width() + pot));
 }
 
-template<uint8_t kSlots>
-bool ParamLock<kSlots>::AnyRecording() const
+template<uint8_t kSlots, class Len>
+bool ParamLock<kSlots, Len>::AnyRecording() const
 {
     const uint8_t off = Offset();
     const uint8_t w   = Width();
@@ -98,8 +125,8 @@ bool ParamLock<kSlots>::AnyRecording() const
     return false;
 }
 
-template<uint8_t kSlots>
-bool ParamLock<kSlots>::AnyActive() const
+template<uint8_t kSlots, class Len>
+bool ParamLock<kSlots, Len>::AnyActive() const
 {
     const uint8_t off = Offset();
     const uint8_t w   = Width();
@@ -108,8 +135,8 @@ bool ParamLock<kSlots>::AnyActive() const
     return false;
 }
 
-template<uint8_t kSlots>
-void ParamLock<kSlots>::Render(LedPanel& panel, uint32_t /*t_ms*/) const
+template<uint8_t kSlots, class Len>
+void ParamLock<kSlots, Len>::Render(LedPanel& panel, uint32_t /*t_ms*/) const
 {
     const uint8_t off = Offset();
     const uint8_t w   = Width();

--- a/framework/include/alchemy/surface/presets.h
+++ b/framework/include/alchemy/surface/presets.h
@@ -15,9 +15,10 @@
  * Slot-level schema gating: every slot is stamped with the XOR of every
  * managed component's SchemaHash().  On Load, a mismatch is treated as
  * an empty slot rather than risking a misaligned restore.  This means
- * adding/removing a managed component, or resizing one (e.g. moving
- * from ParamLock<6> to ParamLock<12>) invalidates existing slots — they
- * disappear instead of corrupting your state.
+ * adding/removing a managed component, or reshaping one (e.g. moving
+ * from ParamLock<6> to ParamLock<12>, or lengthening its locks from 4 s
+ * to 20 s) invalidates existing slots — they disappear instead of
+ * corrupting your state.
  *
  * App extras: if you have state outside the standard surfaces, derive
  * a tiny struct from alchemy::Serializable that wraps it, and Manage()
@@ -28,6 +29,7 @@
 
 #include <cstdint>
 #include <cstddef>
+#include "alchemy/control/preset_capacity.h"  /* kPresetBlobCapacity */
 #include "alchemy/control/preset_store.h"
 #include "alchemy/hw/alchemy_lab_layout.h"  /* PresetFlashOps, kPresetFlashBase, etc. */
 #include "alchemy/surface/preset_name.h"
@@ -37,20 +39,19 @@ namespace daisy { class QSPIHandle; }
 
 namespace alchemy {
 
-/* ── Flash blob sizing ───────────────────────────────────────────────── */
-
-/**
- * Bytes available per slot for the concatenated managed-component payload.
+/* ── Flash blob sizing ───────────────────────────────────────────────────
  *
- * Computed from the Alchemy Lab preset region constants minus the on-flash
- * record header (20 B) and our own blob preamble (8 B).  In practice a
- * full Pager + ParamLock<16> + Settings load uses ~17 KiB; we cap a few
- * KiB below the physical maximum to leave room for future surfaces.
- *
+ * kPresetBlobCapacity lives in control/preset_capacity.h so components can
+ * budget against it without pulling in daisy_seed.h (ParamLock does, at
+ * its declaration site).  That header owns the payload arithmetic; the
+ * board layout owns the flash geometry.  Prove here that they agree —
+ * a board whose sector geometry ever changes must break the build, not
+ * silently shift every component's budget out from under it.
  */
-constexpr size_t kPresetBlobCapacity =
-    static_cast<size_t>(kPresetSectorSize) * kPresetSectorsPerSide
-    - 32u;  /* RecordHeader (20) + blob preamble (8) + 4-byte safety margin */
+static_assert(kPresetCapacitySectorSize == kPresetSectorSize
+              && kPresetCapacitySectorsPerSide == kPresetSectorsPerSide,
+              "alchemy/control/preset_capacity.h is out of sync with this "
+              "board's preset flash geometry — update it to match.");  /* RecordHeader (20) + blob preamble (8) + 4-byte safety margin */
 
 /** Maximum number of Serializables that can be registered via Manage(). */
 constexpr uint8_t kPresetMaxManaged = 8u;
@@ -131,6 +132,28 @@ class Presets
 
     /** Serialized size of the managed set. */
     size_t LiveSize() const { return ManagedSize(); }
+
+    /* ── Payload budget ─────────────────────────────────────────────
+     *
+     * Save() has always refused an oversized managed set by returning
+     * false, which is easy to miss on the bench — the preset simply
+     * never appears.  These make the budget inspectable *before* the
+     * first save, so an application can report it at boot.
+     *
+     * The dominant contributor is normally ParamLock, which additionally
+     * static_asserts its own configuration against kPresetBlobCapacity at
+     * the declaration site.  That catches "impossible on its own"; this
+     * catches "doesn't fit alongside everything else you manage".
+     */
+
+    /** Bytes the managed set writes into a preset slot. */
+    size_t PayloadBytes() const { return ManagedSize(); }
+
+    /** Bytes available per slot (kPresetBlobCapacity). */
+    static constexpr size_t Capacity() { return kPresetBlobCapacity; }
+
+    /** False when the managed set cannot fit — Save() will always fail. */
+    bool FitsInSlot() const { return ManagedSize() <= kPresetBlobCapacity; }
 
     /** Serialize every managed component into @p out (≤ @p cap bytes).
      *  Returns bytes written, or 0 if cap is too small. */

--- a/framework/src/control/param_lock_manager.cpp
+++ b/framework/src/control/param_lock_manager.cpp
@@ -4,19 +4,36 @@
 
 #include "alchemy/control/param_lock_manager.h"
 
+#include <cstring>
+
 namespace alchemy {
 
-void ParamLockManager::Init(ParamLockSlot* slots,
-                            uint8_t        total_slots,
-                            uint8_t        gesture_width,
-                            float          gesture_threshold)
+/* ── Lifecycle ────────────────────────────────────────────────────────── */
+
+void ParamLockManager::Init(const LockConfig& cfg)
 {
-    slots_         = slots;
-    total_slots_   = total_slots;
-    gesture_width_ = gesture_width < kParamLockMaxGestureWidth
-                         ? gesture_width
+    /* Stay inert rather than half-initialise into a null arena. */
+    if (cfg.slots == nullptr || cfg.arena == nullptr
+        || cfg.stride == 0u || cfg.total_slots == 0u)
+    {
+        slots_  = nullptr;
+        arena_  = nullptr;
+        stride_ = 0u;
+        total_slots_ = 0u;
+        return;
+    }
+
+    slots_         = cfg.slots;
+    arena_         = cfg.arena;
+    stride_        = cfg.stride;
+    total_slots_   = cfg.total_slots;
+    gesture_width_ = cfg.gesture_width < kParamLockMaxGestureWidth
+                         ? cfg.gesture_width
                          : kParamLockMaxGestureWidth;
-    gesture_threshold_ = gesture_threshold;
+    rate_hz_           = cfg.rate_hz;
+    gesture_threshold_ = cfg.gesture_threshold;
+    step_q16_          = LockStepQ16(cfg.rate_hz, cfg.frame_ms);
+    rec_phase_q16_     = 0u;
     button_held_       = false;
     consumed_          = false;
 
@@ -27,9 +44,18 @@ void ParamLockManager::Init(ParamLockSlot* slots,
     }
 }
 
+void ParamLockManager::SetFrameMs(uint32_t frame_ms)
+{
+    step_q16_ = LockStepQ16(rate_hz_, frame_ms);
+}
+
+/* ── Gesture ──────────────────────────────────────────────────────────── */
+
 void ParamLockManager::OnButtonDown(const float phys[])
 {
     button_held_ = true;
+    /* Restart the record clock with the gesture. */
+    rec_phase_q16_ = 0u;
     for (uint8_t i = 0; i < gesture_width_; i++)
     {
         baseline_[i]     = phys[i];
@@ -48,8 +74,16 @@ bool ParamLockManager::OnButtonUp()
 
 void ParamLockManager::ProcessGestures(uint8_t offset, const float phys[])
 {
-    if (!button_held_ || slots_ == nullptr)
+    if (!button_held_ || !IsReady())
         return;
+
+    /* Once per frame, ahead of the per-pot loop, so locks armed together
+     * stay sample-aligned.  `pending` exceeds 1 only when the control
+     * frame is slower than the stored rate — a zero-order hold, rather
+     * than silently running the recording fast. */
+    rec_phase_q16_ += step_q16_;
+    const uint32_t pending = rec_phase_q16_ >> 16;
+    rec_phase_q16_ &= 0xFFFFu;
 
     for (uint8_t i = 0; i < gesture_width_; i++)
     {
@@ -74,140 +108,210 @@ void ParamLockManager::ProcessGestures(uint8_t offset, const float phys[])
             }
             else
             {
+                lk = ParamLockSlot{};
                 lk.recording   = true;
-                lk.active      = false;
-                lk.length      = 0;
-                lk.play_head   = 0;
-                lk.record_base = phys[i];
+                lk.record_base = LockQuant(phys[i]);
             }
         }
 
-        if (lk.recording)
-        {
-            if (lk.length < kParamLockBufferLen)
-            {
-                lk.buf[lk.length++] = phys[i];
-            }
-            else
-            {
-                lk.recording = false;
-                lk.active    = true;
-                lk.play_head = 0;
-            }
-        }
+        if (!lk.recording)
+            continue;
+
+        /* Box-average, so a fast flick between two stored samples is
+         * attenuated rather than aliased into a spike. */
+        lk.rec_accum += phys[i];
+        lk.rec_count++;
+
+        for (uint32_t n = 0; n < pending && lk.recording; n++)
+            EmitSample(lk, Buf(idx));
     }
 }
 
+void ParamLockManager::EmitSample(ParamLockSlot& lk, uint16_t* buf)
+{
+    if (lk.length < stride_)
+    {
+        /* No frames accumulated (the 2nd..Nth emit of a slow control
+         * frame): hold the previous sample.  Falling back to record_base
+         * here would interleave the arm position into every gap. */
+        uint16_t q;
+        if (lk.rec_count)
+            q = LockQuant(lk.rec_accum / static_cast<float>(lk.rec_count));
+        else
+            q = lk.length ? buf[lk.length - 1u] : lk.record_base;
+
+        buf[lk.length++] = q;
+        lk.rec_accum = 0.0f;
+        lk.rec_count = 0u;
+    }
+
+    if (lk.length >= stride_)
+    {
+        /* Buffer full: loop what was captured rather than drop the tail.
+         * `active` publishes last — the ISR-side Read() gates on it. */
+        lk.recording = false;
+        lk.play_pos  = 0u;
+        lk.active    = true;
+    }
+}
+
+void ParamLockManager::Finalise()
+{
+    if (!IsReady())
+        return;
+
+    for (uint8_t i = 0; i < total_slots_; i++)
+    {
+        ParamLockSlot& lk = slots_[i];
+        if (!lk.recording)
+            continue;
+
+        /* Flush the partial sample in flight.  Without this a gesture
+         * shorter than one sample period (40 ms at 20 Hz) records
+         * nothing and leaves a slot that is neither recording nor
+         * active. */
+        if (lk.rec_count && lk.length < stride_)
+            EmitSample(lk, Buf(i));
+
+        /* `active` last, same reasoning as EmitSample. */
+        lk.recording = false;
+        lk.play_pos  = 0u;
+        lk.rec_accum = 0.0f;
+        lk.rec_count = 0u;
+        lk.active    = (lk.length > 0);
+    }
+}
+
+/* ── Playback ─────────────────────────────────────────────────────────── */
+
 void ParamLockManager::Advance()
 {
-    if (slots_ == nullptr) return;
+    if (!IsReady()) return;
+
     for (uint8_t i = 0; i < total_slots_; i++)
     {
         ParamLockSlot& lk = slots_[i];
         if (!lk.active || lk.length == 0) continue;
-        lk.play_head = static_cast<uint16_t>((lk.play_head + 1u) % lk.length);
+
+        /* Compute the whole new position, then publish it as ONE aligned
+         * 32-bit store.  The audio ISR reads play_pos between any two of
+         * these statements. */
+        uint32_t pos  = lk.play_pos + step_q16_;
+        uint32_t head = pos >> 16;
+        if (head >= lk.length)
+            head %= lk.length;
+        lk.play_pos = (head << 16) | (pos & 0xFFFFu);
     }
+}
+
+float ParamLockManager::SampleAt(const ParamLockSlot& lk,
+                                 const uint16_t* buf) const
+{
+    /* One aligned read, so index and fraction are always coherent even
+     * when this runs in the audio ISR mid-Advance. */
+    const uint32_t pos  = lk.play_pos;
+    const uint16_t head = static_cast<uint16_t>(pos >> 16);
+    const uint16_t next = static_cast<uint16_t>(
+        (static_cast<uint32_t>(head) + 1u) % lk.length);
+
+    const float a = LockDequant(buf[head]);
+    const float b = LockDequant(buf[next]);
+    const float f = static_cast<float>(pos & 0xFFFFu) * (1.0f / 65536.0f);
+
+    /* Interpolate rather than hold: at 20-30 Hz a held sample steps
+     * audibly on a cutoff or pitch.  When a == b this returns exactly a,
+     * so a stationary lock contributes exactly 0.0. */
+    return a + (b - a) * f;
 }
 
 float ParamLockManager::Read(uint8_t index) const
 {
-    if (slots_ == nullptr || index >= total_slots_) return 0.0f;
+    if (!IsReady() || index >= total_slots_) return 0.0f;
+
     const ParamLockSlot& lk = slots_[index];
     if (!lk.active || lk.length == 0) return 0.0f;
-    return lk.buf[lk.play_head] - lk.record_base;
+
+    return SampleAt(lk, Buf(index)) - LockDequant(lk.record_base);
 }
 
 bool ParamLockManager::IsActive(uint8_t index) const
 {
-    return slots_ != nullptr && index < total_slots_ && slots_[index].active;
+    return IsReady() && index < total_slots_ && slots_[index].active;
 }
 
 bool ParamLockManager::IsRecording(uint8_t index) const
 {
-    return slots_ != nullptr && index < total_slots_ && slots_[index].recording;
+    return IsReady() && index < total_slots_ && slots_[index].recording;
 }
 
-void ParamLockManager::Capture(SavedEntry out[], uint8_t count, uint8_t offset) const
+/* ── Serialized form ──────────────────────────────────────────────────── */
+
+void ParamLockManager::CaptureSlot(uint8_t index, uint8_t* out) const
 {
-    for (uint8_t i = 0; i < count; i++)
+    const size_t sample_bytes =
+        static_cast<size_t>(stride_) * sizeof(uint16_t);
+
+    const bool valid = IsReady()
+                    && index < total_slots_
+                    && slots_[index].active
+                    && slots_[index].length > 0;
+
+    ParamLockSavedHeader h = {0u, 0u, 0u};
+
+    if (!valid)
     {
-        const uint8_t idx = static_cast<uint8_t>(offset + i);
-        SavedEntry&   dst = out[i];
-
-        const bool valid = slots_ != nullptr
-                        && idx < total_slots_
-                        && slots_[idx].active
-                        && slots_[idx].length > 0;
-
-        if (!valid)
-        {
-            dst.active      = 0u;
-            dst.length      = 0u;
-            dst.record_base = 0.0f;
-            for (uint16_t j = 0; j < kParamLockBufferLen; j++)
-                dst.buf[j] = 0.0f;
-            continue;
-        }
-
-        const ParamLockSlot& lk = slots_[idx];
-        dst.active      = 1u;
-        dst.length      = lk.length;
-        dst.record_base = lk.record_base;
-        for (uint16_t j = 0; j < lk.length; j++)
-            dst.buf[j] = lk.buf[j];
-        for (uint16_t j = lk.length; j < kParamLockBufferLen; j++)
-            dst.buf[j] = 0.0f;
+        std::memcpy(out, &h, sizeof h);
+        std::memset(out + sizeof h, 0, sample_bytes);
+        return;
     }
+
+    const ParamLockSlot& lk = slots_[index];
+    h.active      = 1u;
+    h.length      = lk.length;
+    h.record_base = lk.record_base;
+    std::memcpy(out, &h, sizeof h);
+
+    const size_t used = static_cast<size_t>(lk.length) * sizeof(uint16_t);
+    std::memcpy(out + sizeof h, Buf(index), used);
+    std::memset(out + sizeof h + used, 0, sample_bytes - used);
 }
 
-void ParamLockManager::Restore(const SavedEntry in[], uint8_t count, uint8_t offset)
+void ParamLockManager::RestoreSlot(uint8_t index, const uint8_t* in)
 {
-    for (uint8_t i = 0; i < count; i++)
-    {
-        const uint8_t idx = static_cast<uint8_t>(offset + i);
-        if (slots_ == nullptr || idx >= total_slots_)
-            break;
+    if (!IsReady() || index >= total_slots_)
+        return;
 
-        ParamLockSlot&    lk  = slots_[idx];
-        const SavedEntry& src = in[i];
+    ParamLockSlot& lk = slots_[index];
+    lk = ParamLockSlot{};   /* active=false while we rebuild below */
 
-        lk = ParamLockSlot{};
+    ParamLockSavedHeader h;
+    std::memcpy(&h, in, sizeof h);
 
-        if (!src.active || src.length == 0 || src.length > kParamLockBufferLen)
-            continue;
+    if (!h.active || h.length == 0u || h.length > stride_)
+        return;
 
-        lk.active      = true;
-        lk.recording   = false;
-        lk.length      = src.length;
-        lk.play_head   = 0;
-        lk.record_base = src.record_base;
-        for (uint16_t j = 0; j < src.length; j++)
-            lk.buf[j] = src.buf[j];
-    }
+    std::memcpy(Buf(index), in + sizeof h,
+                static_cast<size_t>(h.length) * sizeof(uint16_t));
+
+    lk.length      = h.length;
+    lk.record_base = h.record_base;
+    lk.active      = true;
 }
 
 void ParamLockManager::Clear()
 {
-    if (slots_ == nullptr)
+    if (!IsReady())
         return;
     for (uint8_t i = 0; i < total_slots_; i++)
         slots_[i] = ParamLockSlot{};
 }
 
-void ParamLockManager::Finalise()
+void ParamLockManager::ClearArena()
 {
-    if (slots_ == nullptr)
+    if (!IsReady())
         return;
-    for (uint8_t i = 0; i < total_slots_; i++)
-    {
-        ParamLockSlot& lk = slots_[i];
-        if (lk.recording)
-        {
-            lk.recording = false;
-            lk.active    = (lk.length > 0);
-            lk.play_head = 0;
-        }
-    }
+    std::memset(arena_, 0,
+                static_cast<size_t>(total_slots_) * stride_ * sizeof(uint16_t));
 }
 
 } // namespace alchemy

--- a/framework/src/surface/control_loop.cpp
+++ b/framework/src/surface/control_loop.cpp
@@ -82,7 +82,11 @@ void ControlLoop::Tick()
     /* ── Lock playback advances every frame, unconditionally: recorded
      *    modulation must keep running while Settings owns the surface.
      *    Only the gesture half (locks_->Update below) stands down. */
-    if (locks_) locks_->Advance();
+    if (locks_)
+    {
+        locks_->SetFrameMs(frame_ms_);
+        locks_->Advance();
+    }
 
     if (!in_settings)
     {

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SDK_ROOT "${CMAKE_SOURCE_DIR}")
 add_executable(hostlink_tests
     hostlink_tests.cpp
     fs_tests.cpp
+    param_lock_tests.cpp
     ram_diskio.cpp
     "${SDK_ROOT}/framework/src/host_link/host_link.cpp"
     "${SDK_ROOT}/framework/src/host_link/descriptor.cpp"

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -38,6 +38,7 @@
 #include "alchemy/surface/virtual_knob.h"
 
 #include "fs_tests.h"
+#include "param_lock_tests.h"
 
 using namespace alchemy;
 using namespace alchemy::hostlink;
@@ -1400,102 +1401,6 @@ static void TestUseNames()
     CHECK_EQ(p1.LiveSize(), p2.LiveSize());
 }
 
-/* ParamLock's Serializable path stages one ~1 KiB SavedEntry at a time
- * (not the whole array on the stack); the byte stream must stay exactly
- * the flat SavedEntry array Restore→Capture reproduces. */
-static void TestParamLockSerializeRoundTrip()
-{
-    struct FakeButton : IButton
-    {
-        bool  Pressed() const override { return false; }
-        bool  RisingEdge() override { return false; }
-        bool  FallingEdge() override { return false; }
-        float TimeHeldMs() const override { return 0.0f; }
-    } button;
-
-    ParamLock<4> locks(button);
-    using Entry = ParamLock<4>::SavedEntry;
-    CHECK_EQ(locks.SerializedSize(), size_t{4} * sizeof(Entry));
-
-    /* Craft an image: slots 0 and 2 active with distinct ramps (zero-
-     * padded past `length`, exactly as Capture emits), slots 1 and 3
-     * inactive (all zeros). */
-    std::vector<uint8_t> image(locks.SerializedSize(), 0u);
-    {
-        Entry e{};
-        e.active      = 1u;
-        e.length      = 5u;
-        e.record_base = 0.25f;
-        for (uint16_t j = 0; j < e.length; j++)
-            e.buf[j] = 0.01f * static_cast<float>(j + 1);
-        std::memcpy(image.data(), &e, sizeof(e));
-    }
-    {
-        Entry e{};
-        e.active      = 1u;
-        e.length      = kParamLockBufferLen; /* full motion buffer */
-        e.record_base = -1.0f;
-        for (uint16_t j = 0; j < e.length; j++)
-            e.buf[j] = (j & 1u) ? 0.5f : -0.5f;
-        std::memcpy(image.data() + 2u * sizeof(Entry), &e, sizeof(e));
-    }
-
-    CHECK(locks.Deserialize(image.data()));
-
-    std::vector<uint8_t> out(locks.SerializedSize(), 0xAAu);
-    locks.Serialize(out.data());
-    CHECK(out == image);
-}
-
-/* Playback lives in Advance(), not Update(): Update() only consumes
- * gesture edges, so ControlLoop can keep automation running (Advance
- * every frame) while Settings suspends the gesture path (Update). */
-static void TestParamLockAdvanceSplit()
-{
-    struct FakeButton : IButton
-    {
-        bool  Pressed() const override { return false; }
-        bool  RisingEdge() override { return false; }
-        bool  FallingEdge() override { return false; }
-        float TimeHeldMs() const override { return 0.0f; }
-    } button;
-
-    ParamLock<4> locks(button);
-    using Entry = ParamLock<4>::SavedEntry;
-
-    /* Slot 0: active 3-sample loop around record_base 0.5. */
-    std::vector<uint8_t> image(locks.SerializedSize(), 0u);
-    Entry e{};
-    e.active      = 1u;
-    e.length      = 3u;
-    e.record_base = 0.5f;
-    e.buf[0]      = 0.6f;
-    e.buf[1]      = 0.7f;
-    e.buf[2]      = 0.9f;
-    std::memcpy(image.data(), &e, sizeof(e));
-    CHECK(locks.Deserialize(image.data()));
-
-    const float phys[4] = {};
-    CHECK(locks.Delta(0) == 0.6f - 0.5f);
-
-    /* Update() with no pending edges must not move the play head. */
-    locks.Update(phys, 0u);
-    locks.Update(phys, 1u);
-    CHECK(locks.Delta(0) == 0.6f - 0.5f);
-
-    /* Advance() steps the loop — including through the LockSource base,
-     * which is how ControlLoop drives it. */
-    locks.Advance();
-    CHECK(locks.Delta(0) == 0.7f - 0.5f);
-    static_cast<LockSource&>(locks).Advance();
-    CHECK(locks.Delta(0) == 0.9f - 0.5f);
-    locks.Advance();
-    CHECK(locks.Delta(0) == 0.6f - 0.5f); /* wrapped */
-
-    /* Inactive slots are unaffected either way. */
-    CHECK(locks.Delta(1) == 0.0f);
-}
-
 /* ── Golden vector emission ────────────────────────────────────────── */
 
 static std::string Hex(const uint8_t* p, size_t n)
@@ -1730,10 +1635,9 @@ int main(int argc, char** argv)
     TestJsonCheck();
     TestDescriptorJsonValidation();
     TestUseNames();
-    TestParamLockSerializeRoundTrip();
-    TestParamLockAdvanceSplit();
     TestSettingsLoadCanonicalization();
 
+    RunParamLockTests(g_checks, g_failures);
     RunFsTests(g_checks, g_failures);
 
     std::printf("%d checks, %d failures\n", g_checks, g_failures);

--- a/tests/host/param_lock_tests.cpp
+++ b/tests/host/param_lock_tests.cpp
@@ -1,0 +1,792 @@
+/**
+ * @file tests/host/param_lock_tests.cpp
+ * @brief ParamLock / ParamLockManager test battery.
+ *
+ * Covers the configurable-length automation surface end to end: the
+ * record gesture, the millisecond sample clock (the part that makes
+ * "20 seconds" mean twenty seconds at any frame rate), decimation and
+ * playback interpolation, the serialized byte form, externally-placed
+ * motion arenas, and the preset budget.
+ */
+
+#include "param_lock_tests.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "alchemy/surface/pager.h"
+#include "alchemy/surface/param_lock.h"
+#include "alchemy/surface/presets.h"
+
+using namespace alchemy;
+
+static daisy::QSPIHandle s_dummy_qspi;   /* stubbed on host */
+
+/* ── Local check harness (totals returned to main) ─────────────────── */
+
+static int s_checks   = 0;
+static int s_failures = 0;
+
+#define PCHECK(cond)                                                       \
+    do {                                                                   \
+        s_checks++;                                                        \
+        if (!(cond)) {                                                     \
+            s_failures++;                                                  \
+            std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);    \
+        }                                                                  \
+    } while (0)
+
+#define PCHECK_EQ(a, b)                                                    \
+    do {                                                                   \
+        s_checks++;                                                        \
+        const auto va = (a);                                               \
+        const auto vb = (b);                                               \
+        if (!(va == vb)) {                                                 \
+            s_failures++;                                                  \
+            std::printf("FAIL %s:%d  %s == %s  (%lld != %lld)\n",          \
+                        __FILE__, __LINE__, #a, #b,                        \
+                        (long long)va, (long long)vb);                     \
+        }                                                                  \
+    } while (0)
+
+#define PCHECK_NEAR(a, b, tol)                                             \
+    do {                                                                   \
+        s_checks++;                                                        \
+        const float va = (a);                                              \
+        const float vb = (b);                                              \
+        if (!(std::fabs(va - vb) <= (tol))) {                              \
+            s_failures++;                                                  \
+            std::printf("FAIL %s:%d  %s ~= %s  (%.6f vs %.6f, tol %g)\n",  \
+                        __FILE__, __LINE__, #a, #b, va, vb, (double)(tol));\
+        }                                                                  \
+    } while (0)
+
+namespace {
+
+/* ── Fakes and drivers ─────────────────────────────────────────────── */
+
+struct FakeButton : IButton
+{
+    bool pressed = false;
+
+    bool  Pressed() const override { return pressed; }
+    bool  RisingEdge() override { return false; }
+    bool  FallingEdge() override { return false; }
+    float TimeHeldMs() const override { return 0.0f; }
+};
+
+/** One control frame, in ControlLoop's order. */
+template<class Locks>
+void Frame(Locks& locks, const float* phys, uint32_t frame_ms)
+{
+    locks.SetFrameMs(frame_ms);
+    locks.PollButtons(0u, false);
+    locks.Advance();
+    locks.Update(phys, 0u);
+}
+
+/** Pot position every gesture starts from — the gesture engine's baseline. */
+constexpr float kRest = 0.5f;
+
+/**
+ * Hold the trigger and sweep one pot through `values`, then release.
+ *
+ * The first frame stays at kRest because OnButtonDown snapshots the
+ * baseline there — a gesture already displaced on the press frame arms
+ * nothing.  So the lock arms on values[0]: record_base == values[0], and
+ * the recorded samples are `values`.
+ */
+template<class Locks, uint8_t kPots>
+void RecordGesture(Locks& locks, FakeButton& button, uint8_t pot,
+                   const std::vector<float>& values, uint32_t frame_ms)
+{
+    float phys[kPots] = {};
+    for (uint8_t i = 0; i < kPots; i++) phys[i] = kRest;
+
+    button.pressed = true;
+    Frame(locks, phys, frame_ms);          /* baseline snapshot */
+
+    for (float v : values)
+    {
+        phys[pot] = v;
+        Frame(locks, phys, frame_ms);
+    }
+
+    button.pressed = false;
+    Frame(locks, phys, frame_ms);
+}
+
+/**
+ * Frames a playing lock takes to go once round its loop.
+ *
+ * The caller seeds a rising ramp and names an interior level; the ramp
+ * crosses it once per loop.  Crossings rather than "Delta() dropped"
+ * because playback interpolates the wrap over several frames, and
+ * crossing-to-crossing rather than from frame zero because a lock that
+ * auto-armed mid-hold is already playing when the caller looks.
+ */
+template<class Locks>
+uint32_t FramesPerLoop(Locks& locks, uint8_t pot, uint32_t frame_ms,
+                       float level, uint32_t limit = 100000u)
+{
+    const float phys[8] = {};
+    float    prev  = locks.Delta(pot);
+    bool     armed = false;      /* seen the first crossing yet? */
+    uint32_t n     = 0u;
+
+    for (uint32_t i = 0; i < limit; i++)
+    {
+        Frame(locks, phys, frame_ms);
+        n++;
+        const float now = locks.Delta(pot);
+        const bool crossed = (prev < level && now >= level);
+        prev = now;
+
+        if (!crossed) continue;
+        if (!armed) { armed = true; n = 0u; continue; }   /* start counting */
+        return n;
+    }
+    return 0u;   /* never completed a loop */
+}
+
+/** Build a raw saved image for one slot (header + samples, zero tail). */
+template<class Locks>
+void PokeSlot(std::vector<uint8_t>& image, uint8_t slot, bool active,
+              float record_base, const std::vector<float>& samples)
+{
+    uint8_t* p = image.data() + static_cast<size_t>(slot) * Locks::kBytesPerSavedSlot;
+
+    ParamLockSavedHeader h;
+    h.active      = active ? 1u : 0u;
+    h.length      = static_cast<uint16_t>(samples.size());
+    h.record_base = LockQuant(record_base);
+    std::memcpy(p, &h, sizeof h);
+
+    for (size_t i = 0; i < samples.size(); i++)
+    {
+        const uint16_t q = LockQuant(samples[i]);
+        std::memcpy(p + sizeof h + i * sizeof(uint16_t), &q, sizeof q);
+    }
+}
+
+/* ── 1. Sample quantization ────────────────────────────────────────── */
+
+void TestQuantization()
+{
+    /* Under half a step, so the stored gesture is finer than the ADC. */
+    for (int i = 0; i <= 1000; i++)
+    {
+        const float v = static_cast<float>(i) / 1000.0f;
+        PCHECK(std::fabs(LockDequant(LockQuant(v)) - v) <= 1.0f / 131070.0f);
+    }
+
+    PCHECK_EQ(LockQuant(0.0f), 0u);
+    PCHECK_EQ(LockQuant(1.0f), 65535u);
+    PCHECK(LockDequant(0u) == 0.0f);
+    PCHECK(LockDequant(65535u) == 1.0f);
+
+    /* Clamp, not wrap — a wrap turns a clipped gesture into a jump. */
+    PCHECK_EQ(LockQuant(-0.5f), 0u);
+    PCHECK_EQ(LockQuant(2.0f), 65535u);
+    PCHECK_EQ(LockQuant(std::nanf("")), 0u);
+}
+
+/* ── 2. Configuration constants ────────────────────────────────────── */
+
+void TestConfigConstants()
+{
+    using Default = ParamLock<6>;
+    using Long    = ParamLock<6, LockLength<20>>;
+    using Paged   = ParamLock<12, LockLength<30, 20>>;
+
+    /* The default spends the old format's RAM (960 B/slot vs 1,024 B)
+     * on 16 s of automation instead of 4. */
+    PCHECK_EQ(Default::kMaxSeconds, 16u);
+    PCHECK_EQ(Default::kSampleRateHz, 30u);
+    PCHECK_EQ(Default::kFramesPerSlot, 480u);
+    PCHECK(Default::kFramesPerSlot * sizeof(uint16_t) <= 1024u);
+
+    /* A plain ParamLock<16> must keep compiling without a LockArena —
+     * that is the upgrade story.  Pins DefaultLockLength's ceiling. */
+    PCHECK(ParamLock<16>::kInlineArena);
+    PCHECK(ParamLock<16>::kPresetBytes <= kPresetBlobCapacity);
+
+    /* seconds x rate is the whole cost model. */
+    PCHECK_EQ(Long::kFramesPerSlot, 600u);
+    PCHECK_EQ(Paged::kFramesPerSlot, 600u);
+
+    /* 5-byte header + 2 B per sample, per slot. */
+    PCHECK_EQ(Long::kBytesPerSavedSlot, 5u + 600u * 2u);
+    PCHECK_EQ(Long::kSavedBytes, 6u * (5u + 1200u));
+    PCHECK_EQ(Long::kPresetBytes, Long::kSavedBytes);
+
+    /* Arena is 2 B per sample and nothing else. */
+    PCHECK_EQ(Long::kArenaSamples, 6u * 600u);
+    PCHECK_EQ(Long::kArenaBytes, 6u * 600u * 2u);
+
+    /* The headline configurations fit a preset slot. */
+    PCHECK(Long::kPresetBytes  <= kPresetBlobCapacity);
+    PCHECK(Paged::kPresetBytes <= kPresetBlobCapacity);
+    PCHECK(Paged::kPresetBytes  == 12u * (5u + 1200u));
+
+    /* RamOnly contributes nothing to a preset but keeps its byte form. */
+    using RamOnly = ParamLock<6, LockLength<20, 30, LockStore::RamOnly>>;
+    PCHECK_EQ(RamOnly::kPresetBytes, 0u);
+    PCHECK_EQ(RamOnly::kSavedBytes, Long::kSavedBytes);
+
+    /* Inline-vs-external is purely a size decision against the limit. */
+    PCHECK(Default::kInlineArena);
+    PCHECK(Long::kArenaBytes <= ALCHEMY_LOCK_INLINE_RAM_LIMIT);
+    PCHECK(Long::kInlineArena);
+
+    /* RamBytes() accounts for the object too, so it is strictly larger
+     * than the arena it reports. */
+    PCHECK(Long::RamBytes() > Long::kArenaBytes);
+}
+
+/* ── 3. Record → playback round trip ───────────────────────────────── */
+
+/* Rate 50 Hz at 20 ms frames is exactly one sample per frame, which
+ * isolates the record/playback path from the sample clock (tested
+ * separately below). */
+using ExactLocks = ParamLock<4, LockLength<4, 50>>;
+constexpr uint32_t kExactFrameMs = 20u;
+
+void TestRecordPlaybackRoundTrip()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    /* First swept value arms the lock, so it becomes record_base. */
+    const std::vector<float> sweep = {0.6f, 0.7f, 0.8f, 0.9f};
+    RecordGesture<ExactLocks, 4>(locks, button, 1, sweep, kExactFrameMs);
+
+    PCHECK(locks.IsActive(1));
+    PCHECK(!locks.IsRecording(1));
+    PCHECK(!locks.IsActive(0));      /* untouched pots stay clear */
+
+    /* Playback reproduces the recorded deltas in order, and loops. */
+    const float phys[4] = {};
+    for (int loop = 0; loop < 2; loop++)
+    {
+        for (float v : sweep)
+        {
+            PCHECK_NEAR(locks.Delta(1), v - sweep.front(), 1e-3f);
+            Frame(locks, phys, kExactFrameMs);
+        }
+    }
+}
+
+void TestDisarmClearsSlot()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    RecordGesture<ExactLocks, 4>(locks, button, 2, {0.6f, 0.7f, 0.8f},
+                                 kExactFrameMs);
+    PCHECK(locks.IsActive(2));
+
+    /* A second hold-and-nudge on an active slot clears it. */
+    RecordGesture<ExactLocks, 4>(locks, button, 2, {0.6f}, kExactFrameMs);
+    PCHECK(!locks.IsActive(2));
+    PCHECK(!locks.IsRecording(2));
+    PCHECK(locks.Delta(2) == 0.0f);
+}
+
+void TestBufferFullAutoArms()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    /* Hold past the configured length: recording must stop at exactly
+     * kFramesPerSlot and arm playback, not overrun the arena. */
+    float phys[4] = {kRest, kRest, kRest, kRest};
+    button.pressed = true;
+    Frame(locks, phys, kExactFrameMs);            /* baseline snapshot */
+
+    /* Monotonically rising across the whole buffer, so FramesPerLoop's
+     * "Delta went down" wrap detector sees exactly one drop per loop. */
+    const uint32_t held = ExactLocks::kFramesPerSlot + 50u;
+    for (uint32_t i = 0; i < held; i++)
+    {
+        phys[0] = 0.3f + 0.002f * static_cast<float>(i);
+        Frame(locks, phys, kExactFrameMs);
+        if (i == ExactLocks::kFramesPerSlot + 10u)
+        {
+            /* Already flipped to playback while the button is still down. */
+            PCHECK(locks.IsActive(0));
+            PCHECK(!locks.IsRecording(0));
+        }
+    }
+    button.pressed = false;
+    Frame(locks, phys, kExactFrameMs);
+
+    PCHECK(locks.IsActive(0));
+
+    /* kFramesPerSlot samples, one frame each at this cadence. */
+    /* Recorded deltas span 0 .. 0.398; 0.2 is an interior level. */
+    PCHECK_EQ(FramesPerLoop(locks, 0, kExactFrameMs, 0.2f),
+              uint32_t{ExactLocks::kFramesPerSlot});
+}
+
+/* ── 4. The sample clock: seconds mean seconds ─────────────────────── */
+
+void TestWallClockIndependentOfFrameRate()
+{
+    /* Before the buffer was clocked in milliseconds, "4 seconds" meant
+     * "256 frames" — changing FrameMs rescaled every recording. */
+    using Locks = ParamLock<4, LockLength<4, 50>>;
+    FakeButton button;
+
+    /* A 20-sample ramp: 20 samples at 50 Hz is 400 ms of automation, no
+     * matter what the control loop is doing. */
+    std::vector<float> ramp;
+    for (int i = 0; i < 20; i++)
+        ramp.push_back(0.1f + 0.04f * static_cast<float>(i));
+
+    struct Case { uint32_t frame_ms; };
+    const Case cases[] = {{10u}, {16u}, {20u}, {40u}};
+
+    for (const Case& c : cases)
+    {
+        Locks locks(button);
+        locks.Init();
+
+        std::vector<uint8_t> image(Locks::kSavedBytes, 0u);
+        PokeSlot<Locks>(image, 0, true, 0.0f, ramp);
+        locks.Restore(image.data());
+
+        /* Ramp deltas span 0.1 .. 0.86; 0.4 is an interior level. */
+        const uint32_t frames = FramesPerLoop(locks, 0, c.frame_ms, 0.4f);
+        PCHECK(frames > 0u);
+
+        const uint32_t loop_ms = frames * c.frame_ms;
+
+        /* 20 samples at 50 Hz = 400 ms.  Tolerance is one frame: the
+         * wrap can only be observed on a frame boundary. */
+        const bool ok = loop_ms + c.frame_ms >= 400u
+                     && loop_ms <= 400u + c.frame_ms;
+        if (!ok)
+            std::printf("FAIL wall clock: frame_ms=%u -> %u frames = %u ms "
+                        "(expected ~400 ms)\n",
+                        c.frame_ms, frames, loop_ms);
+        s_checks++;
+        if (!ok) s_failures++;
+    }
+}
+
+void TestPlaybackInterpolates()
+{
+    /* 0.4 samples per frame, so most frames land between stored
+     * samples.  Holding instead of interpolating steps audibly. */
+    using Locks = ParamLock<2, LockLength<4, 20>>;
+    FakeButton button;
+    Locks locks(button);
+    locks.Init();
+
+    std::vector<uint8_t> image(Locks::kSavedBytes, 0u);
+    PokeSlot<Locks>(image, 0, true, 0.0f, {0.0f, 1.0f});
+    locks.Restore(image.data());
+
+    const float phys[2] = {};
+    PCHECK_NEAR(locks.Delta(0), 0.0f, 1e-4f);
+
+    /* 0.4, 0.8 — both strictly between the two stored samples. */
+    Frame(locks, phys, 20u);
+    PCHECK_NEAR(locks.Delta(0), 0.4f, 1e-3f);
+    Frame(locks, phys, 20u);
+    PCHECK_NEAR(locks.Delta(0), 0.8f, 1e-3f);
+
+    /* Exactly zero, not 1e-7 — else a motionless lock detunes its knob. */
+    Locks flat(button);
+    flat.Init();
+    std::vector<uint8_t> flat_image(Locks::kSavedBytes, 0u);
+    PokeSlot<Locks>(flat_image, 0, true, 0.375f, {0.375f, 0.375f, 0.375f});
+    flat.Restore(flat_image.data());
+    for (int i = 0; i < 12; i++)
+    {
+        PCHECK(flat.Delta(0) == 0.0f);
+        Frame(flat, phys, 20u);
+    }
+}
+
+void TestRecordingBoxAverages()
+{
+    /* Several frames share one sample.  Point-sampling would make a
+     * one-frame flick vanish or hit full amplitude depending on phase. */
+    using Locks = ParamLock<2, LockLength<4, 10>>;   /* 10 Hz stored */
+    FakeButton button;
+    Locks locks(button);
+    locks.Init();
+
+    /* 20 ms frames, 10 Hz stored: 5 frames per stored sample.  Arm on
+     * frame 0, then a single-frame excursion inside the first sample. */
+    std::vector<float> gesture = {0.9f, 0.5f, 0.5f, 0.5f, 0.5f,
+                                  0.5f, 0.5f, 0.5f, 0.5f, 0.5f};
+    RecordGesture<Locks, 2>(locks, button, 0, gesture, 20u);
+
+    PCHECK(locks.IsActive(0));
+
+    /* The first stored sample averages the 0.9 arm frame with the 0.5
+     * frames sharing its period, landing inside the raw -0.4 excursion. */
+    const float first = locks.Delta(0);
+    PCHECK(first > -0.4f);
+    PCHECK(first < 0.0f);
+    PCHECK_NEAR(first, (0.9f + 4.0f * 0.5f) / 5.0f - 0.9f, 3e-2f);
+}
+
+void TestSlowFrameHoldsLastSample()
+{
+    /* Control frame slower than the stored rate: 6 samples per frame,
+     * one average and five zero-order holds.  The holds must repeat the
+     * last sample — record_base would interleave the arm position into
+     * every gap, a buzz at half the sample rate on playback. */
+    using Locks = ParamLock<2, LockLength<4, 60>>;
+    FakeButton button;
+    Locks locks(button);
+    locks.Init();
+
+    /* Arm at 0.6 (nudge from rest), then hold two frames at 0.9. */
+    RecordGesture<Locks, 2>(locks, button, 0, {0.6f, 0.9f, 0.9f}, 100u);
+    PCHECK(locks.IsActive(0));
+
+    std::vector<uint8_t> out(Locks::kSavedBytes, 0u);
+    locks.Save(out.data());
+
+    ParamLockSavedHeader h;
+    std::memcpy(&h, out.data(), sizeof h);
+    PCHECK_EQ(h.record_base, LockQuant(0.6f));
+    PCHECK(h.length >= 12u);                 /* ~3 frames x 6 samples */
+
+    /* Every sample from the second frame on is 0.9, averages and holds
+     * alike.  The bug put quant(0.6) in the gaps. */
+    for (uint16_t j = 6u; j < h.length; j++)
+    {
+        uint16_t q;
+        std::memcpy(&q, out.data() + sizeof h + j * sizeof q, sizeof q);
+        PCHECK_NEAR(LockDequant(q), 0.9f, 1e-3f);
+    }
+}
+
+void TestShortGestureStillRecords()
+{
+    /* Shorter than one sample period (100 ms at 10 Hz).  Without the
+     * flush in Finalise the slot ends up neither recording nor active. */
+    using Locks = ParamLock<2, LockLength<4, 10>>;
+    FakeButton button;
+    Locks locks(button);
+    locks.Init();
+
+    RecordGesture<Locks, 2>(locks, button, 0, {0.9f, 0.9f}, 20u);
+
+    PCHECK(locks.IsActive(0));
+    PCHECK(!locks.IsRecording(0));
+}
+
+/* ── 5. Serialized byte form ───────────────────────────────────────── */
+
+void TestSerializeRoundTrip()
+{
+    /* The byte stream is a pure function of musical content: same
+     * gesture, same bytes, same slot CRC. */
+    using Locks = ParamLock<4, LockLength<4, 60>>;
+    FakeButton button;
+    Locks locks(button);
+    locks.Init();
+
+    PCHECK_EQ(locks.SerializedSize(), Locks::kSavedBytes);
+
+    std::vector<uint8_t> image(locks.SerializedSize(), 0u);
+    PokeSlot<Locks>(image, 0, true, 0.25f,
+                    {0.01f, 0.02f, 0.03f, 0.04f, 0.05f});
+
+    /* Slot 2 uses the full motion buffer. */
+    std::vector<float> full;
+    full.reserve(Locks::kFramesPerSlot);
+    for (uint32_t j = 0; j < Locks::kFramesPerSlot; j++)
+        full.push_back((j & 1u) ? 0.75f : 0.25f);
+    PokeSlot<Locks>(image, 2, true, 0.5f, full);
+
+    PCHECK(locks.Deserialize(image.data()));
+
+    std::vector<uint8_t> out(locks.SerializedSize(), 0xAAu);
+    locks.Serialize(out.data());
+    PCHECK(out == image);
+
+    /* Inactive slots come back zeroed, not carrying arena residue. */
+    const size_t off = Locks::kBytesPerSavedSlot;
+    for (size_t i = 0; i < Locks::kBytesPerSavedSlot; i++)
+        PCHECK(out[off + i] == 0u);
+}
+
+void TestSerializeRejectsMalformed()
+{
+    using Locks = ParamLock<2, LockLength<4, 60>>;
+    FakeButton button;
+    Locks locks(button);
+    locks.Init();
+
+    std::vector<uint8_t> image(Locks::kSavedBytes, 0u);
+
+    /* A length past the stride — what a longer-configured build would
+     * write, if the schema hash failed to gate it. */
+    ParamLockSavedHeader h;
+    h.active      = 1u;
+    h.length      = static_cast<uint16_t>(Locks::kFramesPerSlot + 1u);
+    h.record_base = LockQuant(0.5f);
+    std::memcpy(image.data(), &h, sizeof h);
+
+    PCHECK(locks.Deserialize(image.data()));
+    PCHECK(!locks.IsActive(0));
+    PCHECK(locks.Delta(0) == 0.0f);
+
+    /* An active-but-empty entry is equally inert. */
+    h.length = 0u;
+    std::memcpy(image.data(), &h, sizeof h);
+    PCHECK(locks.Deserialize(image.data()));
+    PCHECK(!locks.IsActive(0));
+}
+
+void TestAdvanceSplit()
+{
+    /* Playback lives in Advance(), not Update(), so ControlLoop keeps
+     * automation running while Settings suspends the gesture path. */
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    std::vector<uint8_t> image(ExactLocks::kSavedBytes, 0u);
+    PokeSlot<ExactLocks>(image, 0, true, 0.5f, {0.6f, 0.7f, 0.9f});
+    PCHECK(locks.Deserialize(image.data()));
+
+    const float phys[4] = {};
+    PCHECK_NEAR(locks.Delta(0), 0.1f, 1e-3f);
+
+    /* Update() with no pending edges must not move the play head. */
+    locks.Update(phys, 0u);
+    locks.Update(phys, 1u);
+    PCHECK_NEAR(locks.Delta(0), 0.1f, 1e-3f);
+
+    /* Advance() steps the loop — including through the LockSource base,
+     * which is how ControlLoop drives it. */
+    locks.SetFrameMs(kExactFrameMs);
+    locks.Advance();
+    PCHECK_NEAR(locks.Delta(0), 0.2f, 1e-3f);
+    static_cast<LockSource&>(locks).Advance();
+    PCHECK_NEAR(locks.Delta(0), 0.4f, 1e-3f);
+    locks.Advance();
+    PCHECK_NEAR(locks.Delta(0), 0.1f, 1e-3f);   /* wrapped */
+
+    /* Inactive slots are unaffected either way. */
+    PCHECK(locks.Delta(1) == 0.0f);
+}
+
+void TestSchemaHashSeparatesConfigurations()
+{
+    FakeButton button;
+
+    ParamLock<4, LockLength<4, 60>>                     a(button);
+    ParamLock<4, LockLength<4, 60>>                     a2(button);
+    ParamLock<4, LockLength<20, 60>>                    longer(button);
+    ParamLock<4, LockLength<4, 30>>                     slower(button);
+    ParamLock<6, LockLength<4, 60>>                     wider(button);
+    ParamLock<4, LockLength<4, 60, LockStore::RamOnly>> ram(button);
+
+    /* Same shape, same hash. */
+    PCHECK_EQ(a.SchemaHash(), a2.SchemaHash());
+
+    /* Anything that changes the bytes, or their meaning, changes it. */
+    PCHECK(a.SchemaHash() != longer.SchemaHash());
+    PCHECK(a.SchemaHash() != slower.SchemaHash());
+    PCHECK(a.SchemaHash() != wider.SchemaHash());
+    PCHECK(a.SchemaHash() != ram.SchemaHash());
+    PCHECK(longer.SchemaHash() != slower.SchemaHash());
+}
+
+void TestRamOnlyStaysOutOfPresets()
+{
+    using Ram = ParamLock<4, LockLength<30, 60, LockStore::RamOnly>>;
+    FakeButton button;
+    Ram locks(button);
+    locks.Init();
+
+    /* Contributes nothing to a preset slot... */
+    PCHECK_EQ(locks.SerializedSize(), 0u);
+
+    std::vector<uint8_t> guard(16u, 0x5Au);
+    locks.Serialize(guard.data());
+    for (uint8_t b : guard) PCHECK(b == 0x5Au);   /* wrote nothing */
+
+    /* ...but the byte form still works by hand. */
+    std::vector<uint8_t> image(Ram::kSavedBytes, 0u);
+    PokeSlot<Ram>(image, 1, true, 0.5f, {0.6f, 0.7f});
+    locks.Restore(image.data());
+    PCHECK(locks.IsActive(1));
+    PCHECK_NEAR(locks.Delta(1), 0.1f, 1e-3f);
+
+    std::vector<uint8_t> out(Ram::kSavedBytes, 0xAAu);
+    locks.Save(out.data());
+    PCHECK(out == image);
+}
+
+/* ── 6. Externally-placed motion arenas ────────────────────────────── */
+
+/* Past ALCHEMY_LOCK_INLINE_RAM_LIMIT the arena must be supplied by the
+ * application — on target this is where ALCHEMY_SDRAM_BSS goes. */
+using BigLocks = ParamLock<8, LockLength<60, 60, LockStore::RamOnly>>;
+static uint16_t s_big_arena[BigLocks::kArenaSamples];
+
+void TestExternalArena()
+{
+    PCHECK(!BigLocks::kInlineArena);
+    PCHECK(BigLocks::kArenaBytes > ALCHEMY_LOCK_INLINE_RAM_LIMIT);
+
+    /* Only the arena is out of line; the object stays small. */
+    PCHECK(sizeof(BigLocks) < 1024u);
+    PCHECK_EQ(BigLocks::RamBytes(), sizeof(BigLocks) + BigLocks::kArenaBytes);
+
+    FakeButton button;
+    BigLocks locks(button, LockArena{s_big_arena, sizeof s_big_arena});
+    locks.Init();
+    PCHECK(locks.IsReady());
+
+    std::vector<uint8_t> image(BigLocks::kSavedBytes, 0u);
+    PokeSlot<BigLocks>(image, 7, true, 0.2f, {0.3f, 0.4f, 0.5f});
+    locks.Restore(image.data());
+
+    PCHECK(locks.IsActive(7));
+    PCHECK_NEAR(locks.Delta(7), 0.1f, 1e-3f);
+
+    /* Writes landed in the caller's arena, at the right slot's stride. */
+    PCHECK_EQ(s_big_arena[7u * BigLocks::kFramesPerSlot], LockQuant(0.3f));
+}
+
+void TestShortArenaIsRefused()
+{
+    /* A short arena makes the surface inert rather than running off the
+     * end.  Runtime, because the length is the user's number. */
+    static uint16_t small[16];
+    FakeButton button;
+    BigLocks locks(button, LockArena{small, sizeof small});
+
+    PCHECK(!locks.IsReady());
+
+    locks.Init();                       /* must not touch `small` */
+    PCHECK(locks.Delta(0) == 0.0f);
+    PCHECK(!locks.IsActive(0));
+
+    std::vector<uint8_t> image(BigLocks::kSavedBytes, 0u);
+    PokeSlot<BigLocks>(image, 0, true, 0.2f, {0.3f, 0.4f});
+    locks.Restore(image.data());        /* refused, not written */
+    PCHECK(!locks.IsActive(0));
+    for (uint16_t v : small) PCHECK(v == 0u);
+
+    /* An inert surface still owes a full image: headers only would
+     * leave gaps uninitialised, and that buffer is a preset slot. */
+    std::vector<uint8_t> out(BigLocks::kSavedBytes, 0xC3u);
+    locks.Save(out.data());
+    PCHECK(out == std::vector<uint8_t>(BigLocks::kSavedBytes, 0u));
+}
+
+/* ── 7. Paged addressing ───────────────────────────────────────────── */
+
+void TestPagedSlotAddressing()
+{
+    using Locks = ParamLock<12, LockLength<4, 60>>;   /* 2 pages x 6 pots */
+    FakeButton button;
+    Pager pager(button, 2, 6);
+    Locks locks(button, pager);
+    locks.Init();
+
+    /* Distinct content on page 1, pot 2 — flat index 1*6 + 2 = 8. */
+    std::vector<uint8_t> image(Locks::kSavedBytes, 0u);
+    PokeSlot<Locks>(image, 8, true, 0.5f, {0.7f, 0.7f});
+    locks.Restore(image.data());
+
+    PCHECK(locks.IsActiveAtPage(1, 2));
+    PCHECK_NEAR(locks.DeltaAtPage(1, 2), 0.2f, 1e-3f);
+
+    /* Not visible from page 0 — the pager starts there. */
+    PCHECK_EQ(pager.Page(), 0u);
+    PCHECK(!locks.IsActive(2));
+    PCHECK(locks.Delta(2) == 0.0f);
+    PCHECK(!locks.AnyActive());
+
+    /* Inactive-page reads are still available by explicit index, which
+     * is what a composition site uses for off-page parameters. */
+    PCHECK(!locks.IsActiveAtPage(0, 2));
+}
+
+/* ── 8. Preset budgeting ───────────────────────────────────────────── */
+
+struct DummySerializable : Serializable
+{
+    size_t   SerializedSize() const override { return 64u; }
+    void     Serialize(uint8_t* out) const override { std::memset(out, 0, 64u); }
+    bool     Deserialize(const uint8_t*) override { return true; }
+    uint32_t SchemaHash() const override { return 0x1234u; }
+};
+
+void TestPresetBudget()
+{
+    Presets presets{s_dummy_qspi};
+
+    FakeButton button;
+    ParamLock<12, LockLength<30, 20>> locks(button);
+    DummySerializable extra;
+
+    PCHECK_EQ(Presets::Capacity(), kPresetBlobCapacity);
+    PCHECK_EQ(presets.PayloadBytes(), 0u);
+    PCHECK(presets.FitsInSlot());
+
+    presets.Manage(locks);
+    presets.Manage(extra);
+
+    /* Readable at boot, before the first Save returns false. */
+    PCHECK_EQ(presets.PayloadBytes(),
+              decltype(locks)::kPresetBytes + 64u);
+    PCHECK(presets.FitsInSlot());
+    PCHECK(presets.PayloadBytes() <= Presets::Capacity());
+
+    /* Fits, with room left for other components. */
+    PCHECK(decltype(locks)::kPresetBytesFree > 5000u);
+}
+
+} // namespace
+
+int RunParamLockTests(int& checks, int& failures)
+{
+    TestQuantization();
+    TestConfigConstants();
+
+    TestRecordPlaybackRoundTrip();
+    TestDisarmClearsSlot();
+    TestBufferFullAutoArms();
+
+    TestWallClockIndependentOfFrameRate();
+    TestPlaybackInterpolates();
+    TestRecordingBoxAverages();
+    TestSlowFrameHoldsLastSample();
+    TestShortGestureStillRecords();
+
+    TestSerializeRoundTrip();
+    TestSerializeRejectsMalformed();
+    TestAdvanceSplit();
+    TestSchemaHashSeparatesConfigurations();
+    TestRamOnlyStaysOutOfPresets();
+
+    TestExternalArena();
+    TestShortArenaIsRefused();
+    TestPagedSlotAddressing();
+    TestPresetBudget();
+
+    checks   += s_checks;
+    failures += s_failures;
+    return s_failures;
+}

--- a/tests/host/param_lock_tests.h
+++ b/tests/host/param_lock_tests.h
@@ -1,0 +1,10 @@
+/**
+ * @file tests/host/param_lock_tests.h
+ * @brief ParamLock / ParamLockManager test battery.
+ */
+
+#pragma once
+
+/** Run the looping-automation tests (record, playback, sample clock,
+ *  serialization, preset budgeting).  Adds to the caller's totals. */
+int RunParamLockTests(int& checks, int& failures);


### PR DESCRIPTION
Parameter lock length is now a compile-time policy rather than a fixed 256-frame buffer.

```cpp
ParamLock<6>                      locks(b);         // 16 s (default)
ParamLock<6,  LockLength<20>>     locks(b);         // 20 s
ParamLock<12, LockLength<30, 20>> locks(b, pager);  // 30 s at 20 Hz
```

`LockLength<seconds, rate_hz = 30, store = Preset>` drives both budgets.

## Default change

The default is **16 s at 30 Hz**, sized to spend exactly the RAM the old fixed 256-float buffer used — 960 B/slot vs 1024 B. An unchanged firmware gets 4x the length for the RAM it was already paying.

To keep the old behaviour: `ParamLock<6, LockLength<4, 60>>`.

**Existing preset slots read as empty after this lands.** `SchemaHash()` folds in slot count, length, rate and storage policy, so a reconfigured build sees old slots as absent.

## Why the representation changed

30 s x 12 slots of `float` is 86 KB against a preset slot that holds 20,448 B and cannot grow — the preset region is already the top 640 KiB of the QSPI chip. Longer locks were not reachable without a denser payload:

- **uint16 samples.** Pot positions come from a 16-bit ADC, so a 1/65535 grid is finer than the signal and 3x finer than `kCatchTolerance`. Float was doubling both budgets to store noise.
- **Stored rate decoupled from the frame rate.** Recording box-averages, playback interpolates. A hand gesture carries nothing above ~8 Hz.

Together these make 20-30 s configurations fit; see the table in `docs/param-locks.md`.

## Fixes carried along

- **Seconds now mean seconds.** The buffer is clocked in milliseconds, not frames. Previously "4 seconds" meant "256 frames", so changing `ControlLoop::FrameMs` silently rescaled every lock and replayed recordings at the wrong speed.
- **Playback position is one aligned `uint32` (Q16.16)** published in a single store, and `active` is written last on every slot transition. The audio-side `Read()` can no longer observe a torn slot — previously a preset load could be heard interpolating over stale buffer contents.

## Structure

`ParamLockSlot` is now a small header; motion samples live in a flat arena addressed by stride. That keeps `ParamLockManager` a non-template `.cpp` (one copy of the algorithm regardless of configuration) and lets an application place a large arena outside DTCM.
