### PR TITLE
USB composite: class-compliant MIDI alongside HostLink CDC

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -105,6 +105,48 @@ endif()
 
 endif()
 
+# ── alchemy::usb (firmware — cross-compile only) ───────────────────────────
+
+if(CMAKE_CROSSCOMPILING)
+
+add_library(alchemy_usb STATIC
+    src/usb/usb_descriptors.c
+    src/usb/usb_composite.c
+    src/usb/usb_device.c
+)
+add_library(alchemy::usb ALIAS alchemy_usb)
+
+target_include_directories(alchemy_usb PUBLIC
+    "${FRAMEWORK_INCLUDE}"
+)
+target_link_libraries(alchemy_usb PUBLIC daisy)
+
+# See __wrap_USBD_StdItfReq in usb_composite.c; the wrapper fails the
+# link if this flag is lost.
+target_link_options(alchemy_usb INTERFACE "LINKER:--wrap=USBD_StdItfReq")
+
+endif()
+
+# ── alchemy::midi (firmware — cross-compile only) ──────────────────────────
+# USB-MIDI service + mono note tracker.
+
+if(CMAKE_CROSSCOMPILING)
+
+add_library(alchemy_midi STATIC
+    src/midi/usb_midi.cpp
+    src/midi/mono_note_tracker.cpp
+    src/midi/poly_note_allocator.cpp
+)
+add_library(alchemy::midi ALIAS alchemy_midi)
+
+target_include_directories(alchemy_midi PUBLIC
+    "${FRAMEWORK_INCLUDE}"
+    "${HW_INCLUDE}"
+)
+target_link_libraries(alchemy_midi PUBLIC alchemy::usb daisy)
+
+endif()
+
 # ── alchemy::host_link (firmware — cross-compile only) ────────────────────
 # Links alchemy::surface, so it exists only where surface does; host
 # builds are board-free and exercise the protocol sources directly.
@@ -125,7 +167,7 @@ target_include_directories(alchemy_host_link PUBLIC
     "${FRAMEWORK_INCLUDE}"
     "${HW_INCLUDE}"
 )
-target_link_libraries(alchemy_host_link PUBLIC alchemy::surface)
+target_link_libraries(alchemy_host_link PUBLIC alchemy::surface alchemy::usb)
 
 endif()
 

--- a/framework/include/alchemy/host_link/cdc_transport.h
+++ b/framework/include/alchemy/host_link/cdc_transport.h
@@ -55,12 +55,11 @@ class CdcUsbTransport : public IHostTransport
      * must pass FS_EXTERNAL.  V1 boards expose the onboard port:
      * FS_INTERNAL.
      *
-     * @p product_name, when non-null, replaces the USB product string
-     * ("Daisy Seed …") the OS and browser port-picker display — e.g.
-     * "Alchemy Lab".  Implemented by repointing the ST descriptor
-     * table's GetProductStrDescriptor callback before the peripheral
-     * initializes; stock libDaisy is untouched.  The pointer must stay
-     * valid for the lifetime of the link (pass a string literal).
+     * @p product_name, when non-null, sets the USB product string the
+     * OS, the browser port-picker and DAW MIDI lists display — e.g.
+     * "Alchemy Lab".  Carried by the composite device's own descriptor
+     * table (alchemy/usb).  The pointer must stay valid for the
+     * lifetime of the link (pass a string literal).
      */
     void Init(daisy::UsbHandle& usb,
               daisy::UsbHandle::UsbPeriph periph

--- a/framework/include/alchemy/host_link/descriptor.h
+++ b/framework/include/alchemy/host_link/descriptor.h
@@ -132,9 +132,13 @@ class DescriptorBuilder
     bool BeginSettings(const char* id, const Settings& settings,
                        const char* const* page_names  = nullptr,
                        const char* const* page_colors = nullptr);
+    /** @p labels (Selector only): zone names for the enum disp, emitted
+     *  when @p disp_json is null and @p num_labels matches the zones. */
     bool SettingsField(uint8_t page, uint8_t pot,
                        const char* field_id, const char* name,
-                       const char* disp_json);
+                       const char* disp_json,
+                       const char* const* labels = nullptr,
+                       uint8_t num_labels        = 0u);
     bool EndSettings();
 
     /* ── Buttons (top-level, optional) ──────────────────────────────

--- a/framework/include/alchemy/midi/midi_event.h
+++ b/framework/include/alchemy/midi/midi_event.h
@@ -1,0 +1,162 @@
+/**
+ * @file alchemy/midi/midi_event.h
+ * @brief MIDI event type + USB-MIDI 1.0 event-packet codec.  Pure,
+ *        host-tested; USB framing delimits messages per packet, so no
+ *        running-status handling exists here.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace alchemy {
+namespace midi {
+
+enum class MidiMsg : uint8_t
+{
+    NoteOff         = 0x80,
+    NoteOn          = 0x90,
+    PolyPressure    = 0xA0,
+    ControlChange   = 0xB0,
+    ProgramChange   = 0xC0,
+    ChannelPressure = 0xD0,
+    PitchBend       = 0xE0,
+    SongPosition    = 0xF2,
+    SongSelect      = 0xF3,
+    TuneRequest     = 0xF6,
+    Clock           = 0xF8,
+    Start           = 0xFA,
+    Continue        = 0xFB,
+    Stop            = 0xFC,
+    ActiveSensing   = 0xFE,
+    SystemReset     = 0xFF,
+};
+
+struct MidiEvent
+{
+    uint8_t status = 0u;
+    uint8_t d1     = 0u;
+    uint8_t d2     = 0u;
+
+    bool IsChannelVoice() const
+    {
+        return status >= 0x80u && status < 0xF0u;
+    }
+    uint8_t Channel() const { return status & 0x0Fu; }
+    MidiMsg Type() const
+    {
+        return static_cast<MidiMsg>(IsChannelVoice() ? (status & 0xF0u)
+                                                     : status);
+    }
+    /** 14-bit pitch bend, 0x2000 = center. */
+    uint16_t Bend14() const
+    {
+        return static_cast<uint16_t>(d1 | (static_cast<uint16_t>(d2) << 7));
+    }
+
+    static MidiEvent Make(MidiMsg m, uint8_t ch, uint8_t d1, uint8_t d2 = 0u)
+    {
+        MidiEvent e;
+        const uint8_t s = static_cast<uint8_t>(m);
+        e.status = (s < 0xF0u) ? static_cast<uint8_t>(s | (ch & 0x0Fu)) : s;
+        e.d1     = d1 & 0x7Fu;
+        e.d2     = d2 & 0x7Fu;
+        return e;
+    }
+};
+
+/** Decodes one event packet.  False for packets with no event
+ *  semantics here: reserved CINs and SysEx spans (discarded). */
+inline bool EventFromUsbPacket(const uint8_t pkt[4], MidiEvent& out)
+{
+    const uint8_t cin = pkt[0] & 0x0Fu;
+    switch (cin)
+    {
+        case 0x2u: /* 2-byte system common (F1, F3) */
+        case 0xCu: /* program change */
+        case 0xDu: /* channel pressure */
+            out.status = pkt[1];
+            out.d1     = pkt[2];
+            out.d2     = 0u;
+            return true;
+
+        case 0x3u: /* 3-byte system common (F2) */
+        case 0x8u:
+        case 0x9u:
+        case 0xAu:
+        case 0xBu:
+        case 0xEu:
+            out.status = pkt[1];
+            out.d1     = pkt[2];
+            out.d2     = pkt[3];
+            return true;
+
+        case 0x5u: /* 1-byte system common — or 1-byte SysEx end */
+            if (pkt[1] == 0xF6u)
+            {
+                out = {0xF6u, 0u, 0u};
+                return true;
+            }
+            return false;
+
+        case 0xFu: /* single byte (realtime) */
+            if (pkt[1] >= 0xF8u)
+            {
+                out = {pkt[1], 0u, 0u};
+                return true;
+            }
+            return false;
+
+        default: /* 0x0, 0x1, 0x4, 0x6, 0x7 */
+            return false;
+    }
+}
+
+/** Encodes an event as a packet; false if it has no packet form. */
+inline bool EventToUsbPacket(const MidiEvent& ev, uint8_t cable,
+                             uint8_t pkt[4])
+{
+    uint8_t cin;
+    uint8_t n = 3u;
+
+    if (ev.status >= 0xF8u)
+    {
+        cin = 0xFu;
+        n   = 1u;
+    }
+    else if (ev.status == 0xF2u)
+    {
+        cin = 0x3u;
+    }
+    else if (ev.status == 0xF1u || ev.status == 0xF3u)
+    {
+        cin = 0x2u;
+        n   = 2u;
+    }
+    else if (ev.status == 0xF6u)
+    {
+        cin = 0x5u;
+        n   = 1u;
+    }
+    else if (ev.status >= 0x80u && ev.status < 0xF0u)
+    {
+        cin = ev.status >> 4;
+        if (cin == 0xCu || cin == 0xDu)
+        {
+            n = 2u;
+        }
+    }
+    else
+    {
+        return false;
+    }
+
+    pkt[0] = static_cast<uint8_t>((cable << 4) | cin);
+    pkt[1] = ev.status;
+    pkt[2] = (n >= 2u) ? ev.d1 : 0u;
+    pkt[3] = (n >= 3u) ? ev.d2 : 0u;
+    return true;
+}
+
+} // namespace midi
+} // namespace alchemy

--- a/framework/include/alchemy/midi/mono_note_tracker.h
+++ b/framework/include/alchemy/midi/mono_note_tracker.h
@@ -1,0 +1,84 @@
+/**
+ * @file alchemy/midi/mono_note_tracker.h
+ * @brief Held-note stack → one (gate, note, velocity) for mono voices.
+ *        After the last release, Note()/Velocity() hold their final
+ *        values so release tails keep pitch.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace alchemy {
+namespace midi {
+
+class MonoNoteTracker
+{
+  public:
+    static constexpr uint8_t kCapacity = 16u;
+
+    enum class Priority : uint8_t
+    {
+        Last = 0,
+        Low  = 1,
+        High = 2,
+    };
+
+    MonoNoteTracker& SetPriority(Priority p)
+    {
+        prio_ = p;
+        return *this;
+    }
+
+    /** Retrigger when a release re-selects an older held note
+     *  (default off: releasing back to a held note is legato). */
+    MonoNoteTracker& RetrigOnReturn(bool on)
+    {
+        retrig_on_return_ = on;
+        return *this;
+    }
+
+    void NoteOn(uint8_t note, uint8_t velocity);
+    void NoteOff(uint8_t note);
+    void SetSustain(bool on);
+    void Clear();
+
+    bool SustainActive() const { return sustain_; }
+
+    bool    GateHigh() const { return n_ > 0u; }
+    uint8_t Note() const { return cur_note_; }
+    uint8_t Velocity() const { return cur_vel_; }
+    uint8_t HeldCount() const { return n_; }
+
+    /** One-shot: true once per (re)trigger edge. */
+    bool TakeRetrigger()
+    {
+        const bool r = retrig_;
+        retrig_      = false;
+        return r;
+    }
+
+  private:
+    struct Held
+    {
+        uint8_t note;
+        uint8_t vel;
+        bool    sustained;
+    };
+
+    uint8_t SelectIndex() const;
+    void    Remove(uint8_t idx);
+    void    Reselect();
+
+    Held     held_[kCapacity] = {};
+    uint8_t  n_               = 0u;
+    Priority prio_            = Priority::Last;
+    bool     retrig_on_return_ = false;
+    bool     retrig_           = false;
+    bool     sustain_          = false;
+    uint8_t  cur_note_         = 60u;
+    uint8_t  cur_vel_          = 0u;
+};
+
+} // namespace midi
+} // namespace alchemy

--- a/framework/include/alchemy/midi/poly_note_allocator.h
+++ b/framework/include/alchemy/midi/poly_note_allocator.h
@@ -1,0 +1,79 @@
+/**
+ * @file alchemy/midi/poly_note_allocator.h
+ * @brief N-voice note allocation for polyphonic firmware: voice
+ *        stealing, sustain, per-voice retrigger.  Notes are keyed
+ *        (channel, note), so an omni feed from member channels (MPE)
+ *        allocates correctly; per-voice expression is read from the
+ *        UsbMidi per-channel caches via Voice::channel.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace alchemy {
+namespace midi {
+
+class PolyNoteAllocator
+{
+  public:
+    static constexpr uint8_t kMaxVoices = 16u;
+
+    enum class Steal : uint8_t
+    {
+        None    = 0, /* drop new notes when full     */
+        Oldest  = 1,
+        Lowest  = 2,
+        Highest = 3,
+    };
+
+    struct Voice
+    {
+        uint8_t note     = 60u;
+        uint8_t velocity = 0u;
+        uint8_t channel  = 0u;
+        bool    gate     = false;
+    };
+
+    PolyNoteAllocator& SetVoiceCount(uint8_t n);
+    PolyNoteAllocator& SetSteal(Steal s)
+    {
+        steal_ = s;
+        return *this;
+    }
+
+    void NoteOn(uint8_t channel, uint8_t note, uint8_t velocity);
+    void NoteOff(uint8_t channel, uint8_t note);
+    void SetSustain(bool on);
+    void Clear();
+
+    uint8_t      VoiceCount() const { return num_voices_; }
+    const Voice& VoiceAt(uint8_t i) const { return voices_[i]; }
+    bool         SustainActive() const { return sustain_; }
+    uint8_t      GatedCount() const;
+
+    /** One-shot per voice: true once per (re)trigger. */
+    bool TakeRetrigger(uint8_t i)
+    {
+        const bool r = retrig_[i];
+        retrig_[i]   = false;
+        return r;
+    }
+
+  private:
+    uint8_t FindGated(uint8_t channel, uint8_t note) const;
+    uint8_t PickVoice();
+
+    Voice    voices_[kMaxVoices];
+    bool     retrig_[kMaxVoices]    = {};
+    bool     sustained_[kMaxVoices] = {};
+    uint32_t on_order_[kMaxVoices]  = {};
+    uint32_t off_order_[kMaxVoices] = {};
+    uint32_t counter_               = 0u;
+    uint8_t  num_voices_            = kMaxVoices;
+    Steal    steal_                 = Steal::Oldest;
+    bool     sustain_               = false;
+};
+
+} // namespace midi
+} // namespace alchemy

