### PR TITLE
ClipIndicator: SDK clipping light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+# Unreleased
+
+## ClipIndicator: SDK clipping light
+
+- `alchemy::ClipIndicator` (`anims/clip_indicator.h`) — audio-fed clip light
+  with a 98 % full-scale threshold, leaky-bucket transient suppression (a
+  one-sample graze no longer flashes the panel), and a 50 ms minimum hold that
+  retriggers while clipping persists. Feed `Process()` from the audio callback
+  (ISR-safe single-word handoff); everything else is wired by `loop.Use(clip)`
+  — detection ticks at the poll cadence, pips draw above the perf render.
+- Declares like a VirtualKnob, with good defaults (every pot pip, red, 50 ms):
+
+  ```cpp
+  static ClipIndicator clip = ClipIndicator()
+      .Hold(120.0f)
+      .Pots(kPotTopLeft, kPotTopRight)
+      .Buttons(kButtonB3);
+  ```
+
+  Also `Threshold`, `Suppression(samples, window_ms)`, `Accent`, `PipHour`,
+  `Color`, `AllPots`, and `SetEnabled()` for a settings toggle. Bespoke loops
+  call `Tick(dt_ms)` / `Draw(panel)` directly; `Draw(panel, color)` serves
+  palette-driven modules.
+- The sample scan runs as integer bit-pattern compares (abs = clear the sign
+  bit; IEEE ordering is monotonic), so the audio-side cost is ~7 integer
+  instructions per checked sample with no FPU flag transfers — and it probes
+  at a stride derived from the suppression config (`min_clipped_samples / 2`,
+  capped at 16; 4 for the default 8), with each hit counting as one stride of
+  samples. The derivation keeps the suppression contract intact at any
+  setting — a lone sub-stride burst can never reach the trigger — while the
+  scan gets proportionally cheaper as suppression relaxes, and exact when it
+  drops below 4. Non-finite samples (NaN/Inf) count as clipped — a broken
+  signal lights the alarm.
+
 # Alchemy SDK v0.9.0 — 2026-08-14
 
 The first versioned Alchemy SDK release, trying out a new cadence instead of merging PRs as I please.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ Supported boards:
 
 <img src="media/hero.jpg" alt="Hero Hardware" width="600">
 