--- a/framework/include/alchemy/midi/usb_midi.h
+++ b/framework/include/alchemy/midi/usb_midi.h
@@ -1,0 +1,273 @@
+/**
+ * @file alchemy/midi/usb_midi.h
+ * @brief USB-MIDI service over the composite device.  Target-only.
+ *
+ * RX: endpoint IRQ → SPSC ring → Poll() (~1 ms, from the firmware's
+ * OnPoll hook) → channel filter → consumers.  TX: Send*() queue,
+ * Poll() drains.  With hostlink::Host present USB is already started;
+ * otherwise call Start() once after Init().
+ *
+ * NoteOn velocity 0 dispatches as NoteOff.  CC 64 drives sustain and
+ * CC 120/123 clear on the attached tracker/allocator.  Pitch bend,
+ * channel pressure and CC 74 are cached per channel (the MPE per-note
+ * dimensions — an MPE consumer runs omni with the allocator and reads
+ * them via Voice::channel).  RPN 0 sets the bend range until the bound
+ * setting is next moved.  SysEx is delivered to OnSysEx when hooked,
+ * discarded otherwise; either way the stream stays aligned.  Active
+ * sensing is ignored.  Cable pull / suspend clears note state.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "alchemy/midi/midi_event.h"
+#include "alchemy/midi/mono_note_tracker.h"
+#include "alchemy/midi/poly_note_allocator.h"
+#include "alchemy/surface/settings_control.h"
+#include "alchemy/usb/usb_device.h"
+
+namespace alchemy {
+namespace midi {
+
+class UsbMidi
+{
+  public:
+    static constexpr uint8_t kOmni = 0xFFu;
+
+    using EventFn = void (*)(const MidiEvent& ev, void* ctx);
+    using ClockFn = void (*)(uint32_t stamp_us, void* ctx);
+    using SysExFn = void (*)(const uint8_t* data, uint8_t len, bool terminal,
+                             void* ctx);
+    using RpnFn   = void (*)(uint8_t channel, uint16_t param, uint16_t value14,
+                           bool is_nrpn, void* ctx);
+
+    /** Registers the RX hook.  One instance per system. */
+    void Init();
+
+    /** Starts USB for firmware without hostlink::Host (first caller
+     *  wins). */
+    void Start(const char* product_name = nullptr,
+               AlchemyUsbPeriph periph =
+#if defined(ALCHEMY_BOARD_V2)
+                   ALCHEMY_USB_PERIPH_HS
+#else
+                   ALCHEMY_USB_PERIPH_FS
+#endif
+    );
+
+    UsbMidi& SetChannel(uint8_t ch_0_15)
+    {
+        channel_ = (ch_0_15 > 15u) ? kOmni : ch_0_15;
+        return *this;
+    }
+    UsbMidi& SetOmni()
+    {
+        channel_ = kOmni;
+        return *this;
+    }
+    uint8_t Channel() const { return channel_; }
+
+    UsbMidi& UseTracker(MonoNoteTracker& t)
+    {
+        tracker_ = &t;
+        return *this;
+    }
+    UsbMidi& UseAllocator(PolyNoteAllocator& a)
+    {
+        allocator_ = &a;
+        return *this;
+    }
+
+    /* ── Settings recipes ───────────────────────────────────────────
+     * Declare a Selector with the matching zone count, hand the handle
+     * over: the recipe names + labels the field for the web editor and
+     * live-binds the value (applied each Poll, persists with presets). */
+
+    static constexpr uint8_t kChannelZones   = 17u; /* Omni + 1..16   */
+    static constexpr uint8_t kBendRangeZones = 5u;  /* 0/1/2/7/12 st  */
+    static constexpr uint8_t kPriorityZones  = 3u;  /* Last/Low/High  */
+
+    static const char* const kChannelLabels[kChannelZones];
+    static const char* const kBendRangeLabels[kBendRangeZones];
+    static const char* const kPriorityLabels[kPriorityZones];
+    static const float       kBendRangeSemis[kBendRangeZones];
+    /* Convention for a firmware-owned velocity-mode Selector(3). */
+    static const char* const kVelocityModeLabels[3];
+
+    UsbMidi& UseChannelSetting(SelectorHandle h);
+    UsbMidi& UseBendRangeSetting(SelectorHandle h);
+    UsbMidi& UsePrioritySetting(SelectorHandle h);
+
+    UsbMidi& OnEvent(EventFn fn, void* ctx)
+    {
+        event_ctx_ = ctx;
+        event_fn_  = fn;
+        return *this;
+    }
+
+    /** 0xF8 only, IRQ context — keep it to a couple of word stores
+     *  (ClockFollower::OnPulse qualifies). */
+    UsbMidi& OnClockPulse(ClockFn fn, void* ctx)
+    {
+        clock_ctx_ = ctx;
+        clock_fn_  = fn;
+        return *this;
+    }
+
+    /** Raw SysEx bytes (F0..F7 inclusive) as they arrive, ≤3 per call;
+     *  terminal marks the packet carrying the end. */
+    UsbMidi& OnSysEx(SysExFn fn, void* ctx)
+    {
+        sysex_ctx_ = ctx;
+        sysex_fn_  = fn;
+        return *this;
+    }
+
+    /** Decoded (N)RPN data entry, per channel. */
+    UsbMidi& OnRpn(RpnFn fn, void* ctx)
+    {
+        rpn_ctx_ = ctx;
+        rpn_fn_  = fn;
+        return *this;
+    }
+
+    void Poll(uint32_t t_ms);
+
+    /* ── TX ─────────────────────────────────────────────────────────── */
+
+    void Send(const MidiEvent& ev);
+    void SendNoteOn(uint8_t ch, uint8_t note, uint8_t vel)
+    {
+        Send(MidiEvent::Make(MidiMsg::NoteOn, ch, note, vel));
+    }
+    void SendNoteOff(uint8_t ch, uint8_t note)
+    {
+        Send(MidiEvent::Make(MidiMsg::NoteOff, ch, note, 0x40u));
+    }
+    void SendControlChange(uint8_t ch, uint8_t cc, uint8_t val)
+    {
+        Send(MidiEvent::Make(MidiMsg::ControlChange, ch, cc, val));
+    }
+    void SendProgramChange(uint8_t ch, uint8_t program)
+    {
+        Send(MidiEvent::Make(MidiMsg::ProgramChange, ch, program));
+    }
+    void SendChannelPressure(uint8_t ch, uint8_t value)
+    {
+        Send(MidiEvent::Make(MidiMsg::ChannelPressure, ch, value));
+    }
+    void SendPitchBend(uint8_t ch, uint16_t bend14)
+    {
+        Send(MidiEvent::Make(MidiMsg::PitchBend, ch,
+                             static_cast<uint8_t>(bend14 & 0x7Fu),
+                             static_cast<uint8_t>((bend14 >> 7) & 0x7Fu)));
+    }
+    /** Clock / Start / Continue / Stop / SystemReset. */
+    void SendRealtime(MidiMsg m)
+    {
+        MidiEvent ev;
+        ev.status = static_cast<uint8_t>(m);
+        Send(ev);
+    }
+    /** Queues F0 + payload + F7.  False (and counted) if the queue
+     *  can't take the whole message now. */
+    bool SendSysEx(const uint8_t* payload, uint16_t len);
+
+    /* ── State ──────────────────────────────────────────────────────── */
+
+    /** Last accepted pitch bend; 0x2000 center. */
+    uint16_t PitchBend14() const { return bend14_; }
+    uint16_t PitchBend14(uint8_t ch) const { return bend14_ch_[ch & 0x0Fu]; }
+    float    BendSemis(float range_semis) const
+    {
+        return BendVal(bend14_, range_semis);
+    }
+    /** Semitones at the effective bend range (bound setting, or RPN 0
+     *  when a host has sent one; ±2 default). */
+    float BendSemis() const { return BendVal(bend14_, bend_range_semis_); }
+    float BendSemis(uint8_t ch) const
+    {
+        return BendVal(bend14_ch_[ch & 0x0Fu], bend_range_semis_);
+    }
+    float   BendRangeSemis() const { return bend_range_semis_; }
+    uint8_t ChannelPressure(uint8_t ch) const
+    {
+        return pressure_[ch & 0x0Fu];
+    }
+    /** CC 74 (MPE timbre / brightness), per channel. */
+    uint8_t Cc74(uint8_t ch) const { return cc74_[ch & 0x0Fu]; }
+
+    bool HostConnected() const { return alchemy_usb_configured(); }
+
+    uint32_t RxDropped() const { return rx_dropped_; }
+    uint32_t TxDropped() const { return tx_dropped_; }
+    uint32_t ClockCount() const { return clock_count_; }
+
+  private:
+    static constexpr uint16_t kRxRing = 256u; /* packets (pow-2) */
+    static constexpr uint16_t kTxRing = 256u; /* packets (pow-2) */
+
+    static void  RxTrampoline(const uint8_t pkt[4], void* ctx);
+    void         OnRxPacket(const uint8_t pkt[4]);
+    void         Dispatch(const MidiEvent& ev);
+    void         HandleCc(uint8_t ch, uint8_t cc, uint8_t val);
+    void         HandleSysExPacket(const uint8_t pkt[4]);
+    void         PushPacket(const uint8_t pkt[4]);
+    uint16_t     TxFree() const;
+    void         DrainTx();
+    void         ResetChannelState();
+    static float BendVal(uint16_t b14, float range)
+    {
+        return (static_cast<float>(b14) - 8192.0f) * (1.0f / 8192.0f) * range;
+    }
+
+    static UsbMidi* s_instance;
+
+    uint8_t           rx_[kRxRing][4];
+    volatile uint16_t rx_w_ = 0u; /* IRQ writes  */
+    uint16_t          rx_r_ = 0u; /* Poll reads  */
+
+    uint8_t  tx_[kTxRing][4];
+    uint16_t tx_w_ = 0u;
+    uint16_t tx_r_ = 0u;
+
+    MonoNoteTracker*   tracker_   = nullptr;
+    PolyNoteAllocator* allocator_ = nullptr;
+
+    EventFn event_fn_  = nullptr;
+    void*   event_ctx_ = nullptr;
+    ClockFn clock_fn_  = nullptr;
+    void*   clock_ctx_ = nullptr;
+    SysExFn sysex_fn_  = nullptr;
+    void*   sysex_ctx_ = nullptr;
+    RpnFn   rpn_fn_    = nullptr;
+    void*   rpn_ctx_   = nullptr;
+
+    uint8_t  channel_    = kOmni;
+    bool     was_online_ = false;
+    uint32_t rx_dropped_ = 0u;
+    uint32_t tx_dropped_ = 0u;
+    volatile uint32_t clock_count_ = 0u;
+
+    uint16_t bend14_       = 0x2000u;
+    uint16_t bend14_ch_[16];
+    uint8_t  pressure_[16] = {};
+    uint8_t  cc74_[16]     = {};
+
+    /* (N)RPN state machine, per channel.  mode: 0 none / 1 RPN / 2 NRPN. */
+    uint8_t rpn_mode_[16] = {};
+    uint8_t param_msb_[16] = {};
+    uint8_t param_lsb_[16] = {};
+    uint8_t data_msb_[16]  = {};
+
+    /* Live-bound setting zones (Settings-owned storage). */
+    const uint8_t* channel_zone_     = nullptr;
+    const uint8_t* bend_zone_        = nullptr;
+    const uint8_t* priority_zone_    = nullptr;
+    uint8_t        last_bend_zone_   = 0xFFu;
+    float          bend_range_semis_ = 2.0f;
+};
+
+} // namespace midi
+} // namespace alchemy

--- a/framework/include/alchemy/surface/settings.h
+++ b/framework/include/alchemy/surface/settings.h
@@ -169,6 +169,8 @@ class Settings : public Serializable
 
     /** Control kind at (page, pot); None when out of range. */
     SettingsKind KindAt(uint8_t page, uint8_t pot) const;
+    const char* NameAt(uint8_t page, uint8_t pot) const;
+    const char* const* ZoneLabelsAt(uint8_t page, uint8_t pot) const;
 
     /** Selector zone count at (page, pot); 0 for non-selectors. */
     uint8_t ZonesAt(uint8_t page, uint8_t pot) const;

--- a/framework/include/alchemy/surface/settings_control.h
+++ b/framework/include/alchemy/surface/settings_control.h
@@ -60,6 +60,9 @@ struct SettingsSlot
 {
     SettingsKind kind = SettingsKind::None;
 
+    const char*        name        = nullptr;
+    const char* const* zone_labels = nullptr;
+
     /* Catch state — common to every kind that maps a pot to a value. */
     PotState pot = {};
 
@@ -142,6 +145,8 @@ class KnobHandle
     KnobHandle() = default;
     explicit KnobHandle(SettingsSlot* s) : s_(s) {}
 
+    KnobHandle& Name(const char* n)
+    { if (s_) s_->name = n; return *this; }
     KnobHandle& Default(float v)
     { if (!s_) return *this; s_->value = v; s_->pot.stored = v; return *this; }
     KnobHandle& Color  (LedPanel::Rgb c)
@@ -168,6 +173,8 @@ class BipolarHandle
     BipolarHandle() = default;
     explicit BipolarHandle(SettingsSlot* s) : s_(s) {}
 
+    BipolarHandle& Name(const char* n)
+    { if (s_) s_->name = n; return *this; }
     BipolarHandle& Default    (float v) /* -1..+1 */
     {
         if (!s_) return *this;
@@ -219,6 +226,10 @@ class SelectorHandle
         s_->pot.stored = IdxToPot(idx);
         return *this;
     }
+    SelectorHandle& Name(const char* n)
+    { if (s_) s_->name = n; return *this; }
+    SelectorHandle& Labels(const char* const* labels, uint8_t n)
+    { if (s_ && n == s_->num_zones) s_->zone_labels = labels; return *this; }
     SelectorHandle& Colors        (const LedPanel::Rgb* palette)
     { if (!s_) return *this; s_->zone_colors    = palette; return *this; }
     SelectorHandle& InactiveColor (LedPanel::Rgb c)

--- a/framework/include/alchemy/usb/usb_descriptors.h
+++ b/framework/include/alchemy/usb/usb_descriptors.h
@@ -1,0 +1,48 @@
+/**
+ * @file alchemy/usb/usb_descriptors.h
+ * @brief Fixed descriptor set for the composite device (CDC + MIDI).
+ *
+ * Pure data — host tests pin these bytes.  The shape is platform-fixed;
+ * any change to it is host-visible and must bump ALCHEMY_USB_BCD_DEVICE
+ * so cached hosts re-read.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* 0x0483:0x5740 is the libDaisy CDC identity shipped firmware already
+ * enumerates with; a dedicated PID lands here when assigned. */
+#define ALCHEMY_USB_VID 0x0483u
+#define ALCHEMY_USB_PID 0x5740u
+
+/* 0x0200 was the CDC-only shape; 0x0210 is the composite shape. */
+#define ALCHEMY_USB_BCD_DEVICE 0x0210u
+
+#define ALCHEMY_CDC_CMD_EP 0x82u
+#define ALCHEMY_CDC_OUT_EP 0x01u
+#define ALCHEMY_CDC_IN_EP 0x81u
+#define ALCHEMY_MIDI_OUT_EP 0x02u
+#define ALCHEMY_MIDI_IN_EP 0x83u
+
+#define ALCHEMY_USB_NUM_INTERFACES 4u
+#define ALCHEMY_USB_CFG_DESC_SIZE 175u
+#define ALCHEMY_USB_DEV_DESC_SIZE 18u
+#define ALCHEMY_USB_QUALIFIER_DESC_SIZE 10u
+
+#define ALCHEMY_MIDI_EP_PACKET_SIZE 64u
+
+extern const uint8_t alchemy_usb_dev_desc[ALCHEMY_USB_DEV_DESC_SIZE];
+/* Not const: the ST core stamps bDescriptorType into the served buffer
+ * (usbd_ctlreq.c GET_DESCRIPTOR), so this must live in RAM. */
+extern uint8_t alchemy_usb_cfg_desc[ALCHEMY_USB_CFG_DESC_SIZE];
+extern const uint8_t
+    alchemy_usb_qualifier_desc[ALCHEMY_USB_QUALIFIER_DESC_SIZE];
+
+#ifdef __cplusplus
+}
+#endif

--- a/framework/include/alchemy/usb/usb_device.h
+++ b/framework/include/alchemy/usb/usb_device.h
@@ -1,0 +1,50 @@
+/**
+ * @file alchemy/usb/usb_device.h
+ * @brief Composite USB device (CDC HostLink + class-compliant MIDI).
+ *        Target-only.
+ *
+ * The CDC function behaves exactly like the shipped single-class device
+ * (same endpoints and usbd_cdc_if plumbing).  MIDI RX delivers 4-byte
+ * event packets in USB IRQ context — copy out and return.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "alchemy/usb/usb_descriptors.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum
+{
+    ALCHEMY_USB_PERIPH_FS = 0, /* Seed onboard connector (V1)           */
+    ALCHEMY_USB_PERIPH_HS = 1, /* Seed external pins → panel USB-C (V2) */
+} AlchemyUsbPeriph;
+
+typedef void (*AlchemyUsbMidiRxFn)(const uint8_t packet[4], void* ctx);
+
+/** Idempotent; the first caller's arguments win.  @p product_name must
+ *  outlive the device (string literal); NULL keeps the default. */
+void alchemy_usb_start(AlchemyUsbPeriph periph, const char* product_name);
+
+/** True while the host has the device configured.  Falls false on
+ *  suspend, reset and detach — poll it to catch cable pulls, which need
+ *  not produce any other event with VBUS sense off. */
+bool alchemy_usb_configured(void);
+
+void alchemy_usb_midi_set_rx(AlchemyUsbMidiRxFn fn, void* ctx);
+
+bool alchemy_usb_midi_tx_ready(void);
+
+/** Queues one bulk-IN burst of whole 4-byte packets (len ≤ 64, len % 4
+ *  == 0).  Returns bytes accepted: all of @p len, or 0 when busy /
+ *  unconfigured / bad length.  Single caller. */
+uint16_t alchemy_usb_midi_write(const uint8_t* packets, uint16_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/framework/src/host_link/cdc_transport.cpp
+++ b/framework/src/host_link/cdc_transport.cpp
@@ -7,30 +7,10 @@
 
 #include <cstring>
 
-#include "usbd_def.h"     /* USBD_DescriptorsTypeDef                  */
-#include "usbd_desc.h"    /* FS_Desc / HS_Desc descriptor tables      */
-#include "usbd_ctlreq.h"  /* USBD_GetString                           */
+#include "alchemy/usb/usb_device.h"
 
 namespace alchemy {
 namespace hostlink {
-
-namespace {
-
-/* Runtime product-string override: the ST USB core fetches the product
- * string through a function pointer in FS_Desc/HS_Desc — repointing it
- * before USBD_Init renames the device without touching libDaisy. */
-const char* s_product_name = nullptr;
-uint8_t     s_product_desc[2u + 2u * 48u];   /* UTF-16 string descriptor */
-
-uint8_t* ProductStrOverride(USBD_SpeedTypeDef /*speed*/, uint16_t* length)
-{
-    USBD_GetString(
-        reinterpret_cast<uint8_t*>(const_cast<char*>(s_product_name)),
-        s_product_desc, length);
-    return s_product_desc;
-}
-
-} // namespace
 
 CdcUsbTransport* CdcUsbTransport::s_instance = nullptr;
 
@@ -42,15 +22,13 @@ void CdcUsbTransport::Init(daisy::UsbHandle& usb,
     periph_    = periph;
     s_instance = this;
 
-    if (product_name != nullptr)
-    {
-        s_product_name = product_name;
-        USBD_DescriptorsTypeDef& desc =
-            (periph == daisy::UsbHandle::FS_INTERNAL) ? FS_Desc : HS_Desc;
-        desc.GetProductStrDescriptor = &ProductStrOverride;
-    }
-
-    usb.Init(periph);
+    /* Composite bring-up replaces UsbHandle::Init; the CDC function
+     * delegates to the same handlers, so the UsbHandle transmit path
+     * and receive callback below are unchanged. */
+    alchemy_usb_start(periph == daisy::UsbHandle::FS_INTERNAL
+                          ? ALCHEMY_USB_PERIPH_FS
+                          : ALCHEMY_USB_PERIPH_HS,
+                      product_name);
     usb.SetReceiveCallback(&CdcUsbTransport::RxTrampoline, periph);
 }
 

--- a/framework/src/host_link/describe.cpp
+++ b/framework/src/host_link/describe.cpp
@@ -271,8 +271,11 @@ bool DescribeSettings(DescriptorBuilder& db, const Settings& st,
             else
                 std::snprintf(nm, sizeof nm, "%s", SettingsKindName(k));
 
-            ok = db.SettingsField(pg, pot, fid, nm,
-                                  nullptr /* derive from kind */);
+            const char* declared = st.NameAt(pg, pot);
+            ok = db.SettingsField(pg, pot, fid, declared ? declared : nm,
+                                  nullptr /* derive from kind */,
+                                  st.ZoneLabelsAt(pg, pot),
+                                  st.ZonesAt(pg, pot));
         }
     }
     return ok && db.EndSettings();

--- a/framework/src/host_link/descriptor.cpp
+++ b/framework/src/host_link/descriptor.cpp
@@ -374,7 +374,9 @@ bool DescriptorBuilder::BeginSettings(const char* id, const Settings& settings,
 
 bool DescriptorBuilder::SettingsField(uint8_t page, uint8_t pot,
                                       const char* field_id, const char* name,
-                                      const char* disp_json)
+                                      const char* disp_json,
+                                      const char* const* labels,
+                                      uint8_t num_labels)
 {
     if (!settings_ || !fields_open_) { error_ = true; return false; }
     if (page >= kMaxSettingsPages || pot >= kMaxPots) { error_ = true; return false; }
@@ -391,12 +393,29 @@ bool DescriptorBuilder::SettingsField(uint8_t page, uint8_t pot,
 
     if (kind == SettingsKind::Selector)
     {
+        const uint8_t zones = settings_->ZonesAt(page, pot);
         w_.Key("type");  w_.Str("enum");
-        w_.Key("zones"); w_.UInt(settings_->ZonesAt(page, pot));
+        w_.Key("zones"); w_.UInt(zones);
         w_.Key("def");   w_.UInt(settings_->SelectorIdxAt(page, pot));
         w_.Key("disp");
-        if (disp_json) w_.RawValue(disp_json);
-        else           w_.RawValue("{\"kind\":\"enum\"}");
+        if (disp_json)
+        {
+            w_.RawValue(disp_json);
+        }
+        else if (labels != nullptr && num_labels == zones && zones > 0u)
+        {
+            w_.BeginObj();
+            w_.Key("kind"); w_.Str("enum");
+            w_.Key("labels");
+            w_.BeginArr();
+            for (uint8_t i = 0; i < zones; i++) w_.Str(labels[i]);
+            w_.EndArr();
+            w_.EndObj();
+        }
+        else
+        {
+            w_.RawValue("{\"kind\":\"enum\"}");
+        }
     }
     else
     {

--- a/framework/src/midi/mono_note_tracker.cpp
+++ b/framework/src/midi/mono_note_tracker.cpp
@@ -1,0 +1,128 @@
+#include "alchemy/midi/mono_note_tracker.h"
+
+namespace alchemy {
+namespace midi {
+
+uint8_t MonoNoteTracker::SelectIndex() const
+{
+    if (prio_ == Priority::Last)
+    {
+        return static_cast<uint8_t>(n_ - 1u);
+    }
+
+    uint8_t best = 0u;
+    for (uint8_t i = 1u; i < n_; i++)
+    {
+        const bool wins = (prio_ == Priority::Low)
+                              ? (held_[i].note < held_[best].note)
+                              : (held_[i].note > held_[best].note);
+        if (wins)
+        {
+            best = i;
+        }
+    }
+    return best;
+}
+
+void MonoNoteTracker::Remove(uint8_t idx)
+{
+    for (uint8_t i = idx; i + 1u < n_; i++)
+    {
+        held_[i] = held_[i + 1u];
+    }
+    n_--;
+}
+
+void MonoNoteTracker::Reselect()
+{
+    if (n_ == 0u)
+    {
+        return;
+    }
+    const uint8_t sel = SelectIndex();
+    if (held_[sel].note != cur_note_)
+    {
+        cur_note_ = held_[sel].note;
+        cur_vel_  = held_[sel].vel;
+        if (retrig_on_return_)
+        {
+            retrig_ = true;
+        }
+    }
+}
+
+void MonoNoteTracker::NoteOn(uint8_t note, uint8_t velocity)
+{
+    for (uint8_t i = 0u; i < n_; i++)
+    {
+        if (held_[i].note == note)
+        {
+            Remove(i);
+            break;
+        }
+    }
+    if (n_ == kCapacity)
+    {
+        Remove(0u);
+    }
+
+    const bool was_gated = (n_ > 0u);
+    held_[n_++]          = Held{note, velocity, false};
+
+    const uint8_t sel = SelectIndex();
+    if (!was_gated || held_[sel].note != cur_note_
+        || held_[sel].note == note)
+    {
+        if (held_[sel].note == note || !was_gated)
+        {
+            retrig_ = true;
+        }
+        cur_note_ = held_[sel].note;
+        cur_vel_  = held_[sel].vel;
+    }
+}
+
+void MonoNoteTracker::NoteOff(uint8_t note)
+{
+    for (uint8_t i = 0u; i < n_; i++)
+    {
+        if (held_[i].note == note)
+        {
+            if (sustain_)
+            {
+                held_[i].sustained = true;
+                return;
+            }
+            Remove(i);
+            Reselect();
+            return;
+        }
+    }
+}
+
+void MonoNoteTracker::SetSustain(bool on)
+{
+    sustain_ = on;
+    if (on)
+    {
+        return;
+    }
+    for (uint8_t i = n_; i > 0u; i--)
+    {
+        if (held_[i - 1u].sustained)
+        {
+            Remove(static_cast<uint8_t>(i - 1u));
+        }
+    }
+    Reselect();
+}
+
+void MonoNoteTracker::Clear()
+{
+    n_       = 0u;
+    retrig_  = false;
+    sustain_ = false;
+}
+
+} // namespace midi
+} // namespace alchemy

--- a/framework/src/midi/poly_note_allocator.cpp
+++ b/framework/src/midi/poly_note_allocator.cpp
@@ -1,0 +1,143 @@
+#include "alchemy/midi/poly_note_allocator.h"
+
+namespace alchemy {
+namespace midi {
+
+PolyNoteAllocator& PolyNoteAllocator::SetVoiceCount(uint8_t n)
+{
+    if (n < 1u) n = 1u;
+    if (n > kMaxVoices) n = kMaxVoices;
+    num_voices_ = n;
+    Clear();
+    return *this;
+}
+
+uint8_t PolyNoteAllocator::GatedCount() const
+{
+    uint8_t n = 0u;
+    for (uint8_t i = 0u; i < num_voices_; i++)
+        if (voices_[i].gate) n++;
+    return n;
+}
+
+uint8_t PolyNoteAllocator::FindGated(uint8_t channel, uint8_t note) const
+{
+    for (uint8_t i = 0u; i < num_voices_; i++)
+    {
+        if (voices_[i].gate && voices_[i].note == note
+            && voices_[i].channel == channel)
+            return i;
+    }
+    return kMaxVoices;
+}
+
+uint8_t PolyNoteAllocator::PickVoice()
+{
+    /* Free voice, least-recently released first. */
+    uint8_t  best      = kMaxVoices;
+    uint32_t best_off  = 0u;
+    bool     have_free = false;
+    for (uint8_t i = 0u; i < num_voices_; i++)
+    {
+        if (!voices_[i].gate)
+        {
+            if (!have_free || off_order_[i] < best_off)
+            {
+                have_free = true;
+                best      = i;
+                best_off  = off_order_[i];
+            }
+        }
+    }
+    if (have_free) return best;
+
+    switch (steal_)
+    {
+        case Steal::None: return kMaxVoices;
+        case Steal::Oldest:
+        {
+            uint32_t oldest = 0u;
+            for (uint8_t i = 0u; i < num_voices_; i++)
+            {
+                if (best == kMaxVoices || on_order_[i] < oldest)
+                {
+                    best   = i;
+                    oldest = on_order_[i];
+                }
+            }
+            return best;
+        }
+        case Steal::Lowest:
+        case Steal::Highest:
+        {
+            for (uint8_t i = 0u; i < num_voices_; i++)
+            {
+                if (best == kMaxVoices) { best = i; continue; }
+                const bool wins = (steal_ == Steal::Lowest)
+                                      ? (voices_[i].note < voices_[best].note)
+                                      : (voices_[i].note > voices_[best].note);
+                if (wins) best = i;
+            }
+            return best;
+        }
+    }
+    return kMaxVoices;
+}
+
+void PolyNoteAllocator::NoteOn(uint8_t channel, uint8_t note, uint8_t velocity)
+{
+    uint8_t v = FindGated(channel, note);
+    if (v == kMaxVoices) v = PickVoice();
+    if (v == kMaxVoices) return;
+
+    voices_[v].note     = note;
+    voices_[v].velocity = velocity;
+    voices_[v].channel  = channel;
+    voices_[v].gate     = true;
+    sustained_[v]       = false;
+    retrig_[v]          = true;
+    on_order_[v]        = ++counter_;
+}
+
+void PolyNoteAllocator::NoteOff(uint8_t channel, uint8_t note)
+{
+    const uint8_t v = FindGated(channel, note);
+    if (v == kMaxVoices) return;
+
+    if (sustain_)
+    {
+        sustained_[v] = true;
+        return;
+    }
+    voices_[v].gate = false;
+    off_order_[v]   = ++counter_;
+}
+
+void PolyNoteAllocator::SetSustain(bool on)
+{
+    sustain_ = on;
+    if (on) return;
+    for (uint8_t i = 0u; i < num_voices_; i++)
+    {
+        if (sustained_[i])
+        {
+            sustained_[i]   = false;
+            voices_[i].gate = false;
+            off_order_[i]   = ++counter_;
+        }
+    }
+}
+
+void PolyNoteAllocator::Clear()
+{
+    for (uint8_t i = 0u; i < kMaxVoices; i++)
+    {
+        voices_[i].gate = false;
+        retrig_[i]      = false;
+        sustained_[i]   = false;
+    }
+    sustain_ = false;
+}
+
+} // namespace midi
+} // namespace alchemy

--- a/framework/src/midi/usb_midi.cpp
+++ b/framework/src/midi/usb_midi.cpp
@@ -1,0 +1,382 @@
+#include "alchemy/midi/usb_midi.h"
+
+#include "daisy_seed.h"
+
+namespace alchemy {
+namespace midi {
+
+UsbMidi* UsbMidi::s_instance = nullptr;
+
+const char* const UsbMidi::kChannelLabels[UsbMidi::kChannelZones] = {
+    "Omni", "1", "2", "3", "4", "5", "6", "7", "8",
+    "9", "10", "11", "12", "13", "14", "15", "16",
+};
+const char* const UsbMidi::kBendRangeLabels[UsbMidi::kBendRangeZones] = {
+    "Off", "±1", "±2", "±7", "±12",
+};
+const float UsbMidi::kBendRangeSemis[UsbMidi::kBendRangeZones] = {
+    0.0f, 1.0f, 2.0f, 7.0f, 12.0f,
+};
+const char* const UsbMidi::kPriorityLabels[UsbMidi::kPriorityZones] = {
+    "Last", "Low", "High",
+};
+const char* const UsbMidi::kVelocityModeLabels[3] = {
+    "Off", "Accent", "Level",
+};
+
+UsbMidi& UsbMidi::UseChannelSetting(SelectorHandle h)
+{
+    h.Name("MIDI Channel").Labels(kChannelLabels, kChannelZones);
+    channel_zone_ = h.IndexPtr();
+    return *this;
+}
+
+UsbMidi& UsbMidi::UseBendRangeSetting(SelectorHandle h)
+{
+    h.Name("Bend Range").Labels(kBendRangeLabels, kBendRangeZones);
+    bend_zone_ = h.IndexPtr();
+    return *this;
+}
+
+UsbMidi& UsbMidi::UsePrioritySetting(SelectorHandle h)
+{
+    h.Name("Note Priority").Labels(kPriorityLabels, kPriorityZones);
+    priority_zone_ = h.IndexPtr();
+    return *this;
+}
+
+void UsbMidi::Init()
+{
+    s_instance = this;
+    for (uint8_t i = 0u; i < 16u; i++) bend14_ch_[i] = 0x2000u;
+    alchemy_usb_midi_set_rx(&UsbMidi::RxTrampoline, this);
+}
+
+void UsbMidi::Start(const char* product_name, AlchemyUsbPeriph periph)
+{
+    alchemy_usb_start(periph, product_name);
+}
+
+void UsbMidi::RxTrampoline(const uint8_t pkt[4], void* ctx)
+{
+    static_cast<UsbMidi*>(ctx)->OnRxPacket(pkt);
+}
+
+void UsbMidi::OnRxPacket(const uint8_t pkt[4])
+{
+    /* IRQ context: single producer. */
+    const uint8_t cin = pkt[0] & 0x0Fu;
+
+    if (cin == 0x0Fu && pkt[1] >= 0xF8u)
+    {
+        if (pkt[1] == 0xF8u)
+        {
+            clock_count_ = clock_count_ + 1u;
+            if (clock_fn_ != nullptr)
+            {
+                clock_fn_(daisy::System::GetUs(), clock_ctx_);
+            }
+            return;
+        }
+        if (pkt[1] == 0xFEu)
+        {
+            return;
+        }
+    }
+
+    const uint16_t next = static_cast<uint16_t>((rx_w_ + 1u) & (kRxRing - 1u));
+    if (next == rx_r_)
+    {
+        rx_dropped_++;
+        return;
+    }
+    rx_[rx_w_][0] = pkt[0];
+    rx_[rx_w_][1] = pkt[1];
+    rx_[rx_w_][2] = pkt[2];
+    rx_[rx_w_][3] = pkt[3];
+    rx_w_         = next;
+}
+
+void UsbMidi::HandleCc(uint8_t ch, uint8_t cc, uint8_t val)
+{
+    switch (cc)
+    {
+        case 64u:
+            if (tracker_ != nullptr) tracker_->SetSustain(val >= 64u);
+            if (allocator_ != nullptr) allocator_->SetSustain(val >= 64u);
+            break;
+
+        case 74u: cc74_[ch] = val; break;
+
+        case 98u:
+            rpn_mode_[ch]  = 2u;
+            param_lsb_[ch] = val;
+            break;
+        case 99u:
+            rpn_mode_[ch]  = 2u;
+            param_msb_[ch] = val;
+            break;
+        case 100u:
+            param_lsb_[ch] = val;
+            rpn_mode_[ch] =
+                (param_msb_[ch] == 0x7Fu && val == 0x7Fu) ? 0u : 1u;
+            break;
+        case 101u:
+            param_msb_[ch] = val;
+            rpn_mode_[ch] =
+                (val == 0x7Fu && param_lsb_[ch] == 0x7Fu) ? 0u : 1u;
+            break;
+
+        case 6u:
+        case 38u:
+        {
+            if (rpn_mode_[ch] == 0u) break;
+            if (cc == 6u) data_msb_[ch] = val;
+            const uint8_t  lsb = (cc == 38u) ? val : 0u;
+            const uint16_t param =
+                static_cast<uint16_t>((param_msb_[ch] << 7) | param_lsb_[ch]);
+            const uint16_t value14 =
+                static_cast<uint16_t>((data_msb_[ch] << 7) | lsb);
+            if (rpn_mode_[ch] == 1u && param == 0u)
+            {
+                bend_range_semis_ = static_cast<float>(data_msb_[ch])
+                                    + static_cast<float>(lsb) * 0.01f;
+            }
+            if (rpn_fn_ != nullptr)
+            {
+                rpn_fn_(ch, param, value14, rpn_mode_[ch] == 2u, rpn_ctx_);
+            }
+            break;
+        }
+
+        case 120u:
+        case 123u:
+            if (tracker_ != nullptr) tracker_->Clear();
+            if (allocator_ != nullptr) allocator_->Clear();
+            break;
+
+        default: break;
+    }
+}
+
+void UsbMidi::Dispatch(const MidiEvent& ev)
+{
+    const uint8_t ch = ev.Channel();
+
+    if (ev.IsChannelVoice())
+    {
+        switch (ev.Type())
+        {
+            case MidiMsg::NoteOn:
+                if (tracker_ != nullptr) tracker_->NoteOn(ev.d1, ev.d2);
+                if (allocator_ != nullptr)
+                    allocator_->NoteOn(ch, ev.d1, ev.d2);
+                break;
+            case MidiMsg::NoteOff:
+                if (tracker_ != nullptr) tracker_->NoteOff(ev.d1);
+                if (allocator_ != nullptr) allocator_->NoteOff(ch, ev.d1);
+                break;
+            case MidiMsg::ControlChange: HandleCc(ch, ev.d1, ev.d2); break;
+            case MidiMsg::PitchBend:
+                bend14_        = ev.Bend14();
+                bend14_ch_[ch] = ev.Bend14();
+                break;
+            case MidiMsg::ChannelPressure: pressure_[ch] = ev.d1; break;
+            default: break;
+        }
+    }
+    if (event_fn_ != nullptr)
+    {
+        event_fn_(ev, event_ctx_);
+    }
+}
+
+void UsbMidi::HandleSysExPacket(const uint8_t pkt[4])
+{
+    if (sysex_fn_ == nullptr)
+    {
+        return;
+    }
+    const uint8_t cin = pkt[0] & 0x0Fu;
+    uint8_t       len;
+    bool          terminal;
+    switch (cin)
+    {
+        case 0x4u: len = 3u; terminal = false; break;
+        case 0x5u: len = 1u; terminal = true; break;
+        case 0x6u: len = 2u; terminal = true; break;
+        case 0x7u: len = 3u; terminal = true; break;
+        default: return;
+    }
+    sysex_fn_(&pkt[1], len, terminal, sysex_ctx_);
+}
+
+void UsbMidi::ResetChannelState()
+{
+    bend14_ = 0x2000u;
+    for (uint8_t i = 0u; i < 16u; i++)
+    {
+        bend14_ch_[i] = 0x2000u;
+        pressure_[i]  = 0u;
+        cc74_[i]      = 0u;
+        rpn_mode_[i]  = 0u;
+    }
+}
+
+void UsbMidi::Poll(uint32_t t_ms)
+{
+    (void)t_ms;
+
+    if (channel_zone_ != nullptr)
+    {
+        const uint8_t z = *channel_zone_;
+        channel_ = (z == 0u) ? kOmni : static_cast<uint8_t>((z - 1u) & 0x0Fu);
+    }
+    /* Applied on change only, so a host-sent RPN 0 holds until the user
+     * next moves the setting. */
+    if (bend_zone_ != nullptr && *bend_zone_ != last_bend_zone_)
+    {
+        last_bend_zone_ = *bend_zone_;
+        const uint8_t z = (last_bend_zone_ < kBendRangeZones)
+                              ? last_bend_zone_
+                              : static_cast<uint8_t>(kBendRangeZones - 1u);
+        bend_range_semis_ = kBendRangeSemis[z];
+    }
+    if (priority_zone_ != nullptr && tracker_ != nullptr)
+    {
+        const uint8_t z =
+            (*priority_zone_ < kPriorityZones) ? *priority_zone_ : 0u;
+        tracker_->SetPriority(static_cast<MonoNoteTracker::Priority>(z));
+    }
+
+    const bool online = alchemy_usb_configured();
+    if (was_online_ && !online)
+    {
+        if (tracker_ != nullptr) tracker_->Clear();
+        if (allocator_ != nullptr) allocator_->Clear();
+        ResetChannelState();
+    }
+    was_online_ = online;
+
+    const uint16_t w = rx_w_;
+    while (rx_r_ != w)
+    {
+        MidiEvent ev;
+        if (EventFromUsbPacket(rx_[rx_r_], ev))
+        {
+            if (!ev.IsChannelVoice() || channel_ == kOmni
+                || ev.Channel() == channel_)
+            {
+                if (ev.Type() == MidiMsg::NoteOn && ev.d2 == 0u)
+                {
+                    ev.status = static_cast<uint8_t>(
+                        static_cast<uint8_t>(MidiMsg::NoteOff) | ev.Channel());
+                    ev.d2 = 0x40u;
+                }
+                Dispatch(ev);
+            }
+        }
+        else
+        {
+            HandleSysExPacket(rx_[rx_r_]);
+        }
+        rx_r_ = static_cast<uint16_t>((rx_r_ + 1u) & (kRxRing - 1u));
+    }
+
+    DrainTx();
+}
+
+uint16_t UsbMidi::TxFree() const
+{
+    const uint16_t used = static_cast<uint16_t>((tx_w_ - tx_r_)
+                                                & (kTxRing - 1u));
+    return static_cast<uint16_t>(kTxRing - 1u - used);
+}
+
+void UsbMidi::PushPacket(const uint8_t pkt[4])
+{
+    const uint16_t next = static_cast<uint16_t>((tx_w_ + 1u) & (kTxRing - 1u));
+    if (next == tx_r_)
+    {
+        tx_dropped_++;
+        return;
+    }
+    tx_[tx_w_][0] = pkt[0];
+    tx_[tx_w_][1] = pkt[1];
+    tx_[tx_w_][2] = pkt[2];
+    tx_[tx_w_][3] = pkt[3];
+    tx_w_         = next;
+}
+
+void UsbMidi::Send(const MidiEvent& ev)
+{
+    uint8_t pkt[4];
+    if (!EventToUsbPacket(ev, 0u, pkt))
+    {
+        tx_dropped_++;
+        return;
+    }
+    PushPacket(pkt);
+}
+
+bool UsbMidi::SendSysEx(const uint8_t* payload, uint16_t len)
+{
+    const uint32_t total   = static_cast<uint32_t>(len) + 2u; /* F0 .. F7 */
+    const uint32_t packets = (total + 2u) / 3u;
+    if (packets > TxFree())
+    {
+        tx_dropped_++;
+        return false;
+    }
+
+    uint8_t buf[3];
+    uint8_t n = 0u;
+    for (uint32_t i = 0u; i < total; i++)
+    {
+        const uint8_t b = (i == 0u) ? 0xF0u
+                          : (i == total - 1u) ? 0xF7u
+                                              : payload[i - 1u];
+        buf[n++] = b;
+        const bool last = (i == total - 1u);
+        if (n == 3u || last)
+        {
+            uint8_t pkt[4] = {0u, 0u, 0u, 0u};
+            pkt[0] = last ? (n == 1u ? 0x05u : (n == 2u ? 0x06u : 0x07u))
+                          : 0x04u;
+            for (uint8_t k = 0u; k < n; k++) pkt[1u + k] = buf[k];
+            PushPacket(pkt);
+            n = 0u;
+        }
+    }
+    return true;
+}
+
+void UsbMidi::DrainTx()
+{
+    if (tx_r_ == tx_w_ || !alchemy_usb_midi_tx_ready())
+    {
+        return;
+    }
+
+    uint8_t  burst[ALCHEMY_MIDI_EP_PACKET_SIZE];
+    uint16_t n = 0u;
+    uint16_t r = tx_r_;
+
+    while (r != tx_w_ && (n + 4u) <= sizeof burst)
+    {
+        burst[n]      = tx_[r][0];
+        burst[n + 1u] = tx_[r][1];
+        burst[n + 2u] = tx_[r][2];
+        burst[n + 3u] = tx_[r][3];
+        n             = static_cast<uint16_t>(n + 4u);
+        r             = static_cast<uint16_t>((r + 1u) & (kTxRing - 1u));
+    }
+
+    if (alchemy_usb_midi_write(burst, n) == n)
+    {
+        tx_r_ = r;
+    }
+}
+
+} // namespace midi
+} // namespace alchemy

--- a/framework/src/surface/settings.cpp
+++ b/framework/src/surface/settings.cpp
@@ -618,6 +618,18 @@ SettingsKind Settings::KindAt(uint8_t page, uint8_t pot) const
     return slots_[page][pot].kind;
 }
 
+const char* Settings::NameAt(uint8_t page, uint8_t pot) const
+{
+    if (page >= num_pages_ || pot >= kNumPots) return nullptr;
+    return slots_[page][pot].name;
+}
+
+const char* const* Settings::ZoneLabelsAt(uint8_t page, uint8_t pot) const
+{
+    if (page >= num_pages_ || pot >= kNumPots) return nullptr;
+    return slots_[page][pot].zone_labels;
+}
+
 uint8_t Settings::ZonesAt(uint8_t page, uint8_t pot) const
 {
     if (page >= num_pages_ || pot >= kNumPots) return 0u;

--- a/framework/src/usb/usb_composite.c
+++ b/framework/src/usb/usb_composite.c
@@ -1,0 +1,324 @@
+/**
+ * @file usb/usb_composite.c
+ * @brief One USBD class serving both functions of the composite.
+ *
+ * The CDC function is delegated to ST's shipped USBD_CDC handlers, so
+ * the serial path is behaviorally identical to the single-class device.
+ * This class only routes: interfaces 0/1 and endpoints 0x01/0x81/0x82
+ * to CDC, interfaces 2/3 and endpoints 0x02/0x83 to the MIDI handlers.
+ */
+
+#include <string.h>
+
+#include "usbd_core.h"
+#include "usbd_cdc.h"
+
+#include "alchemy/usb/usb_descriptors.h"
+#include "alchemy/usb/usb_device.h"
+
+#define MIDI_IN_IDX (ALCHEMY_MIDI_IN_EP & 0x0FU)
+#define MIDI_OUT_IDX (ALCHEMY_MIDI_OUT_EP & 0x0FU)
+
+static USBD_HandleTypeDef* s_pdev = NULL;
+
+/* DWC2 moves FIFO data by word — keep endpoint buffers aligned. */
+__ALIGN_BEGIN static uint8_t s_midi_rx_buf[ALCHEMY_MIDI_EP_PACKET_SIZE]
+    __ALIGN_END;
+__ALIGN_BEGIN static uint8_t s_midi_tx_buf[ALCHEMY_MIDI_EP_PACKET_SIZE]
+    __ALIGN_END;
+
+static volatile uint8_t s_midi_tx_busy = 0U;
+
+static AlchemyUsbMidiRxFn s_rx_fn = NULL;
+static void* s_rx_ctx = NULL;
+
+static uint8_t Composite_Init(USBD_HandleTypeDef* pdev, uint8_t cfgidx)
+{
+    const uint8_t ret = USBD_CDC.Init(pdev, cfgidx);
+    if (ret != (uint8_t)USBD_OK)
+    {
+        return ret;
+    }
+
+    (void)USBD_LL_OpenEP(pdev, ALCHEMY_MIDI_IN_EP, USBD_EP_TYPE_BULK,
+                         ALCHEMY_MIDI_EP_PACKET_SIZE);
+    pdev->ep_in[MIDI_IN_IDX].is_used = 1U;
+
+    (void)USBD_LL_OpenEP(pdev, ALCHEMY_MIDI_OUT_EP, USBD_EP_TYPE_BULK,
+                         ALCHEMY_MIDI_EP_PACKET_SIZE);
+    pdev->ep_out[MIDI_OUT_IDX].is_used = 1U;
+
+    s_midi_tx_busy = 0U;
+    (void)USBD_LL_PrepareReceive(pdev, ALCHEMY_MIDI_OUT_EP, s_midi_rx_buf,
+                                 ALCHEMY_MIDI_EP_PACKET_SIZE);
+    return (uint8_t)USBD_OK;
+}
+
+static uint8_t Composite_DeInit(USBD_HandleTypeDef* pdev, uint8_t cfgidx)
+{
+    (void)USBD_LL_CloseEP(pdev, ALCHEMY_MIDI_IN_EP);
+    pdev->ep_in[MIDI_IN_IDX].is_used = 0U;
+
+    (void)USBD_LL_CloseEP(pdev, ALCHEMY_MIDI_OUT_EP);
+    pdev->ep_out[MIDI_OUT_IDX].is_used = 0U;
+
+    s_midi_tx_busy = 0U;
+    return USBD_CDC.DeInit(pdev, cfgidx);
+}
+
+static uint8_t MidiInterfaceSetup(USBD_HandleTypeDef* pdev,
+                                  USBD_SetupReqTypedef* req)
+{
+    static uint8_t alt0 = 0U;
+    static uint16_t status0 = 0U;
+    USBD_StatusTypeDef ret = USBD_OK;
+
+    switch (req->bmRequest & USB_REQ_TYPE_MASK)
+    {
+        case USB_REQ_TYPE_STANDARD:
+            switch (req->bRequest)
+            {
+                case USB_REQ_GET_STATUS:
+                    if (pdev->dev_state == USBD_STATE_CONFIGURED)
+                    {
+                        (void)USBD_CtlSendData(pdev, (uint8_t*)&status0, 2U);
+                    }
+                    else
+                    {
+                        USBD_CtlError(pdev, req);
+                        ret = USBD_FAIL;
+                    }
+                    break;
+
+                case USB_REQ_GET_INTERFACE:
+                    if (pdev->dev_state == USBD_STATE_CONFIGURED)
+                    {
+                        (void)USBD_CtlSendData(pdev, &alt0, 1U);
+                    }
+                    else
+                    {
+                        USBD_CtlError(pdev, req);
+                        ret = USBD_FAIL;
+                    }
+                    break;
+
+                case USB_REQ_SET_INTERFACE:
+                    if ((pdev->dev_state != USBD_STATE_CONFIGURED)
+                        || (req->wValue != 0U))
+                    {
+                        USBD_CtlError(pdev, req);
+                        ret = USBD_FAIL;
+                    }
+                    break;
+
+                case USB_REQ_CLEAR_FEATURE:
+                    break;
+
+                default:
+                    USBD_CtlError(pdev, req);
+                    ret = USBD_FAIL;
+                    break;
+            }
+            break;
+
+        default:
+            USBD_CtlError(pdev, req);
+            ret = USBD_FAIL;
+            break;
+    }
+
+    return (uint8_t)ret;
+}
+
+static uint8_t Composite_Setup(USBD_HandleTypeDef* pdev,
+                               USBD_SetupReqTypedef* req)
+{
+    const uint8_t recipient = req->bmRequest & USB_REQ_RECIPIENT_MASK;
+    const uint8_t target = (uint8_t)(req->wIndex & 0xFFU);
+
+    if ((recipient == USB_REQ_RECIPIENT_INTERFACE) && (target >= 2U))
+    {
+        return MidiInterfaceSetup(pdev, req);
+    }
+    if ((recipient == USB_REQ_RECIPIENT_ENDPOINT)
+        && ((target == ALCHEMY_MIDI_OUT_EP)
+            || (target == ALCHEMY_MIDI_IN_EP)))
+    {
+        USBD_CtlError(pdev, req);
+        return (uint8_t)USBD_FAIL;
+    }
+    return USBD_CDC.Setup(pdev, req);
+}
+
+static uint8_t Composite_EP0_RxReady(USBD_HandleTypeDef* pdev)
+{
+    return USBD_CDC.EP0_RxReady(pdev);
+}
+
+static uint8_t Composite_DataIn(USBD_HandleTypeDef* pdev, uint8_t epnum)
+{
+    if ((epnum & 0x0FU) == MIDI_IN_IDX)
+    {
+        PCD_HandleTypeDef* hpcd = (PCD_HandleTypeDef*)pdev->pData;
+
+        if ((pdev->ep_in[epnum & 0x0FU].total_length > 0U)
+            && ((pdev->ep_in[epnum & 0x0FU].total_length
+                 % hpcd->IN_ep[epnum & 0x0FU].maxpacket)
+                == 0U))
+        {
+            pdev->ep_in[epnum & 0x0FU].total_length = 0U;
+            (void)USBD_LL_Transmit(pdev, epnum, NULL, 0U);
+        }
+        else
+        {
+            s_midi_tx_busy = 0U;
+        }
+        return (uint8_t)USBD_OK;
+    }
+    return USBD_CDC.DataIn(pdev, epnum);
+}
+
+static uint8_t Composite_DataOut(USBD_HandleTypeDef* pdev, uint8_t epnum)
+{
+    if (epnum == MIDI_OUT_IDX)
+    {
+        const uint32_t len = USBD_LL_GetRxDataSize(pdev, epnum);
+
+        if (s_rx_fn != NULL)
+        {
+            for (uint32_t i = 0U; (i + 4U) <= len; i += 4U)
+            {
+                s_rx_fn(&s_midi_rx_buf[i], s_rx_ctx);
+            }
+        }
+
+        (void)USBD_LL_PrepareReceive(pdev, ALCHEMY_MIDI_OUT_EP, s_midi_rx_buf,
+                                     ALCHEMY_MIDI_EP_PACKET_SIZE);
+        return (uint8_t)USBD_OK;
+    }
+    return USBD_CDC.DataOut(pdev, epnum);
+}
+
+static uint8_t* Composite_GetCfgDesc(uint16_t* length)
+{
+    *length = (uint16_t)ALCHEMY_USB_CFG_DESC_SIZE;
+    return alchemy_usb_cfg_desc;
+}
+
+static uint8_t* Composite_GetDeviceQualifierDesc(uint16_t* length)
+{
+    *length = (uint16_t)ALCHEMY_USB_QUALIFIER_DESC_SIZE;
+    return (uint8_t*)(uintptr_t)alchemy_usb_qualifier_desc;
+}
+
+USBD_ClassTypeDef alchemy_usb_composite_class = {
+    .Init = Composite_Init,
+    .DeInit = Composite_DeInit,
+    .Setup = Composite_Setup,
+    .EP0_TxSent = NULL,
+    .EP0_RxReady = Composite_EP0_RxReady,
+    .DataIn = Composite_DataIn,
+    .DataOut = Composite_DataOut,
+    .SOF = NULL,
+    .IsoINIncomplete = NULL,
+    .IsoOUTIncomplete = NULL,
+    .GetHSConfigDescriptor = Composite_GetCfgDesc,
+    .GetFSConfigDescriptor = Composite_GetCfgDesc,
+    .GetOtherSpeedConfigDescriptor = Composite_GetCfgDesc,
+    .GetDeviceQualifierDescriptor = Composite_GetDeviceQualifierDesc,
+};
+
+/* The stock core stalls interface-directed setup requests above
+ * USBD_MAX_NUM_INTERFACES (1) before this class sees them.  The link
+ * wraps USBD_StdItfReq instead of editing libDaisy: REQUIRES
+ * -Wl,--wrap=USBD_StdItfReq (CMake attaches it to alchemy::usb;
+ * Makefile builds add it to LDFLAGS).  The anchor in
+ * alchemy_usb_composite_bind keeps the wrapper referenced, so a lost
+ * flag fails the link on __real_USBD_StdItfReq instead of degrading
+ * silently. */
+USBD_StatusTypeDef USBD_StdItfReq(USBD_HandleTypeDef* pdev,
+                                  USBD_SetupReqTypedef* req);
+USBD_StatusTypeDef __real_USBD_StdItfReq(USBD_HandleTypeDef* pdev,
+                                         USBD_SetupReqTypedef* req);
+
+USBD_StatusTypeDef __wrap_USBD_StdItfReq(USBD_HandleTypeDef* pdev,
+                                         USBD_SetupReqTypedef* req)
+{
+    const uint8_t itf = (uint8_t)(req->wIndex & 0xFFU);
+
+    if ((itf >= 2U) && (itf < ALCHEMY_USB_NUM_INTERFACES))
+    {
+        switch (pdev->dev_state)
+        {
+            case USBD_STATE_DEFAULT:
+            case USBD_STATE_ADDRESSED:
+            case USBD_STATE_CONFIGURED:
+            {
+                USBD_StatusTypeDef ret = USBD_FAIL;
+                if ((pdev->pClass[0] != NULL)
+                    && (pdev->pClass[0]->Setup != NULL))
+                {
+                    pdev->classId = 0U;
+                    ret = (USBD_StatusTypeDef)pdev->pClass[0]->Setup(pdev,
+                                                                     req);
+                }
+                if ((req->wLength == 0U) && (ret == USBD_OK))
+                {
+                    (void)USBD_CtlSendStatus(pdev);
+                }
+                return ret;
+            }
+            default:
+                USBD_CtlError(pdev, req);
+                return USBD_FAIL;
+        }
+    }
+    return __real_USBD_StdItfReq(pdev, req);
+}
+
+static volatile uintptr_t s_itf_wrap_anchor;
+
+void alchemy_usb_composite_bind(USBD_HandleTypeDef* pdev)
+{
+    s_pdev = pdev;
+    s_itf_wrap_anchor = (uintptr_t)&__wrap_USBD_StdItfReq;
+}
+
+void alchemy_usb_midi_set_rx(AlchemyUsbMidiRxFn fn, void* ctx)
+{
+    s_rx_ctx = ctx;
+    s_rx_fn = fn;
+}
+
+bool alchemy_usb_configured(void)
+{
+    return (s_pdev != NULL) && (s_pdev->dev_state == USBD_STATE_CONFIGURED);
+}
+
+bool alchemy_usb_midi_tx_ready(void)
+{
+    return alchemy_usb_configured() && (s_midi_tx_busy == 0U);
+}
+
+uint16_t alchemy_usb_midi_write(const uint8_t* packets, uint16_t len)
+{
+    if (!alchemy_usb_configured())
+    {
+        return 0U;
+    }
+    if ((len == 0U) || (len > ALCHEMY_MIDI_EP_PACKET_SIZE)
+        || ((len & 3U) != 0U))
+    {
+        return 0U;
+    }
+    if (s_midi_tx_busy != 0U)
+    {
+        return 0U;
+    }
+
+    s_midi_tx_busy = 1U;
+    memcpy(s_midi_tx_buf, packets, len);
+    s_pdev->ep_in[MIDI_IN_IDX].total_length = len;
+    (void)USBD_LL_Transmit(s_pdev, ALCHEMY_MIDI_IN_EP, s_midi_tx_buf, len);
+    return len;
+}

--- a/framework/src/usb/usb_descriptors.c
+++ b/framework/src/usb/usb_descriptors.c
@@ -1,0 +1,93 @@
+/**
+ * @file usb/usb_descriptors.c
+ * @brief Composite descriptor bytes.  CDC interfaces/endpoints match the
+ *        shipped single-class device byte-for-byte; MIDI follows the
+ *        USB-MIDI 1.0 appendix B example, one virtual cable.
+ */
+
+#include "alchemy/usb/usb_descriptors.h"
+
+#define U16_LE(v) (uint8_t)((v) & 0xFFu), (uint8_t)(((v) >> 8) & 0xFFu)
+
+const uint8_t alchemy_usb_dev_desc[ALCHEMY_USB_DEV_DESC_SIZE] = {
+    0x12,                            /* bLength */
+    0x01,                            /* bDescriptorType: DEVICE */
+    0x00, 0x02,                      /* bcdUSB 2.00 */
+    0xEF,                            /* bDeviceClass: Miscellaneous */
+    0x02,                            /* bDeviceSubClass: Common Class */
+    0x01,                            /* bDeviceProtocol: IAD */
+    0x40,                            /* bMaxPacketSize0 */
+    U16_LE(ALCHEMY_USB_VID),         /* idVendor */
+    U16_LE(ALCHEMY_USB_PID),         /* idProduct */
+    U16_LE(ALCHEMY_USB_BCD_DEVICE),  /* bcdDevice */
+    0x01,                            /* iManufacturer */
+    0x02,                            /* iProduct */
+    0x03,                            /* iSerialNumber */
+    0x01,                            /* bNumConfigurations */
+};
+
+uint8_t alchemy_usb_cfg_desc[ALCHEMY_USB_CFG_DESC_SIZE] = {
+    /* Configuration */
+    0x09, 0x02, U16_LE(ALCHEMY_USB_CFG_DESC_SIZE),
+    ALCHEMY_USB_NUM_INTERFACES,
+    0x01,                            /* bConfigurationValue */
+    0x04,                            /* iConfiguration */
+    0xC0,                            /* bmAttributes: self-powered */
+    0x32,                            /* bMaxPower: 100 mA */
+
+    /* IAD: CDC function, interfaces 0..1 */
+    0x08, 0x0B, 0x00, 0x02, 0x02, 0x02, 0x01, 0x00,
+
+    /* Interface 0: CDC Communications (ACM) */
+    0x09, 0x04, 0x00, 0x00, 0x01, 0x02, 0x02, 0x01, 0x00,
+    /* CS: Header, bcdCDC 1.10 */
+    0x05, 0x24, 0x00, 0x10, 0x01,
+    /* CS: Call Management, data interface 1 */
+    0x05, 0x24, 0x01, 0x00, 0x01,
+    /* CS: ACM capabilities */
+    0x04, 0x24, 0x02, 0x02,
+    /* CS: Union, master 0 slave 1 */
+    0x05, 0x24, 0x06, 0x00, 0x01,
+    /* EP 0x82: interrupt IN, 8 bytes, bInterval 16 */
+    0x07, 0x05, ALCHEMY_CDC_CMD_EP, 0x03, 0x08, 0x00, 0x10,
+
+    /* Interface 1: CDC Data */
+    0x09, 0x04, 0x01, 0x00, 0x02, 0x0A, 0x00, 0x00, 0x00,
+    /* EP 0x01: bulk OUT, 64 */
+    0x07, 0x05, ALCHEMY_CDC_OUT_EP, 0x02, 0x40, 0x00, 0x00,
+    /* EP 0x81: bulk IN, 64 */
+    0x07, 0x05, ALCHEMY_CDC_IN_EP, 0x02, 0x40, 0x00, 0x00,
+
+    /* IAD: audio function, interfaces 2..3 */
+    0x08, 0x0B, 0x02, 0x02, 0x01, 0x01, 0x00, 0x00,
+
+    /* Interface 2: AudioControl */
+    0x09, 0x04, 0x02, 0x00, 0x00, 0x01, 0x01, 0x00, 0x00,
+    /* CS AC: header, bcdADC 1.00, one streaming interface (#3) */
+    0x09, 0x24, 0x01, 0x00, 0x01, 0x09, 0x00, 0x01, 0x03,
+
+    /* Interface 3: MIDIStreaming */
+    0x09, 0x04, 0x03, 0x00, 0x02, 0x01, 0x03, 0x00, 0x00,
+    /* CS MS: header, bcdMSC 1.00, wTotalLength 65 */
+    0x07, 0x24, 0x01, 0x00, 0x01, 0x41, 0x00,
+    /* MIDI IN jack, embedded, id 1 */
+    0x06, 0x24, 0x02, 0x01, 0x01, 0x00,
+    /* MIDI IN jack, external, id 2 */
+    0x06, 0x24, 0x02, 0x02, 0x02, 0x00,
+    /* MIDI OUT jack, embedded, id 3, source jack 2 pin 1 */
+    0x09, 0x24, 0x03, 0x01, 0x03, 0x01, 0x02, 0x01, 0x00,
+    /* MIDI OUT jack, external, id 4, source jack 1 pin 1 */
+    0x09, 0x24, 0x03, 0x02, 0x04, 0x01, 0x01, 0x01, 0x00,
+    /* EP 0x02: bulk OUT, 64 (audio-class 9-byte form) */
+    0x09, 0x05, ALCHEMY_MIDI_OUT_EP, 0x02, 0x40, 0x00, 0x00, 0x00, 0x00,
+    /* CS EP: 1 embedded jack, id 1 */
+    0x05, 0x25, 0x01, 0x01, 0x01,
+    /* EP 0x83: bulk IN, 64 */
+    0x09, 0x05, ALCHEMY_MIDI_IN_EP, 0x02, 0x40, 0x00, 0x00, 0x00, 0x00,
+    /* CS EP: 1 embedded jack, id 3 */
+    0x05, 0x25, 0x01, 0x01, 0x03,
+};
+
+const uint8_t alchemy_usb_qualifier_desc[ALCHEMY_USB_QUALIFIER_DESC_SIZE] = {
+    0x0A, 0x06, 0x00, 0x02, 0xEF, 0x02, 0x01, 0x40, 0x01, 0x00,
+};

--- a/framework/src/usb/usb_device.c
+++ b/framework/src/usb/usb_device.c
@@ -1,0 +1,158 @@
+/**
+ * @file usb/usb_device.c
+ * @brief Device bring-up + descriptor table for the composite device.
+ *        Reuses libDaisy's USBD handles and usbd_cdc_if fops, so the
+ *        shared IRQ handlers and UsbHandle transmit path stay valid.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "usbd_core.h"
+#include "usbd_ctlreq.h"
+#include "usbd_cdc.h"
+#include "usbd_cdc_if.h"
+
+#include "alchemy/usb/usb_descriptors.h"
+#include "alchemy/usb/usb_device.h"
+
+extern USBD_HandleTypeDef hUsbDeviceFS;
+extern USBD_HandleTypeDef hUsbDeviceHS;
+
+void alchemy_usb_composite_bind(USBD_HandleTypeDef* pdev);
+extern USBD_ClassTypeDef alchemy_usb_composite_class;
+
+static bool s_started = false;
+static const char* s_product = "Alchemy Lab";
+
+static uint8_t s_str_buf[USBD_MAX_STR_DESC_SIZ];
+
+static uint8_t* DeviceDesc(USBD_SpeedTypeDef speed, uint16_t* length)
+{
+    (void)speed;
+    *length = (uint16_t)ALCHEMY_USB_DEV_DESC_SIZE;
+    return (uint8_t*)(uintptr_t)alchemy_usb_dev_desc;
+}
+
+static uint8_t* LangIdDesc(USBD_SpeedTypeDef speed, uint16_t* length)
+{
+    static uint8_t lang_id[4] = {0x04, USB_DESC_TYPE_STRING, 0x09, 0x04};
+    (void)speed;
+    *length = 4U;
+    return lang_id;
+}
+
+static uint8_t* StringDesc(const char* s, uint16_t* length)
+{
+    USBD_GetString((uint8_t*)(uintptr_t)s, s_str_buf, length);
+    return s_str_buf;
+}
+
+static uint8_t* ManufacturerDesc(USBD_SpeedTypeDef speed, uint16_t* length)
+{
+    (void)speed;
+    return StringDesc("Hermetic Modular", length);
+}
+
+static uint8_t* ProductDesc(USBD_SpeedTypeDef speed, uint16_t* length)
+{
+    (void)speed;
+    return StringDesc(s_product, length);
+}
+
+static uint8_t* SerialDesc(USBD_SpeedTypeDef speed, uint16_t* length)
+{
+    static char serial[25];
+    (void)speed;
+    if (serial[0] == '\0')
+    {
+        snprintf(serial, sizeof serial, "%08lX%08lX%08lX",
+                 (unsigned long)HAL_GetUIDw2(), (unsigned long)HAL_GetUIDw1(),
+                 (unsigned long)HAL_GetUIDw0());
+    }
+    return StringDesc(serial, length);
+}
+
+static uint8_t* ConfigDesc(USBD_SpeedTypeDef speed, uint16_t* length)
+{
+    (void)speed;
+    return StringDesc("Alchemy Config", length);
+}
+
+static uint8_t* InterfaceDesc(USBD_SpeedTypeDef speed, uint16_t* length)
+{
+    (void)speed;
+    return StringDesc("Alchemy Interface", length);
+}
+
+static USBD_DescriptorsTypeDef AlchemyUsb_Desc = {
+    .GetDeviceDescriptor = DeviceDesc,
+    .GetLangIDStrDescriptor = LangIdDesc,
+    .GetManufacturerStrDescriptor = ManufacturerDesc,
+    .GetProductStrDescriptor = ProductDesc,
+    .GetSerialStrDescriptor = SerialDesc,
+    .GetConfigurationStrDescriptor = ConfigDesc,
+    .GetInterfaceStrDescriptor = InterfaceDesc,
+};
+
+void alchemy_usb_start(AlchemyUsbPeriph periph, const char* product_name)
+{
+    if (s_started)
+    {
+        return;
+    }
+    s_started = true;
+
+    if (product_name != NULL)
+    {
+        s_product = product_name;
+    }
+
+    USBD_HandleTypeDef* pdev;
+    USBD_CDC_ItfTypeDef* fops;
+    uint8_t dev_id;
+
+    if (periph == ALCHEMY_USB_PERIPH_HS)
+    {
+        pdev = &hUsbDeviceHS;
+        fops = &USBD_Interface_fops_HS;
+        dev_id = DEVICE_HS;
+    }
+    else
+    {
+        pdev = &hUsbDeviceFS;
+        fops = &USBD_Interface_fops_FS;
+        dev_id = DEVICE_FS;
+    }
+
+    USBD_Init(pdev, &AlchemyUsb_Desc, dev_id);
+
+    /* Re-sequence the FIFO map over libDaisy's two-FIFO default for the
+     * two extra IN endpoints.  HAL_PCDEx_SetTxFiFo derives each offset
+     * from the live registers, so a full in-order pass is consistent.
+     * HS: 1008/1024 words.  FS: 320/320. */
+    PCD_HandleTypeDef* hpcd = (PCD_HandleTypeDef*)pdev->pData;
+    if (dev_id == DEVICE_HS)
+    {
+        HAL_PCDEx_SetRxFiFo(hpcd, 0x200);
+        HAL_PCDEx_SetTxFiFo(hpcd, 0, 0x80);
+        HAL_PCDEx_SetTxFiFo(hpcd, 1, 0x120);
+        HAL_PCDEx_SetTxFiFo(hpcd, 2, 0x10);
+        HAL_PCDEx_SetTxFiFo(hpcd, 3, 0x40);
+    }
+    else
+    {
+        HAL_PCDEx_SetRxFiFo(hpcd, 0x80);
+        HAL_PCDEx_SetTxFiFo(hpcd, 0, 0x40);
+        HAL_PCDEx_SetTxFiFo(hpcd, 1, 0x40);
+        HAL_PCDEx_SetTxFiFo(hpcd, 2, 0x10);
+        HAL_PCDEx_SetTxFiFo(hpcd, 3, 0x30);
+    }
+
+    USBD_RegisterClass(pdev, &alchemy_usb_composite_class);
+    USBD_CDC_RegisterInterface(pdev, fops);
+    alchemy_usb_composite_bind(pdev);
+    USBD_Start(pdev);
+
+    HAL_PWREx_EnableUSBVoltageDetector();
+}

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -54,3 +54,15 @@ target_compile_definitions(hostlink_tests PRIVATE ALCHEMY_HOSTLINK_MAX_BODY=2048
 target_link_libraries(hostlink_tests PRIVATE alchemy::primitives)
 
 add_test(NAME hostlink COMMAND hostlink_tests)
+
+# Composite-USB descriptor golden + MIDI codec/tracker/service tests.
+add_executable(midi_tests
+    midi_tests.cpp
+    "${SDK_ROOT}/framework/src/usb/usb_descriptors.c"
+    "${SDK_ROOT}/framework/src/midi/mono_note_tracker.cpp"
+    "${SDK_ROOT}/framework/src/midi/poly_note_allocator.cpp"
+    "${SDK_ROOT}/framework/src/midi/usb_midi.cpp"
+)
+target_link_libraries(midi_tests PRIVATE alchemy::primitives)
+
+add_test(NAME midi COMMAND midi_tests)

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -952,6 +952,27 @@ static void TestAutoDescribe()
     }
 }
 
+static void TestSettingsNamedFields()
+{
+    /* Declared .Name()/.Labels() on a settings slot replace the
+     * kind-derived field name and ride the enum disp — the mechanism
+     * the MIDI settings recipes use. */
+    SurfaceFixture sf;
+    static const char* kChLabels[3] = {"Omni", "1", "2"};
+    sf.settings.Page(2).Pot(0).Selector(3)
+        .Name("MIDI Channel")
+        .Labels(kChLabels, 3);
+
+    static char buf[16384];
+    const uint32_t len = RenderDescriptor(buf, sizeof buf, kAutoInfo,
+                                          sf.presets, nullptr, nullptr, 0);
+    CHECK(len > 0u);
+    const std::string json(buf, len);
+    CHECK(json.find("\"name\":\"MIDI Channel\"") != std::string::npos);
+    CHECK(json.find("{\"kind\":\"enum\",\"labels\":[\"Omni\",\"1\",\"2\"]}")
+          != std::string::npos);
+}
+
 static void TestAutoDescribeGenericAndOverrides()
 {
     RamFlash flash;
@@ -1724,6 +1745,7 @@ int main(int argc, char** argv)
     TestTornWrite();
     TestDescriptorBuilder();
     TestAutoDescribe();
+    TestSettingsNamedFields();
     TestAutoDescribeGenericAndOverrides();
     TestButtonsEmission();
     TestComponentMeta();

--- a/tests/host/midi_tests.cpp
+++ b/tests/host/midi_tests.cpp
@@ -1,0 +1,842 @@
+/**
+ * @file tests/host/midi_tests.cpp
+ * @brief Descriptor golden + codec / tracker / UsbMidi service tests
+ *        (service runs against the fake alchemy_usb layer below).
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include "alchemy/midi/midi_event.h"
+#include "alchemy/midi/mono_note_tracker.h"
+#include "alchemy/midi/poly_note_allocator.h"
+#include "alchemy/midi/usb_midi.h"
+#include "alchemy/usb/usb_descriptors.h"
+
+using namespace alchemy::midi;
+
+static int g_checks   = 0;
+static int g_failures = 0;
+
+#define CHECK(cond)                                                        \
+    do {                                                                   \
+        g_checks++;                                                        \
+        if (!(cond)) {                                                     \
+            g_failures++;                                                  \
+            std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);    \
+        }                                                                  \
+    } while (0)
+
+#define CHECK_EQ(a, b)                                                     \
+    do {                                                                   \
+        g_checks++;                                                        \
+        const auto va = (a);                                               \
+        const auto vb = (b);                                               \
+        if (!(va == vb)) {                                                 \
+            g_failures++;                                                  \
+            std::printf("FAIL %s:%d  %s == %s  (%llu != %llu)\n",          \
+                        __FILE__, __LINE__, #a, #b,                        \
+                        (unsigned long long)va, (unsigned long long)vb);   \
+        }                                                                  \
+    } while (0)
+
+/* ── Fake alchemy_usb layer ────────────────────────────────────────── */
+
+static AlchemyUsbMidiRxFn fake_rx_fn  = nullptr;
+static void*              fake_rx_ctx = nullptr;
+static bool               fake_configured = true;
+static bool               fake_tx_ready   = true;
+static std::vector<std::vector<uint8_t>> fake_tx_bursts;
+
+extern "C" {
+void alchemy_usb_start(AlchemyUsbPeriph periph, const char* product_name)
+{
+    (void)periph;
+    (void)product_name;
+}
+bool alchemy_usb_configured(void) { return fake_configured; }
+void alchemy_usb_midi_set_rx(AlchemyUsbMidiRxFn fn, void* ctx)
+{
+    fake_rx_fn  = fn;
+    fake_rx_ctx = ctx;
+}
+bool alchemy_usb_midi_tx_ready(void) { return fake_configured && fake_tx_ready; }
+uint16_t alchemy_usb_midi_write(const uint8_t* packets, uint16_t len)
+{
+    if (!fake_configured || !fake_tx_ready)
+        return 0u;
+    fake_tx_bursts.emplace_back(packets, packets + len);
+    return len;
+}
+}
+
+static void Inject(const uint8_t* pkt) { fake_rx_fn(pkt, fake_rx_ctx); }
+static void Inject4(uint8_t a, uint8_t b, uint8_t c, uint8_t d)
+{
+    const uint8_t p[4] = {a, b, c, d};
+    Inject(p);
+}
+
+/* ── Descriptor tests ──────────────────────────────────────────────── */
+
+static uint32_t Fnv1a(const uint8_t* p, size_t n)
+{
+    uint32_t h = 0x811C9DC5u;
+    for (size_t i = 0; i < n; i++)
+    {
+        h ^= p[i];
+        h *= 16777619u;
+    }
+    return h;
+}
+
+/* Byte-exact pins — changing them is a host-visible USB shape change:
+ * bump ALCHEMY_USB_BCD_DEVICE alongside. */
+static constexpr uint32_t kDevDescPin = 0xF314E77Du;
+static constexpr uint32_t kCfgDescPin = 0xC511C565u;
+
+static void TestDescriptors()
+{
+    CHECK_EQ(alchemy_usb_dev_desc[0], 18u);
+    CHECK_EQ(alchemy_usb_dev_desc[1], 0x01u);
+    CHECK_EQ(alchemy_usb_dev_desc[4], 0xEFu);
+    CHECK_EQ(alchemy_usb_dev_desc[5], 0x02u);
+    CHECK_EQ(alchemy_usb_dev_desc[6], 0x01u);
+    const uint16_t bcd = static_cast<uint16_t>(alchemy_usb_dev_desc[12]
+                                               | (alchemy_usb_dev_desc[13]
+                                                  << 8));
+    CHECK_EQ(bcd, ALCHEMY_USB_BCD_DEVICE);
+
+    const uint8_t* d = alchemy_usb_cfg_desc;
+    const uint16_t total = static_cast<uint16_t>(d[2] | (d[3] << 8));
+    CHECK_EQ(total, ALCHEMY_USB_CFG_DESC_SIZE);
+    CHECK_EQ(d[4], ALCHEMY_USB_NUM_INTERFACES);
+    CHECK_EQ(d[7], 0xC0u); /* self-powered */
+
+    /* Walk: every bLength consumes exactly the blob. */
+    bool     saw_if[4]  = {};
+    uint8_t  if_class[4] = {};
+    int      num_iads   = 0;
+    uint8_t  iad_cover  = 0u;
+    std::vector<uint8_t> eps;
+    uint16_t ms_cs_off = 0u, ms_cs_total = 0u;
+
+    uint16_t off = d[0];
+    while (off < total)
+    {
+        const uint8_t len  = d[off];
+        const uint8_t type = d[off + 1u];
+        CHECK(len >= 2u);
+        CHECK(off + len <= total);
+
+        if (type == 0x0Bu)
+        {
+            num_iads++;
+            for (uint8_t i = 0; i < d[off + 3u]; i++)
+                iad_cover |= static_cast<uint8_t>(1u << (d[off + 2u] + i));
+        }
+        else if (type == 0x04u)
+        {
+            const uint8_t num = d[off + 2u];
+            if (num < 4u)
+            {
+                saw_if[num]   = true;
+                if_class[num] = d[off + 5u];
+            }
+        }
+        else if (type == 0x05u)
+        {
+            eps.push_back(d[off + 2u]);
+        }
+        else if (type == 0x24u && d[off + 2u] == 0x01u && len == 7u)
+        {
+            ms_cs_off   = off;
+            ms_cs_total = static_cast<uint16_t>(d[off + 5u]
+                                                | (d[off + 6u] << 8));
+        }
+        off = static_cast<uint16_t>(off + len);
+    }
+    CHECK_EQ(off, total);
+
+    CHECK(saw_if[0] && saw_if[1] && saw_if[2] && saw_if[3]);
+    CHECK_EQ(if_class[0], 0x02u);
+    CHECK_EQ(if_class[1], 0x0Au);
+    CHECK_EQ(if_class[2], 0x01u);
+    CHECK_EQ(if_class[3], 0x01u);
+
+    CHECK_EQ(num_iads, 2);
+    CHECK_EQ(iad_cover, 0x0Fu);
+
+    CHECK_EQ(eps.size(), 5u);
+    const uint8_t want_eps[5] = {ALCHEMY_CDC_CMD_EP, ALCHEMY_CDC_OUT_EP,
+                                 ALCHEMY_CDC_IN_EP, ALCHEMY_MIDI_OUT_EP,
+                                 ALCHEMY_MIDI_IN_EP};
+    for (size_t i = 0; i < eps.size() && i < 5u; i++)
+        CHECK_EQ(eps[i], want_eps[i]);
+
+    /* MS class-specific total spans from its header to the blob end. */
+    CHECK(ms_cs_off != 0u);
+    CHECK_EQ(ms_cs_total, static_cast<uint16_t>(total - ms_cs_off));
+
+    const uint32_t dev_h = Fnv1a(alchemy_usb_dev_desc,
+                                 ALCHEMY_USB_DEV_DESC_SIZE);
+    const uint32_t cfg_h = Fnv1a(alchemy_usb_cfg_desc,
+                                 ALCHEMY_USB_CFG_DESC_SIZE);
+    if (dev_h != kDevDescPin || cfg_h != kCfgDescPin)
+    {
+        std::printf("descriptor pins: dev 0x%08X cfg 0x%08X\n",
+                    (unsigned)dev_h, (unsigned)cfg_h);
+    }
+    CHECK_EQ(dev_h, kDevDescPin);
+    CHECK_EQ(cfg_h, kCfgDescPin);
+}
+
+/* ── Codec tests ───────────────────────────────────────────────────── */
+
+static void TestCodec()
+{
+    MidiEvent ev;
+
+    uint8_t pkt[4];
+    const MidiEvent note_on = MidiEvent::Make(MidiMsg::NoteOn, 4u, 60u, 100u);
+    CHECK(EventToUsbPacket(note_on, 0u, pkt));
+    CHECK_EQ(pkt[0], 0x09u);
+    CHECK_EQ(pkt[1], 0x94u);
+    CHECK(EventFromUsbPacket(pkt, ev));
+    CHECK_EQ(ev.status, 0x94u);
+    CHECK_EQ(ev.d1, 60u);
+    CHECK_EQ(ev.d2, 100u);
+    CHECK(ev.IsChannelVoice());
+    CHECK_EQ(ev.Channel(), 4u);
+    CHECK(ev.Type() == MidiMsg::NoteOn);
+
+    const MidiEvent prog = MidiEvent::Make(MidiMsg::ProgramChange, 2u, 7u);
+    CHECK(EventToUsbPacket(prog, 0u, pkt));
+    CHECK_EQ(pkt[0], 0x0Cu);
+    CHECK(EventFromUsbPacket(pkt, ev));
+    CHECK_EQ(ev.status, 0xC2u);
+    CHECK_EQ(ev.d1, 7u);
+
+    MidiEvent clk;
+    clk.status = 0xF8u;
+    CHECK(EventToUsbPacket(clk, 0u, pkt));
+    CHECK_EQ(pkt[0], 0x0Fu);
+    CHECK(EventFromUsbPacket(pkt, ev));
+    CHECK_EQ(ev.status, 0xF8u);
+
+    MidiEvent spp;
+    spp.status = 0xF2u;
+    spp.d1     = 0x10u;
+    spp.d2     = 0x02u;
+    CHECK(EventToUsbPacket(spp, 0u, pkt));
+    CHECK_EQ(pkt[0], 0x03u);
+    CHECK(EventFromUsbPacket(pkt, ev));
+    CHECK_EQ(ev.status, 0xF2u);
+    CHECK_EQ(ev.d1, 0x10u);
+    CHECK_EQ(ev.d2, 0x02u);
+
+    /* Bend helper */
+    MidiEvent bend = MidiEvent::Make(MidiMsg::PitchBend, 0u, 0x00u, 0x40u);
+    CHECK_EQ(bend.Bend14(), 0x2000u);
+
+    /* SysEx spans decode to nothing (v1 policy: tolerated, discarded) */
+    const uint8_t syx_start[4] = {0x04u, 0xF0u, 0x01u, 0x02u};
+    const uint8_t syx_end[4]   = {0x07u, 0x03u, 0x04u, 0xF7u};
+    CHECK(!EventFromUsbPacket(syx_start, ev));
+    CHECK(!EventFromUsbPacket(syx_end, ev));
+
+    /* CIN 5 is tune request only when the byte says so */
+    const uint8_t tune[4]    = {0x05u, 0xF6u, 0u, 0u};
+    const uint8_t syx1[4]    = {0x05u, 0xF7u, 0u, 0u};
+    CHECK(EventFromUsbPacket(tune, ev));
+    CHECK_EQ(ev.status, 0xF6u);
+    CHECK(!EventFromUsbPacket(syx1, ev));
+
+    /* Reserved CINs */
+    const uint8_t resv[4] = {0x00u, 0x90u, 60u, 100u};
+    CHECK(!EventFromUsbPacket(resv, ev));
+}
+
+/* ── Tracker tests ─────────────────────────────────────────────────── */
+
+static void TestTracker()
+{
+    MonoNoteTracker t;
+
+    CHECK(!t.GateHigh());
+    t.NoteOn(60u, 100u);
+    CHECK(t.GateHigh());
+    CHECK_EQ(t.Note(), 60u);
+    CHECK_EQ(t.Velocity(), 100u);
+    CHECK(t.TakeRetrigger());
+    CHECK(!t.TakeRetrigger());
+
+    /* Last priority: new note wins, release returns legato */
+    t.NoteOn(64u, 90u);
+    CHECK_EQ(t.Note(), 64u);
+    CHECK(t.TakeRetrigger());
+    t.NoteOff(64u);
+    CHECK(t.GateHigh());
+    CHECK_EQ(t.Note(), 60u);
+    CHECK_EQ(t.Velocity(), 100u);
+    CHECK(!t.TakeRetrigger());
+    t.NoteOff(60u);
+    CHECK(!t.GateHigh());
+    CHECK_EQ(t.Note(), 60u); /* pitch holds through release tail */
+
+    /* Low priority: higher press doesn't steal, lower does */
+    MonoNoteTracker low;
+    low.SetPriority(MonoNoteTracker::Priority::Low);
+    low.NoteOn(48u, 80u);
+    (void)low.TakeRetrigger();
+    low.NoteOn(72u, 90u);
+    CHECK_EQ(low.Note(), 48u);
+    CHECK(!low.TakeRetrigger());
+    low.NoteOn(36u, 70u);
+    CHECK_EQ(low.Note(), 36u);
+    CHECK(low.TakeRetrigger());
+    low.NoteOff(36u);
+    CHECK_EQ(low.Note(), 48u);
+
+    /* High priority */
+    MonoNoteTracker high;
+    high.SetPriority(MonoNoteTracker::Priority::High);
+    high.NoteOn(60u, 80u);
+    high.NoteOn(72u, 90u);
+    CHECK_EQ(high.Note(), 72u);
+    high.NoteOn(65u, 85u);
+    CHECK_EQ(high.Note(), 72u);
+    high.NoteOff(72u);
+    CHECK_EQ(high.Note(), 65u);
+
+    /* Retrig on return, opt-in */
+    MonoNoteTracker rt;
+    rt.RetrigOnReturn(true);
+    rt.NoteOn(60u, 100u);
+    (void)rt.TakeRetrigger();
+    rt.NoteOn(64u, 100u);
+    (void)rt.TakeRetrigger();
+    rt.NoteOff(64u);
+    CHECK(rt.TakeRetrigger());
+
+    /* Same-note restrike retrigs */
+    MonoNoteTracker rs;
+    rs.NoteOn(60u, 100u);
+    (void)rs.TakeRetrigger();
+    rs.NoteOn(60u, 110u);
+    CHECK(rs.TakeRetrigger());
+    CHECK_EQ(rs.Velocity(), 110u);
+    CHECK_EQ(rs.HeldCount(), 1u);
+
+    /* Overflow drops oldest */
+    MonoNoteTracker of;
+    for (uint8_t i = 0u; i < MonoNoteTracker::kCapacity + 4u; i++)
+        of.NoteOn(static_cast<uint8_t>(20u + i), 100u);
+    CHECK_EQ(of.HeldCount(), MonoNoteTracker::kCapacity);
+    of.Clear();
+    CHECK(!of.GateHigh());
+}
+
+/* ── Service tests ─────────────────────────────────────────────────── */
+
+static void TestService()
+{
+    static UsbMidi midi;
+    static MonoNoteTracker tracker;
+    static std::vector<MidiEvent> seen;
+    static uint32_t clock_pulses = 0u;
+
+    seen.clear();
+    fake_tx_bursts.clear();
+    fake_configured = true;
+    fake_tx_ready   = true;
+
+    midi.Init();
+    CHECK(fake_rx_fn != nullptr);
+
+    midi.UseTracker(tracker)
+        .SetChannel(4u)
+        .OnEvent([](const MidiEvent& ev, void*) { seen.push_back(ev); },
+                 nullptr)
+        .OnClockPulse([](uint32_t, void*) { clock_pulses++; }, nullptr);
+
+    /* Channel filter */
+    Inject4(0x09u, 0x95u, 60u, 100u); /* ch 5: dropped */
+    Inject4(0x09u, 0x94u, 60u, 100u); /* ch 4: kept    */
+    midi.Poll(0u);
+    CHECK_EQ(seen.size(), 1u);
+    CHECK(tracker.GateHigh());
+    CHECK_EQ(tracker.Note(), 60u);
+
+    /* NoteOn vel 0 → NoteOff */
+    Inject4(0x09u, 0x94u, 60u, 0u);
+    midi.Poll(1u);
+    CHECK_EQ(seen.size(), 2u);
+    CHECK(seen.back().Type() == MidiMsg::NoteOff);
+    CHECK(!tracker.GateHigh());
+
+    /* CC 123 clears */
+    Inject4(0x09u, 0x94u, 62u, 100u);
+    midi.Poll(2u);
+    CHECK(tracker.GateHigh());
+    Inject4(0x0Bu, 0xB4u, 123u, 0u);
+    midi.Poll(3u);
+    CHECK(!tracker.GateHigh());
+
+    /* Bend cache + helper */
+    Inject4(0x0Eu, 0xE4u, 0x00u, 0x60u);
+    midi.Poll(4u);
+    CHECK_EQ(midi.PitchBend14(), 0x3000u);
+    CHECK(midi.BendSemis(2.0f) > 0.99f && midi.BendSemis(2.0f) < 1.01f);
+
+    /* Clock: IRQ path only, never queued */
+    const uint32_t drops_before = midi.RxDropped();
+    for (int i = 0; i < 1000; i++)
+        Inject4(0x0Fu, 0xF8u, 0u, 0u);
+    CHECK_EQ(clock_pulses, 1000u);
+    CHECK_EQ(midi.ClockCount(), 1000u);
+    CHECK_EQ(midi.RxDropped(), drops_before);
+    midi.Poll(5u);
+    const size_t seen_after_clock = seen.size();
+    CHECK_EQ(seen_after_clock, 5u); /* no clock events dispatched */
+
+    /* Start/Stop do queue */
+    Inject4(0x0Fu, 0xFAu, 0u, 0u);
+    Inject4(0x0Fu, 0xFCu, 0u, 0u);
+    midi.Poll(6u);
+    CHECK_EQ(seen.size(), 7u);
+    CHECK(seen[5].Type() == MidiMsg::Start);
+    CHECK(seen[6].Type() == MidiMsg::Stop);
+
+    /* Active sensing ignored */
+    Inject4(0x0Fu, 0xFEu, 0u, 0u);
+    midi.Poll(7u);
+    CHECK_EQ(seen.size(), 7u);
+
+    /* Disconnect drops the gate */
+    Inject4(0x09u, 0x94u, 65u, 100u);
+    midi.Poll(8u);
+    CHECK(tracker.GateHigh());
+    fake_configured = false;
+    midi.Poll(9u);
+    CHECK(!tracker.GateHigh());
+    CHECK_EQ(midi.PitchBend14(), 0x2000u);
+    fake_configured = true;
+
+    /* TX: three events → one 12-byte burst */
+    midi.SendNoteOn(0u, 60u, 100u);
+    midi.SendControlChange(0u, 1u, 64u);
+    midi.SendNoteOff(0u, 60u);
+    midi.Poll(10u);
+    CHECK_EQ(fake_tx_bursts.size(), 1u);
+    CHECK_EQ(fake_tx_bursts[0].size(), 12u);
+    CHECK_EQ(fake_tx_bursts[0][0], 0x09u);
+    CHECK_EQ(fake_tx_bursts[0][4], 0x0Bu);
+    CHECK_EQ(fake_tx_bursts[0][8], 0x08u);
+
+    /* TX busy: queued until ready */
+    fake_tx_ready = false;
+    midi.SendNoteOn(0u, 61u, 100u);
+    midi.Poll(11u);
+    CHECK_EQ(fake_tx_bursts.size(), 1u);
+    fake_tx_ready = true;
+    midi.Poll(12u);
+    CHECK_EQ(fake_tx_bursts.size(), 2u);
+    CHECK_EQ(fake_tx_bursts[1].size(), 4u);
+
+    /* RX ring overflow is counted, then drains */
+    for (int i = 0; i < 400; i++)
+        Inject4(0x0Bu, 0xB4u, 1u, static_cast<uint8_t>(i & 0x7Fu));
+    CHECK(midi.RxDropped() > 0u);
+    midi.Poll(13u);
+    CHECK(seen.size() > seen_after_clock);
+}
+
+/* ── Mono sustain ──────────────────────────────────────────────────── */
+
+static void TestMonoSustain()
+{
+    MonoNoteTracker t;
+
+    t.NoteOn(60u, 100u);
+    t.SetSustain(true);
+    t.NoteOff(60u);
+    CHECK(t.GateHigh());
+    CHECK_EQ(t.Note(), 60u);
+    t.SetSustain(false);
+    CHECK(!t.GateHigh());
+
+    /* Re-press of a sustained note retriggers. */
+    t.NoteOn(60u, 100u);
+    (void)t.TakeRetrigger();
+    t.SetSustain(true);
+    t.NoteOff(60u);
+    t.NoteOn(60u, 90u);
+    CHECK(t.TakeRetrigger());
+    CHECK_EQ(t.Velocity(), 90u);
+    t.NoteOff(60u);
+    CHECK(t.GateHigh()); /* sustained again */
+    t.SetSustain(false);
+    CHECK(!t.GateHigh());
+
+    /* Held note survives pedal release; sustained ones drop. */
+    t.NoteOn(48u, 80u);
+    t.SetSustain(true);
+    t.NoteOn(52u, 80u);
+    t.NoteOff(52u);
+    t.SetSustain(false);
+    CHECK(t.GateHigh());
+    CHECK_EQ(t.Note(), 48u);
+    CHECK_EQ(t.HeldCount(), 1u);
+    t.Clear();
+}
+
+/* ── Poly allocator ────────────────────────────────────────────────── */
+
+static void TestPolyAllocator()
+{
+    PolyNoteAllocator a;
+    a.SetVoiceCount(4u);
+
+    a.NoteOn(0u, 60u, 100u);
+    a.NoteOn(0u, 64u, 90u);
+    a.NoteOn(0u, 67u, 80u);
+    a.NoteOn(0u, 71u, 70u);
+    CHECK_EQ(a.GatedCount(), 4u);
+    bool notes_seen[4] = {};
+    for (uint8_t i = 0u; i < 4u; i++)
+    {
+        CHECK(a.TakeRetrigger(i));
+        switch (a.VoiceAt(i).note)
+        {
+            case 60u: notes_seen[0] = true; break;
+            case 64u: notes_seen[1] = true; break;
+            case 67u: notes_seen[2] = true; break;
+            case 71u: notes_seen[3] = true; break;
+        }
+    }
+    CHECK(notes_seen[0] && notes_seen[1] && notes_seen[2] && notes_seen[3]);
+
+    /* Oldest steal (default): 5th note replaces note 60. */
+    a.NoteOn(0u, 74u, 100u);
+    CHECK_EQ(a.GatedCount(), 4u);
+    bool has60 = false, has74 = false;
+    for (uint8_t i = 0u; i < 4u; i++)
+    {
+        if (a.VoiceAt(i).note == 60u && a.VoiceAt(i).gate) has60 = true;
+        if (a.VoiceAt(i).note == 74u && a.VoiceAt(i).gate) has74 = true;
+    }
+    CHECK(!has60);
+    CHECK(has74);
+
+    /* Lowest steal. */
+    PolyNoteAllocator lo;
+    lo.SetVoiceCount(2u).SetSteal(PolyNoteAllocator::Steal::Lowest);
+    lo.NoteOn(0u, 40u, 100u);
+    lo.NoteOn(0u, 50u, 100u);
+    lo.NoteOn(0u, 60u, 100u);
+    bool has40 = false;
+    for (uint8_t i = 0u; i < 2u; i++)
+        if (lo.VoiceAt(i).note == 40u && lo.VoiceAt(i).gate) has40 = true;
+    CHECK(!has40);
+
+    /* None: new note drops when full. */
+    PolyNoteAllocator none;
+    none.SetVoiceCount(2u).SetSteal(PolyNoteAllocator::Steal::None);
+    none.NoteOn(0u, 40u, 100u);
+    none.NoteOn(0u, 50u, 100u);
+    none.NoteOn(0u, 60u, 100u);
+    bool has60n = false;
+    for (uint8_t i = 0u; i < 2u; i++)
+        if (none.VoiceAt(i).note == 60u) has60n = true;
+    CHECK(!has60n);
+
+    /* Note-off frees; freed voice is reused least-recently-released
+     * first. */
+    PolyNoteAllocator f;
+    f.SetVoiceCount(4u);
+    f.NoteOn(0u, 60u, 100u);
+    f.NoteOn(0u, 64u, 100u);
+    f.NoteOff(0u, 60u);
+    f.NoteOff(0u, 64u);
+    f.NoteOn(0u, 72u, 100u);
+    bool v72_in_60_slot = false;
+    for (uint8_t i = 0u; i < 4u; i++)
+        if (f.VoiceAt(i).note == 72u) v72_in_60_slot = true;
+    CHECK(v72_in_60_slot);
+    CHECK_EQ(f.GatedCount(), 1u);
+
+    /* Same-note re-press reuses the voice and retriggers. */
+    PolyNoteAllocator s;
+    s.SetVoiceCount(4u);
+    s.NoteOn(0u, 60u, 100u);
+    for (uint8_t i = 0u; i < 4u; i++) (void)s.TakeRetrigger(i);
+    s.NoteOn(0u, 60u, 90u);
+    CHECK_EQ(s.GatedCount(), 1u);
+    uint8_t v = 0xFFu;
+    for (uint8_t i = 0u; i < 4u; i++)
+        if (s.VoiceAt(i).gate && s.VoiceAt(i).note == 60u) v = i;
+    CHECK(v != 0xFFu);
+    CHECK(s.TakeRetrigger(v));
+    CHECK_EQ(s.VoiceAt(v).velocity, 90u);
+
+    /* Sustain: offs deferred, pedal-up releases; sustained re-press
+     * reclaims. */
+    PolyNoteAllocator su;
+    su.SetVoiceCount(4u);
+    su.SetSustain(true);
+    su.NoteOn(0u, 60u, 100u);
+    su.NoteOn(0u, 64u, 100u);
+    su.NoteOff(0u, 60u);
+    su.NoteOff(0u, 64u);
+    CHECK_EQ(su.GatedCount(), 2u);
+    su.NoteOn(0u, 60u, 80u);
+    CHECK_EQ(su.GatedCount(), 2u);
+    su.SetSustain(false);
+    CHECK_EQ(su.GatedCount(), 1u); /* re-pressed 60 survives */
+    su.Clear();
+    CHECK_EQ(su.GatedCount(), 0u);
+
+    /* Notes keyed per channel (MPE member channels). */
+    PolyNoteAllocator m;
+    m.SetVoiceCount(4u);
+    m.NoteOn(1u, 60u, 100u);
+    m.NoteOn(2u, 60u, 100u);
+    CHECK_EQ(m.GatedCount(), 2u);
+    m.NoteOff(1u, 60u);
+    CHECK_EQ(m.GatedCount(), 1u);
+}
+
+/* ── Service: sustain, expression, RPN, SysEx, TX ──────────────────── */
+
+static void TestServiceComplete()
+{
+    static UsbMidi midi;
+    static MonoNoteTracker tracker;
+    static PolyNoteAllocator alloc;
+    static std::vector<uint8_t> syx;
+    static bool syx_done = false;
+    static uint16_t last_rpn_param = 0xFFFFu;
+    static uint16_t last_rpn_val = 0u;
+    static bool last_rpn_nrpn = false;
+
+    syx.clear();
+    fake_tx_bursts.clear();
+    fake_configured = true;
+    fake_tx_ready   = true;
+
+    midi.Init();
+    alloc.SetVoiceCount(4u);
+    midi.UseTracker(tracker).UseAllocator(alloc).SetOmni();
+    midi.OnSysEx(
+        [](const uint8_t* d, uint8_t n, bool term, void*) {
+            syx.insert(syx.end(), d, d + n);
+            if (term) syx_done = true;
+        },
+        nullptr);
+    midi.OnRpn(
+        [](uint8_t, uint16_t param, uint16_t val, bool nrpn, void*) {
+            last_rpn_param = param;
+            last_rpn_val   = val;
+            last_rpn_nrpn  = nrpn;
+        },
+        nullptr);
+
+    /* CC64 routes to both consumers. */
+    Inject4(0x09u, 0x90u, 60u, 100u);
+    Inject4(0x0Bu, 0xB0u, 64u, 127u);
+    Inject4(0x08u, 0x80u, 60u, 0u);
+    midi.Poll(0u);
+    CHECK(tracker.GateHigh());
+    CHECK_EQ(alloc.GatedCount(), 1u);
+    Inject4(0x0Bu, 0xB0u, 64u, 0u);
+    midi.Poll(1u);
+    CHECK(!tracker.GateHigh());
+    CHECK_EQ(alloc.GatedCount(), 0u);
+
+    /* Per-channel expression caches. */
+    Inject4(0x0Eu, 0xE2u, 0x00u, 0x60u); /* ch2 bend up   */
+    Inject4(0x0Du, 0xD3u, 55u, 0u);      /* ch3 pressure  */
+    Inject4(0x0Bu, 0xB4u, 74u, 99u);     /* ch4 cc74      */
+    midi.Poll(2u);
+    CHECK_EQ(midi.PitchBend14(2u), 0x3000u);
+    CHECK_EQ(midi.PitchBend14(0u), 0x2000u);
+    CHECK_EQ(midi.ChannelPressure(3u), 55u);
+    CHECK_EQ(midi.Cc74(4u), 99u);
+
+    /* RPN 0 sets bend range; setting reasserts only on change. */
+    alchemy::SettingsSlot bend_slot;
+    bend_slot.kind      = alchemy::SettingsKind::Selector;
+    bend_slot.num_zones = UsbMidi::kBendRangeZones;
+    bend_slot.value_idx = 2u; /* ±2 */
+    alchemy::SelectorHandle bend(&bend_slot);
+    midi.UseBendRangeSetting(bend);
+    midi.Poll(3u);
+    CHECK(midi.BendRangeSemis() == 2.0f);
+
+    Inject4(0x0Bu, 0xB0u, 101u, 0u);
+    Inject4(0x0Bu, 0xB0u, 100u, 0u);
+    Inject4(0x0Bu, 0xB0u, 6u, 12u);
+    midi.Poll(4u);
+    CHECK(midi.BendRangeSemis() == 12.0f);
+    CHECK_EQ(last_rpn_param, 0u);
+    CHECK(!last_rpn_nrpn);
+    midi.Poll(5u); /* zone unchanged: RPN value holds */
+    CHECK(midi.BendRangeSemis() == 12.0f);
+    Inject4(0x0Bu, 0xB0u, 38u, 50u);
+    midi.Poll(6u);
+    CHECK(midi.BendRangeSemis() > 12.49f && midi.BendRangeSemis() < 12.51f);
+    bend_slot.value_idx = 1u; /* user moves the setting: ±1 wins */
+    midi.Poll(7u);
+    CHECK(midi.BendRangeSemis() == 1.0f);
+
+    /* NRPN reported as such, no bend-range effect. */
+    Inject4(0x0Bu, 0xB0u, 99u, 1u);
+    Inject4(0x0Bu, 0xB0u, 98u, 2u);
+    Inject4(0x0Bu, 0xB0u, 6u, 7u);
+    midi.Poll(8u);
+    CHECK(last_rpn_nrpn);
+    CHECK_EQ(last_rpn_param, static_cast<uint16_t>((1u << 7) | 2u));
+    CHECK(midi.BendRangeSemis() == 1.0f);
+
+    /* Null RPN disarms data entry. */
+    Inject4(0x0Bu, 0xB0u, 101u, 127u);
+    Inject4(0x0Bu, 0xB0u, 100u, 127u);
+    last_rpn_param = 0xFFFFu;
+    Inject4(0x0Bu, 0xB0u, 6u, 3u);
+    midi.Poll(9u);
+    CHECK_EQ(last_rpn_param, 0xFFFFu);
+
+    /* SysEx RX: chunks delivered raw, stream aligned after. */
+    Inject4(0x04u, 0xF0u, 0x7Du, 0x01u);
+    Inject4(0x07u, 0x02u, 0x03u, 0xF7u);
+    midi.Poll(10u);
+    CHECK(syx_done);
+    CHECK_EQ(syx.size(), 6u);
+    CHECK_EQ(syx[0], 0xF0u);
+    CHECK_EQ(syx[5], 0xF7u);
+    Inject4(0x09u, 0x90u, 62u, 100u);
+    midi.Poll(11u);
+    CHECK(tracker.GateHigh());
+    Inject4(0x08u, 0x80u, 62u, 0u);
+    midi.Poll(12u);
+
+    /* TX senders produce exact packets. */
+    fake_tx_bursts.clear();
+    midi.SendPitchBend(0u, 0x2000u);
+    midi.SendProgramChange(0u, 7u);
+    midi.SendRealtime(MidiMsg::Clock);
+    midi.Poll(13u);
+    CHECK_EQ(fake_tx_bursts.size(), 1u);
+    CHECK_EQ(fake_tx_bursts[0].size(), 12u);
+    CHECK_EQ(fake_tx_bursts[0][0], 0x0Eu);
+    CHECK_EQ(fake_tx_bursts[0][2], 0x00u);
+    CHECK_EQ(fake_tx_bursts[0][3], 0x40u);
+    CHECK_EQ(fake_tx_bursts[0][4], 0x0Cu);
+    CHECK_EQ(fake_tx_bursts[0][8], 0x0Fu);
+    CHECK_EQ(fake_tx_bursts[0][9], 0xF8u);
+
+    /* SysEx TX packetization: F0 01 02 03 04 F7 → 0x04 + 0x07. */
+    fake_tx_bursts.clear();
+    const uint8_t payload[4] = {0x01u, 0x02u, 0x03u, 0x04u};
+    CHECK(midi.SendSysEx(payload, 4u));
+    midi.Poll(14u);
+    CHECK_EQ(fake_tx_bursts.size(), 1u);
+    CHECK_EQ(fake_tx_bursts[0].size(), 8u);
+    CHECK_EQ(fake_tx_bursts[0][0], 0x04u);
+    CHECK_EQ(fake_tx_bursts[0][1], 0xF0u);
+    CHECK_EQ(fake_tx_bursts[0][4], 0x07u);
+    CHECK_EQ(fake_tx_bursts[0][7], 0xF7u);
+}
+
+/* ── Settings-recipe binding tests ─────────────────────────────────── */
+
+static void TestSettingsBindings()
+{
+    static UsbMidi midi;
+    static MonoNoteTracker tracker;
+    static std::vector<MidiEvent> seen;
+    seen.clear();
+    fake_configured = true;
+    fake_tx_ready   = true;
+
+    midi.Init();
+    midi.UseTracker(tracker).OnEvent(
+        [](const MidiEvent& ev, void*) { seen.push_back(ev); }, nullptr);
+
+    alchemy::SettingsSlot ch_slot;
+    ch_slot.kind      = alchemy::SettingsKind::Selector;
+    ch_slot.num_zones = UsbMidi::kChannelZones;
+    ch_slot.value_idx = 5u; /* channel 5 → filter ch index 4 */
+    alchemy::SelectorHandle ch(&ch_slot);
+    midi.UseChannelSetting(ch);
+
+    CHECK(ch_slot.name != nullptr
+          && std::strcmp(ch_slot.name, "MIDI Channel") == 0);
+    CHECK(ch_slot.zone_labels == UsbMidi::kChannelLabels);
+
+    Inject4(0x09u, 0x90u, 60u, 100u); /* ch 1: filtered out */
+    Inject4(0x09u, 0x94u, 60u, 100u); /* ch 5: passes       */
+    midi.Poll(0u);
+    CHECK_EQ(seen.size(), 1u);
+    CHECK_EQ(midi.Channel(), 4u);
+
+    ch_slot.value_idx = 0u; /* Omni: everything passes */
+    Inject4(0x09u, 0x91u, 62u, 100u);
+    midi.Poll(1u);
+    CHECK_EQ(seen.size(), 2u);
+    CHECK_EQ(midi.Channel(), UsbMidi::kOmni);
+
+    alchemy::SettingsSlot bend_slot;
+    bend_slot.kind      = alchemy::SettingsKind::Selector;
+    bend_slot.num_zones = UsbMidi::kBendRangeZones;
+    bend_slot.value_idx = 4u; /* ±12 st */
+    alchemy::SelectorHandle bend(&bend_slot);
+    midi.UseBendRangeSetting(bend);
+    CHECK(bend_slot.zone_labels == UsbMidi::kBendRangeLabels);
+
+    Inject4(0x0Eu, 0xE0u, 0x7Fu, 0x7Fu); /* full-up bend */
+    midi.Poll(2u);
+    CHECK(midi.BendSemis() > 11.9f && midi.BendSemis() <= 12.0f);
+    bend_slot.value_idx = 0u; /* Off */
+    midi.Poll(3u);
+    CHECK(midi.BendSemis() == 0.0f);
+
+    alchemy::SettingsSlot prio_slot;
+    prio_slot.kind      = alchemy::SettingsKind::Selector;
+    prio_slot.num_zones = UsbMidi::kPriorityZones;
+    prio_slot.value_idx = 1u; /* Low */
+    alchemy::SelectorHandle prio(&prio_slot);
+    midi.UsePrioritySetting(prio);
+
+    Inject4(0x09u, 0x90u, 48u, 100u);
+    Inject4(0x09u, 0x90u, 72u, 100u); /* higher press must not steal */
+    midi.Poll(4u);
+    CHECK_EQ(tracker.Note(), 48u);
+
+    /* Labels attach only on a zone-count match. */
+    alchemy::SettingsSlot bad_slot;
+    bad_slot.kind      = alchemy::SettingsKind::Selector;
+    bad_slot.num_zones = 4u;
+    alchemy::SelectorHandle bad(&bad_slot);
+    midi.UseBendRangeSetting(bad);
+    CHECK(bad_slot.zone_labels == nullptr);
+    CHECK(bad_slot.name != nullptr); /* still named */
+}
+
+int main()
+{
+    TestDescriptors();
+    TestCodec();
+    TestTracker();
+    TestMonoSustain();
+    TestPolyAllocator();
+    TestService();
+    TestServiceComplete();
+    TestSettingsBindings();
+
+    std::printf("midi_tests: %d checks, %d failures\n", g_checks, g_failures);
+    return g_failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
The front USB port now enumerates one  device for the existing CDC
HostLink function  plus class-compliant USB-MIDI.

- Fixed platform bcdDevice 0x0200 → 0x0210; descriptor bytes pinned
  in tests/host/midi_tests.cpp
- alchemy::midi: mono tracker + poly allocator, sustain, per-channel
  expression (MPE-capable), RPN/NRPN incl. RPN0 bend range, SysEx RX/TX,
  full TX senders, IRQ-timestamped clock for ClockFollower
- Settings selectors bind via UseChannel/BendRange/PrioritySetting and
  render named + labeled in the web editor (beta)
- VID/PID unchanged  pending a proper PID assignment. Application sent to STM for this.