+## Documentation
+
+**The full narrative documentation lives on the Hermetic Modular website. Start
+there: [hermeticmodular.com/docs](https://hermeticmodular.com/docs)**
+
+It's a walkthrough of the whole SDK, Quickstart,
+Fundamentals, the control surfaces (knobs, buttons, pages, jacks,
+presets, settings), firmware anatomy, LED animations, etc.
+
+[<img src="https://hermeticmodular.com/og/docs/og-docs-index.jpg" alt="Alchemy SDK Documentation card over a rack of Hermetic Modular Eurorack modules" width="600">](https://hermeticmodular.com/docs)
+
 ## Beta notice and Community discussion
 
 The Alchemy SDK is in beta.  APIs, surface names, and on-disk preset

--- a/docs/ring-animations.md
+++ b/docs/ring-animations.md
@@ -194,9 +194,12 @@ the same math.
 
 ## Stateful animators
 
-`Sparkle` (spawn/decay scatter across the ring) and `BeatPip`
-(tempo-synced bottom pip) keep caller-owned state and compose alongside
-the stack. See `anims/sparkle.h` and `anims/beat_pip.h`.
+`Sparkle` (spawn/decay scatter across the ring), `BeatPip`
+(tempo-synced bottom pip), and `ClipIndicator` (audio-fed clipping
+light: 98 % threshold, transient suppression, minimum hold; pips on
+configurable pots and buttons) keep caller-owned state and compose
+alongside the stack. See `anims/sparkle.h`, `anims/beat_pip.h`, and
+`anims/clip_indicator.h`.
 
 ## ParamSlot migration (pre-composition firmwares)
 

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(alchemy_primitives STATIC
     src/led/anims/slot_indicator.cpp
     src/led/anims/sparkle.cpp
     src/led/anims/beat_pip.cpp
+    src/led/anims/clip_indicator.cpp
     src/led/anims/field.cpp
     src/led/ring_frame.cpp
     src/led/perf_renderer.cpp

--- a/framework/include/alchemy/led/animations.h
+++ b/framework/include/alchemy/led/animations.h
@@ -17,6 +17,7 @@
 #include "alchemy/led/anims/action_gesture.h"
 #include "alchemy/led/anims/slot_indicator.h"
 #include "alchemy/led/anims/sparkle.h"
+#include "alchemy/led/anims/clip_indicator.h"
 #include "alchemy/led/anims/field.h"
 #include "alchemy/led/ring_frame.h"
 #include "alchemy/led/signal.h"

--- a/framework/include/alchemy/led/anims/clip_indicator.h
+++ b/framework/include/alchemy/led/anims/clip_indicator.h
@@ -1,0 +1,151 @@
+/**
+ * @file alchemy/led/anims/clip_indicator.h
+ * @brief alchemy::ClipIndicator - audio-fed clipping light with transient
+ *        suppression and a minimum hold.
+ *
+ *   THRESHOLD    |sample| ≥ the threshold counts as clipped (default
+ *                0.98 of full scale.
+ *
+ *   SUPPRESSION  clipped samples feed a leaky bucket that drains fully
+ *                over a window (default 50 ms).  The light fires only
+ *                once enough of them accumulate (default 8)
+ *
+ *   HOLD         once fired, the light stays on at least `Hold` ms
+ *                (default 50) and retriggers while clipping persists.
+ *
+ *   STRIDE       Process probes every few samples rather than all of
+ *                them.  The stride is derived from the suppression
+ *                config (min_clipped_samples / 2, capped at 16 — so 4
+ *                for the default 8) and each hit counts as stride
+ *                samples, keeping counts in true-sample units.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+#include "alchemy/led/panel.h"
+
+namespace alchemy {
+
+class ClipIndicator
+{
+  public:
+    /** Which accent LED(s) light on a button passed to Buttons(). */
+    enum class ButtonAccent : uint8_t
+    {
+        Bottom,
+        Top,
+        Pair,
+    };
+
+    ClipIndicator() = default;
+
+    ClipIndicator& Threshold(float frac)
+    {
+        threshold_ = frac;
+        return *this;
+    }
+
+    ClipIndicator& Suppression(uint16_t min_clipped_samples,
+                               float    window_ms = 50.0f)
+    {
+        min_clipped_samples_ = min_clipped_samples ? min_clipped_samples : 1u;
+        window_ms_           = window_ms < 1.0f ? 1.0f : window_ms;
+
+        const uint16_t s = min_clipped_samples_ / 2u;
+        stride_ = static_cast<uint8_t>(s < 1u ? 1u : (s > 16u ? 16u : s));
+        return *this;
+    }
+
+    ClipIndicator& Hold(float ms)
+    {
+        hold_ms_ = ms < 0.0f ? 0.0f : ms;
+        return *this;
+    }
+
+    template <typename... Pot>
+    ClipIndicator& Pots(Pot... pots)
+    {
+        pot_mask_ = (0u | ... | Bit(static_cast<uint32_t>(pots)));
+        return *this;
+    }
+
+    ClipIndicator& AllPots()
+    {
+        pot_mask_ = 0xFFFFFFFFu;
+        return *this;
+    }
+
+    template <typename... Btn>
+    ClipIndicator& Buttons(Btn... btns)
+    {
+        button_mask_ = (0u | ... | Bit(static_cast<uint32_t>(btns)));
+        return *this;
+    }
+
+    ClipIndicator& Accent(ButtonAccent a)
+    {
+        accent_ = a;
+        return *this;
+    }
+
+    ClipIndicator& PipHour(float hour)
+    {
+        pip_hour_ = hour;
+        return *this;
+    }
+
+    ClipIndicator& Color(LedPanel::Rgb c)
+    {
+        color_ = c;
+        return *this;
+    }
+
+    /* ── Runtime switch ──────────────────────────────────────────────── */
+    void SetEnabled(bool on);
+    bool Enabled() const { return enabled_; }
+    void Reset();
+
+    /* ── Audio side ──────────────────────────────────────────────────── */
+    void Process(const float* in, size_t frames);
+    void Process(const float* const* in, size_t num_channels, size_t frames);
+
+    /* ── Control side ────────────────────────────────────────────────── */
+    void Tick(float dt_ms);
+    bool Lit() const { return lit_; }
+    void Draw(LedPanel& panel) const { Draw(panel, color_); }
+    void Draw(LedPanel& panel, LedPanel::Rgb color) const;
+
+  private:
+    /** Guarded single-bit mask (indices ≥ 32 contribute nothing). */
+    static constexpr uint32_t Bit(uint32_t idx)
+    {
+        return idx < 32u ? (1u << idx) : 0u;
+    }
+
+    /* ── Configuration ──────────────────────────────────────────────── */
+    float         threshold_           = 0.98f;
+    uint16_t      min_clipped_samples_ = 8u;
+    float         window_ms_           = 50.0f;
+    float         hold_ms_             = 50.0f;
+    uint8_t       stride_              = 4u;   ///< Derived: min_clipped/2 in [1,16].
+    uint32_t      pot_mask_            = 0xFFFFFFFFu;
+    uint32_t      button_mask_         = 0u;
+    ButtonAccent  accent_              = ButtonAccent::Pair;
+    float         pip_hour_            = 6.0f;
+    LedPanel::Rgb color_               = {0xFF, 0x00, 0x00};
+    bool          enabled_             = true;
+
+    /* ── ISR ↔ poll handoff ─────────────────────────────────────────── */
+    volatile uint32_t clip_count_ = 0u;  ///< Total clipped samples; wraps.
+
+    /* ── Tick-side state ────────────────────────────────────────────── */
+    uint32_t seen_count_        = 0u;    ///< clip_count_ at the last Tick.
+    float    credit_            = 0.0f;  ///< Suppression bucket fill.
+    float    hold_remaining_ms_ = 0.0f;
+    bool     lit_               = false;
+};
+
+} // namespace alchemy

--- a/framework/include/alchemy/surface/control_loop.h
+++ b/framework/include/alchemy/surface/control_loop.h
@@ -32,6 +32,7 @@
  *        buttons.PollButtons       (gated; gestures fire here, and may
  *                                   consume the pager's release)
  *        storage.PollButtons       (gated by settings)
+ *        clip.Tick                 (clip-light detection; never gated)
  *        OnPoll user hook
  *   2. phys[] snapshot
  *   3. settings.Update             (always runs; B2+B3 enter gesture)
@@ -46,14 +47,15 @@
  *        OnPageChange hook
  *        OnFrame user hook
  *   5. Render: clear → (Settings if active, else: PerfRenderer pass →
- *      custom rings → overdraw → page indicator → ButtonBank colors) →
- *      OnRender hook → LockSource overlay → leds.Show
+ *      custom rings → overdraw → page indicator → ButtonBank colors →
+ *      clip light) → OnRender hook → LockSource overlay → leds.Show
  */
 
 #pragma once
 
 #include <cstdint>
 #include "alchemy/hw/alchemy_lab_layout.h"   /* kNumPots, kNumCvInputs */
+#include "alchemy/led/anims/clip_indicator.h"
 #include "alchemy/led/perf_renderer.h"
 #include "alchemy/surface/cv_source.h"
 #include "alchemy/surface/host_service.h"
@@ -154,6 +156,8 @@ class ControlLoop
      * the page indicator (a mode color deliberately wins over the tint).
      */
     ControlLoop& Use(ButtonBank& bank);
+     /* Attach a ClipIndicator. */
+    ControlLoop& Use(ClipIndicator& c) { clip_ = &c; return *this; }
 
     /**
      * Attach a host-communication service (e.g. hostlink::Host).  Polled
@@ -229,12 +233,13 @@ class ControlLoop
     uint8_t num_cv_             = kNumCvInputs;
 
     /* Attached surfaces. */
-    KnobStorage* storage_      = nullptr;
-    LockSource*  locks_        = nullptr;
-    CvSource*    cv_source_    = nullptr;
-    Settings*    settings_     = nullptr;
-    HostService* host_service_ = nullptr;
-    ButtonBank*  buttons_      = nullptr;
+    KnobStorage*   storage_      = nullptr;
+    LockSource*    locks_        = nullptr;
+    CvSource*      cv_source_    = nullptr;
+    Settings*      settings_     = nullptr;
+    HostService*   host_service_ = nullptr;
+    ButtonBank*    buttons_      = nullptr;
+    ClipIndicator* clip_         = nullptr;
 
     /* IButton refs handed to the ButtonBank (uniform across boards). */
     IButton* btn_refs_[kNumButtons] = {};

--- a/framework/src/led/anims/clip_indicator.cpp
+++ b/framework/src/led/anims/clip_indicator.cpp
@@ -1,0 +1,118 @@
+/**
+ * @file alchemy/led/anims/clip_indicator.cpp
+ */
+
+#include "alchemy/led/anims/clip_indicator.h"
+
+#include <cstring>
+
+namespace alchemy {
+
+static_assert(sizeof(float) == sizeof(uint32_t),
+              "the Process fast path puns float bits into uint32_t");
+
+void ClipIndicator::SetEnabled(bool on)
+{
+    enabled_ = on;
+    Reset();
+}
+
+void ClipIndicator::Reset()
+{
+    seen_count_        = clip_count_;
+    credit_            = 0.0f;
+    hold_remaining_ms_ = 0.0f;
+    lit_               = false;
+}
+
+void ClipIndicator::Process(const float* in, size_t frames)
+{
+    if (!enabled_ || in == nullptr) return;
+
+    float t = threshold_ < 0.0f ? 0.0f : threshold_;
+    uint32_t t_bits;
+    std::memcpy(&t_bits, &t, sizeof t_bits);
+
+    /* Stride-spaced probe: each hit stands for `stride` samples, so the
+     * count Tick consumes stays in true-sample units. */
+    const size_t stride = stride_;
+    uint32_t     hits   = 0u;
+    for (size_t i = 0; i < frames; i += stride)
+    {
+        uint32_t u;
+        std::memcpy(&u, &in[i], sizeof u);
+        if ((u & 0x7FFFFFFFu) >= t_bits) hits++;
+    }
+    /* Single word store; Tick only ever reads this member. */
+    if (hits != 0u)
+        clip_count_ = clip_count_ + hits * static_cast<uint32_t>(stride);
+}
+
+void ClipIndicator::Process(const float* const* in,
+                            size_t              num_channels,
+                            size_t              frames)
+{
+    if (in == nullptr) return;
+    for (size_t ch = 0; ch < num_channels; ch++)
+        Process(in[ch], frames);
+}
+
+void ClipIndicator::Tick(float dt_ms)
+{
+    if (!enabled_) return;
+
+    const uint32_t now   = clip_count_;
+    const uint32_t fresh = now - seen_count_;
+    seen_count_          = now;
+
+    /* Leaky bucket: drains fully over the window, capped at the trigger
+     * level so release after heavy clipping stays bounded. */
+    const float trigger = static_cast<float>(min_clipped_samples_);
+    credit_ -= (trigger / window_ms_) * dt_ms;
+    if (credit_ < 0.0f) credit_ = 0.0f;
+    credit_ += static_cast<float>(fresh);
+    if (credit_ > trigger) credit_ = trigger;
+
+    const bool triggered = credit_ >= trigger;
+    if (triggered)
+        hold_remaining_ms_ = hold_ms_;
+    else
+    {
+        hold_remaining_ms_ -= dt_ms;
+        if (hold_remaining_ms_ < 0.0f) hold_remaining_ms_ = 0.0f;
+    }
+
+    lit_ = triggered || hold_remaining_ms_ > 0.0f;
+}
+
+void ClipIndicator::Draw(LedPanel& panel, LedPanel::Rgb color) const
+{
+    if (!enabled_ || !lit_) return;
+
+    const LedPanel::Rgb c = panel.ScaleGlobal(color);
+
+    uint32_t pots = pot_mask_;
+    for (uint8_t p = 0u; pots != 0u; p++, pots >>= 1u)
+        if (pots & 1u)
+            panel.SetRingByHour(p, pip_hour_, c);
+
+    uint32_t btns = button_mask_;
+    for (uint8_t b = 0u; btns != 0u; b++, btns >>= 1u)
+    {
+        if (!(btns & 1u)) continue;
+        switch (accent_)
+        {
+            case ButtonAccent::Bottom:
+                panel.SetButton(b, LedPanel::ButtonLed::Bottom, c);
+                break;
+            case ButtonAccent::Top:
+                panel.SetButton(b, LedPanel::ButtonLed::Top, c);
+                break;
+            case ButtonAccent::Pair:
+                panel.SetButtonPair(b, c);
+                break;
+        }
+    }
+}
+
+} // namespace alchemy

--- a/framework/src/surface/control_loop.cpp
+++ b/framework/src/surface/control_loop.cpp
@@ -70,6 +70,7 @@ void ControlLoop::Tick()
                                   storage_ ? storage_->ActivePage() : 0u);
         if (storage_) storage_->PollButtons(t_ms, gated);
         if (host_service_) host_service_->Poll(t_ms);
+        if (clip_) clip_->Tick(static_cast<float>(poll_ms_));
         if (on_poll_) on_poll_(t_ms);
 
         daisy::System::Delay(poll_ms_);
@@ -205,6 +206,8 @@ void ControlLoop::Render(uint32_t t_ms)
     if (buttons_)
         buttons_->Render(hw_->leds,
                          storage_ ? storage_->ActivePage() : 0u, t_ms);
+
+    if (clip_) clip_->Draw(hw_->leds);
 
     /* Global OnRender hook fires before the LockSource overlay so the
      * overlay always sits on top of anything the user paints. */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,4 +7,9 @@ target_link_libraries(ring_frame_test PRIVATE alchemy::primitives)
 
 add_test(NAME ring_frame COMMAND ring_frame_test)
 
+add_executable(clip_indicator_test clip_indicator_test.cpp)
+target_link_libraries(clip_indicator_test PRIVATE alchemy::primitives)
+
+add_test(NAME clip_indicator COMMAND clip_indicator_test)
+
 add_subdirectory(host)

--- a/tests/clip_indicator_test.cpp
+++ b/tests/clip_indicator_test.cpp
@@ -1,0 +1,495 @@
+/**
+ * @file clip_indicator_test.cpp
+ * @brief Host tests for ClipIndicator detection, suppression, hold, and
+ *        pip drawing.
+ */
+
+#include "alchemy/led/anims/clip_indicator.h"
+#include "alchemy/led/panel.h"
+
+#include <cmath>
+#include <cstdio>
+
+namespace {
+
+/* ── Capture rig: 2 rings × 4 LEDs + 2 buttons (chain 8..11) ─────────── */
+
+constexpr uint16_t kLeds = 12u;
+
+struct CaptureStrip : alchemy::ILedStrip
+{
+    uint8_t r[kLeds] = {}, g[kLeds] = {}, b[kLeds] = {};
+
+    void SetPixel(uint16_t idx, uint8_t rr, uint8_t gg, uint8_t bb) override
+    {
+        if (idx >= kLeds) return;
+        r[idx] = rr; g[idx] = gg; b[idx] = bb;
+    }
+    void Clear() override
+    {
+        for (uint16_t i = 0; i < kLeds; i++) { r[i] = g[i] = b[i] = 0u; }
+    }
+    void     Show() override {}
+    bool     Busy() const override { return false; }
+    uint16_t NumLeds() const override { return kLeds; }
+};
+
+/* Rings advance 3 hours per LED from noon: offsets 0..3 sit at hours
+ * 0, 3, 6, 9 — so the default 6-o'clock pip is ring offset 2. */
+constexpr alchemy::LedRingLayout kRings[] = {
+    {0u, 4u, 0.0f, 3.0f},
+    {4u, 4u, 0.0f, 3.0f},
+};
+constexpr alchemy::LedButtonLayout kButtons[] = {
+    {8u, 9u},    /* button 0: bottom, top */
+    {10u, 11u},  /* button 1: bottom, top */
+};
+constexpr alchemy::HardwareLayout kLayout = {
+    2u,        /* pots */
+    0u,        /* cv   */
+    2u,        /* btns */
+    kLeds,
+    kRings,
+    kButtons,
+};
+
+struct Rig
+{
+    CaptureStrip      strip;
+    alchemy::LedPanel panel;
+
+    Rig()
+    {
+        panel.Init(strip, kLayout);
+        panel.SetBrightness(1.0f);
+    }
+};
+
+int failures = 0;
+
+#define CHECK(cond)                                                        \
+    do {                                                                    \
+        if (!(cond))                                                        \
+        {                                                                   \
+            std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);     \
+            ++failures;                                                     \
+        }                                                                   \
+    } while (0)
+
+/* Feed one block containing @p clipped full-scale samples padded with
+ * silence, then advance one 1 ms tick. */
+void FeedAndTick(alchemy::ClipIndicator& ci, uint32_t clipped)
+{
+    float block[64];
+    for (uint32_t i = 0; i < 64u; i++)
+        block[i] = (i < clipped) ? 1.0f : 0.0f;
+    ci.Process(block, 64u);
+    ci.Tick(1.0f);
+}
+
+void TickSilence(alchemy::ClipIndicator& ci, uint32_t ms)
+{
+    for (uint32_t i = 0; i < ms; i++) ci.Tick(1.0f);
+}
+
+/* ── Detection ───────────────────────────────────────────────────────── */
+
+void TestSingleSampleSuppressed()
+{
+    alchemy::ClipIndicator ci;
+    FeedAndTick(ci, 1u);
+    CHECK(!ci.Lit());
+    TickSilence(ci, 100u);
+    CHECK(!ci.Lit());
+}
+
+void TestBurstFires()
+{
+    alchemy::ClipIndicator ci;
+    FeedAndTick(ci, 8u);   /* default min_clipped_samples in one block */
+    CHECK(ci.Lit());
+}
+
+void TestThreshold()
+{
+    alchemy::ClipIndicator ci;
+
+    /* 0.97 sits below the default 0.98 threshold — never counted. */
+    float low[64];
+    for (uint32_t i = 0; i < 64u; i++) low[i] = (i & 1u) ? -0.97f : 0.97f;
+    for (uint32_t t = 0; t < 20u; t++) { ci.Process(low, 64u); ci.Tick(1.0f); }
+    CHECK(!ci.Lit());
+
+    /* 0.985 counts, negative samples included. */
+    float hi[8];
+    for (uint32_t i = 0; i < 8u; i++) hi[i] = (i & 1u) ? -0.985f : 0.985f;
+    ci.Process(hi, 8u);
+    ci.Tick(1.0f);
+    CHECK(ci.Lit());
+}
+
+void TestSparseAccumulation()
+{
+    /* 2 clipped samples per ms beats the default leak (8 per 50 ms):
+     * sustained crest-clipping accumulates to the trigger in a few ms. */
+    alchemy::ClipIndicator ci;
+    for (uint32_t t = 0; t < 10u; t++) FeedAndTick(ci, 2u);
+    CHECK(ci.Lit());
+}
+
+void TestWindowDecay()
+{
+    /* Two 4-sample grazes further apart than the window never sum to
+     * the trigger. */
+    alchemy::ClipIndicator ci;
+    FeedAndTick(ci, 4u);
+    CHECK(!ci.Lit());
+    TickSilence(ci, 60u);
+    FeedAndTick(ci, 4u);
+    CHECK(!ci.Lit());
+}
+
+void TestHoldDuration()
+{
+    alchemy::ClipIndicator ci;
+    FeedAndTick(ci, 8u);
+    CHECK(ci.Lit());
+
+    /* Default hold: lit through 49 ms of silence, dark at 50. */
+    TickSilence(ci, 49u);
+    CHECK(ci.Lit());
+    TickSilence(ci, 1u);
+    CHECK(!ci.Lit());
+}
+
+void TestRetriggerExtends()
+{
+    alchemy::ClipIndicator ci;
+    FeedAndTick(ci, 8u);
+    TickSilence(ci, 40u);
+    FeedAndTick(ci, 8u);   /* re-fire near the end of the hold */
+    TickSilence(ci, 40u);
+    CHECK(ci.Lit());       /* still inside the refreshed hold */
+}
+
+void TestSustainedStaysLit()
+{
+    alchemy::ClipIndicator ci;
+    for (uint32_t t = 0; t < 200u; t++)
+    {
+        FeedAndTick(ci, 16u);
+        if (t > 10u) CHECK(ci.Lit());
+    }
+}
+
+void TestDerivedStrideProbing()
+{
+    /* Default Suppression(8) derives stride 4 — the probe grid is
+     * indices 0, 4, 8; clipped samples that sit entirely off-grid are
+     * never seen. */
+    {
+        alchemy::ClipIndicator ci;
+        float block[12] = {};
+        const uint32_t off_grid[8] = {1u, 2u, 3u, 5u, 6u, 7u, 9u, 10u};
+        for (uint32_t i = 0; i < 8u; i++) block[off_grid[i]] = 1.0f;
+        ci.Process(block, 12u);
+        ci.Tick(1.0f);
+        CHECK(!ci.Lit());
+    }
+
+    /* Suppression below 4 derives stride 1 — the scan is exact, and
+     * off-grid positions no longer exist. */
+    {
+        alchemy::ClipIndicator ci = alchemy::ClipIndicator().Suppression(2u);
+        float block[8] = {};
+        block[1] = 1.0f;
+        block[2] = -1.0f;
+        ci.Process(block, 8u);
+        ci.Tick(1.0f);
+        CHECK(ci.Lit());
+    }
+}
+
+void TestDerivedStrideRelaxed()
+{
+    /* Suppression(32) derives stride 16: two grid hits reach the
+     * trigger, and a lone 8-sample burst (one hit = 16) cannot —
+     * the lone-burst contract holds at every derived stride. */
+    {
+        alchemy::ClipIndicator ci = alchemy::ClipIndicator().Suppression(32u);
+        float block[32] = {};
+        block[0]  = 1.0f;
+        block[16] = -1.0f;
+        ci.Process(block, 32u);
+        ci.Tick(1.0f);
+        CHECK(ci.Lit());
+    }
+    {
+        alchemy::ClipIndicator ci = alchemy::ClipIndicator().Suppression(32u);
+        float block[32] = {};
+        for (uint32_t i = 0; i < 8u; i++) block[i] = 1.0f;
+        ci.Process(block, 32u);
+        ci.Tick(1.0f);
+        CHECK(!ci.Lit());
+    }
+}
+
+void TestStrideScalesCounts()
+{
+    /* Each on-grid hit stands for `stride` samples, so the default
+     * trigger (8) needs two hits at stride 4 — one is not enough. */
+    {
+        alchemy::ClipIndicator ci;
+        float block[8] = {};
+        block[0] = 1.0f;
+        block[4] = -1.0f;
+        ci.Process(block, 8u);
+        ci.Tick(1.0f);
+        CHECK(ci.Lit());
+    }
+    {
+        alchemy::ClipIndicator ci;
+        float block[8] = {};
+        block[0] = 1.0f;
+        ci.Process(block, 8u);
+        ci.Tick(1.0f);
+        CHECK(!ci.Lit());
+    }
+}
+
+void TestNonFiniteCountsAsClipped()
+{
+    /* NaN and Inf order above every finite threshold in the bit-pattern
+     * compare — a broken signal lights the alarm by design. */
+    {
+        alchemy::ClipIndicator ci;
+        float inf[8];
+        for (uint32_t i = 0; i < 8u; i++)
+            inf[i] = (i & 1u) ? -INFINITY : INFINITY;
+        ci.Process(inf, 8u);
+        ci.Tick(1.0f);
+        CHECK(ci.Lit());
+    }
+    {
+        alchemy::ClipIndicator ci;
+        float nan[8];
+        for (uint32_t i = 0; i < 8u; i++) nan[i] = std::nanf("");
+        ci.Process(nan, 8u);
+        ci.Tick(1.0f);
+        CHECK(ci.Lit());
+    }
+}
+
+void TestMultiChannelProcess()
+{
+    alchemy::ClipIndicator ci;
+    float        l[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    float        r[4] = {-1.0f, -1.0f, -1.0f, -1.0f};
+    const float* ch[2] = {l, r};
+    ci.Process(ch, 2u, 4u);   /* 4 + 4 = 8 across channels */
+    ci.Tick(1.0f);
+    CHECK(ci.Lit());
+}
+
+/* ── Fluent configuration ────────────────────────────────────────────── */
+
+void TestSuppressionAndHoldSetters()
+{
+    alchemy::ClipIndicator ci = alchemy::ClipIndicator()
+                                    .Suppression(1u)   /* no suppression */
+                                    .Hold(10.0f);
+
+    FeedAndTick(ci, 1u);
+    CHECK(ci.Lit());
+    TickSilence(ci, 9u);
+    CHECK(ci.Lit());
+    TickSilence(ci, 1u);
+    CHECK(!ci.Lit());
+}
+
+void TestSetterClamps()
+{
+    /* Suppression(0, 0) clamps to 1 sample / 1 ms; Hold(-5) clamps to 0
+     * — asserted behaviorally: any clipped sample fires, and the light
+     * is lit only on the trigger tick itself. */
+    alchemy::ClipIndicator ci = alchemy::ClipIndicator()
+                                    .Suppression(0u, 0.0f)
+                                    .Hold(-5.0f);
+
+    FeedAndTick(ci, 1u);
+    CHECK(ci.Lit());
+    TickSilence(ci, 1u);
+    CHECK(!ci.Lit());
+}
+
+void TestChainInitCopies()
+{
+    /* VirtualKnob-style static-init chain: the copy at the end of the
+     * chain must carry every setting across. */
+    Rig rig;
+    alchemy::ClipIndicator ci = alchemy::ClipIndicator()
+                                    .Threshold(0.5f)
+                                    .Suppression(4u)
+                                    .Hold(20.0f)
+                                    .Pots(1u)
+                                    .Color({0x12, 0x34, 0x56});
+
+    float block[4] = {0.6f, -0.6f, 0.6f, -0.6f};   /* clips only at 0.5 */
+    ci.Process(block, 4u);
+    ci.Tick(1.0f);
+    CHECK(ci.Lit());
+
+    ci.Draw(rig.panel);                  /* configured color, ring 1 only */
+    CHECK(rig.strip.r[6] == 0x12u);
+    CHECK(rig.strip.g[6] == 0x34u);
+    CHECK(rig.strip.b[6] == 0x56u);
+    CHECK(rig.strip.r[2] == 0x00u);      /* ring 0 untouched */
+
+    TickSilence(ci, 19u);
+    CHECK(ci.Lit());
+    TickSilence(ci, 1u);
+    CHECK(!ci.Lit());
+}
+
+void TestDisable()
+{
+    alchemy::ClipIndicator ci;
+    FeedAndTick(ci, 8u);
+    CHECK(ci.Lit());
+
+    ci.SetEnabled(false);
+    CHECK(!ci.Lit());          /* disable drops the hold immediately */
+    FeedAndTick(ci, 32u);
+    CHECK(!ci.Lit());          /* counting is off */
+
+    ci.SetEnabled(true);
+    CHECK(!ci.Lit());          /* re-enable starts clean */
+    FeedAndTick(ci, 8u);
+    CHECK(ci.Lit());
+}
+
+void TestReset()
+{
+    alchemy::ClipIndicator ci;
+    FeedAndTick(ci, 8u);
+    CHECK(ci.Lit());
+    ci.Reset();
+    CHECK(!ci.Lit());
+
+    /* Samples fed before the Reset don't leak into the next Tick. */
+    float block[8] = {1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f, 1.0f};
+    ci.Process(block, 8u);
+    ci.Reset();
+    ci.Tick(1.0f);
+    CHECK(!ci.Lit());
+}
+
+/* ── Drawing ─────────────────────────────────────────────────────────── */
+
+void TestDrawMasks()
+{
+    Rig rig;
+    alchemy::ClipIndicator ci = alchemy::ClipIndicator()
+                                    .Pots(0u)      /* ring 0 only   */
+                                    .Buttons(1u);  /* button 1 only */
+
+    FeedAndTick(ci, 8u);
+    CHECK(ci.Lit());
+    ci.Draw(rig.panel, {0xFF, 0x00, 0x00});
+
+    CHECK(rig.strip.r[2]  == 0xFFu);  /* ring 0, 6-o'clock pip     */
+    CHECK(rig.strip.g[2]  == 0x00u);
+    CHECK(rig.strip.r[6]  == 0x00u);  /* ring 1 untouched          */
+    CHECK(rig.strip.r[8]  == 0x00u);  /* button 0 untouched        */
+    CHECK(rig.strip.r[9]  == 0x00u);
+    CHECK(rig.strip.r[10] == 0xFFu);  /* button 1 pair lit         */
+    CHECK(rig.strip.r[11] == 0xFFu);
+}
+
+void TestDrawButtonAccentSelection()
+{
+    Rig rig;
+    alchemy::ClipIndicator ci = alchemy::ClipIndicator()
+                                    .Pots()        /* no pot pips */
+                                    .Buttons(0u)
+                                    .Accent(alchemy::ClipIndicator::ButtonAccent::Bottom);
+
+    FeedAndTick(ci, 8u);
+    ci.Draw(rig.panel, {0x00, 0xFF, 0x00});
+
+    CHECK(rig.strip.g[8] == 0xFFu);   /* bottom accent only */
+    CHECK(rig.strip.g[9] == 0x00u);
+    for (uint16_t i = 0; i < 8u; i++)
+        CHECK(rig.strip.g[i] == 0x00u);   /* Pots() emptied the rings */
+}
+
+void TestDrawDefaults()
+{
+    /* Stock instance: every ring's pip, default red, no buttons. */
+    Rig rig;
+    alchemy::ClipIndicator ci;
+    FeedAndTick(ci, 8u);
+    ci.Draw(rig.panel);
+
+    CHECK(rig.strip.r[2]  == 0xFFu);
+    CHECK(rig.strip.r[6]  == 0xFFu);
+    CHECK(rig.strip.g[2]  == 0x00u);
+    CHECK(rig.strip.r[8]  == 0x00u);
+    CHECK(rig.strip.r[10] == 0x00u);
+}
+
+void TestDrawUnlitIsNoOp()
+{
+    Rig rig;
+    alchemy::ClipIndicator ci;
+    ci.Draw(rig.panel, {0xFF, 0x00, 0x00});
+    for (uint16_t i = 0; i < kLeds; i++)
+        CHECK(rig.strip.r[i] == 0x00u);
+}
+
+void TestDrawScalesWithBrightness()
+{
+    Rig rig;
+    rig.panel.SetBrightness(0.5f);
+    alchemy::ClipIndicator ci;
+    FeedAndTick(ci, 8u);
+    ci.Draw(rig.panel, {0xFF, 0x00, 0x00});
+    CHECK(rig.strip.r[2] == 0x80u);   /* 255 × 0.5 + 0.5 rounding */
+}
+
+} // namespace
+
+int main()
+{
+    TestSingleSampleSuppressed();
+    TestBurstFires();
+    TestThreshold();
+    TestSparseAccumulation();
+    TestWindowDecay();
+    TestHoldDuration();
+    TestRetriggerExtends();
+    TestSustainedStaysLit();
+    TestDerivedStrideProbing();
+    TestDerivedStrideRelaxed();
+    TestStrideScalesCounts();
+    TestNonFiniteCountsAsClipped();
+    TestMultiChannelProcess();
+    TestSuppressionAndHoldSetters();
+    TestSetterClamps();
+    TestChainInitCopies();
+    TestDisable();
+    TestReset();
+    TestDrawMasks();
+    TestDrawButtonAccentSelection();
+    TestDrawDefaults();
+    TestDrawUnlitIsNoOp();
+    TestDrawScalesWithBrightness();
+
+    if (failures)
+    {
+        std::printf("%d failure(s)\n", failures);
+        return 1;
+    }
+    std::printf("all clip indicator tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
Audio-fed clip light: 98% full-scale threshold, leaky-bucket transient suppression so single-sample grazes don't flash, and a 50 ms minimum hold that retriggers while clipping persists. NaN/Inf counts as clipped.

- `clip.Process(...)` from the audio callback. ISR-safe single-word handoff. The sample scan is integer bit-pattern compares at a stride derived from the suppression config, so probing cannot break the suppression contract.
- `loop.Use(clip)` wires the rest: detection at the poll cadence (never gated), pips drawn above the perf render, never over Settings.
