### PR TITLE
Interactive manual support

### DIFF
--- a/docs/hostlink-protocol.md
+++ b/docs/hostlink-protocol.md
@@ -341,6 +341,16 @@ key (see §8) so hosts can light up file-management UI without probing:
 "storage": { "sd": true, "fsv": 1 }
 ```
 
+A firmware whose descriptor build failed its drift/ref validation emits a
+minimal descriptor instead of none: module identity intact, `schemaHash`
+and `size` zero, `components` empty, and an `error` root key holding the
+reason.  Hosts must treat any descriptor carrying `error` as
+identity-only — show the reason, attempt no state operations:
+
+```jsonc
+"error": "see 'flt.cutof' names no field"
+```
+
 Unknown root keys must be ignored (additive, per §6).
 
 ### 5.3 Buttons (root metadata array — legacy)

--- a/framework/include/alchemy/host_link/component_writer.h
+++ b/framework/include/alchemy/host_link/component_writer.h
@@ -8,8 +8,8 @@
  * until the first Field() (or Finalize()) emits the component, and every
  * offset is validated against the component's SerializedSize() by the
  * underlying builder.  A misuse (metadata after a field, out-of-bounds
- * offset) latches failure — the whole descriptor build then returns 0
- * and the module reports "no descriptor" instead of shipping a wrong one.
+ * offset) latches failure — the build fails and the module reports the
+ * reason via the error descriptor instead of shipping a wrong one.
  *
  * Typical custom component:
  *

--- a/framework/include/alchemy/host_link/component_writer.h
+++ b/framework/include/alchemy/host_link/component_writer.h
@@ -71,7 +71,9 @@ class ComponentWriter
     /** One field at byte offset @p off; see DescriptorBuilder::GenericField. */
     bool Field(const char* id, const char* name, uint32_t off,
                FieldType type, float def, const char* disp_json = nullptr,
-               uint16_t zones = 0u, int16_t page = -1, int16_t pot = -1);
+               uint16_t zones = 0u, int16_t page = -1, int16_t pot = -1,
+               const char* help = nullptr,
+               const SeeRef* see = nullptr, uint8_t num_see = 0u);
 
     /**
      * Emit `,"<key>":<raw_json>` inside the component object, between the
@@ -86,6 +88,9 @@ class ComponentWriter
     bool Meta(const char* key, const char* raw_json);
 
     bool MetaUInt(const char* key, uint32_t value);
+
+    /** String meta, JSON-escaped (component-level "help"). */
+    bool MetaStr(const char* key, const char* value);
 
     /* ── Renderer interface ─────────────────────────────────────────── */
 

--- a/framework/include/alchemy/host_link/describe.h
+++ b/framework/include/alchemy/host_link/describe.h
@@ -80,11 +80,11 @@ uint32_t RenderDescriptor(char* buf, size_t cap,
                           const PageSet* pages,
                           const DescribeOverride* overrides,
                           uint8_t num_overrides,
-                          const VirtualButton* buttons = nullptr,
+                          const VirtualButton* const* buttons = nullptr,
                           uint8_t num_buttons = 0u,
                           const char* const* root_fragments = nullptr,
                           uint8_t num_root_fragments = 0u,
-                          const Jack* jacks = nullptr,
+                          const Jack* const* jacks = nullptr,
                           uint8_t num_jacks = 0u,
                           const Manual* manual = nullptr);
 

--- a/framework/include/alchemy/host_link/describe.h
+++ b/framework/include/alchemy/host_link/describe.h
@@ -20,8 +20,11 @@
  * Page::Name()/Color().  Without a PageSet the pager still describes
  * fully — with positional ids and generic labels.
  *
- * All DescriptorBuilder drift guards apply; any failure returns 0 and
- * the module reports "no descriptor" (hosts fall back to raw backup).
+ * All DescriptorBuilder drift guards apply; any failure degrades to a
+ * minimal descriptor carrying the module identity and an "error" root
+ * key with the reason — hosts show the cause instead of a silent
+ * "no descriptor".  0 is returned only when the buffer cannot even
+ * hold that.
  *
  * This layer is host-buildable and unit-tested; hostlink::Host wraps it
  * on target with transport/buffer/uid/reboot defaults.
@@ -71,8 +74,11 @@ struct PageSet
  * (§5.2, e.g. the storage advertisement).  @p jacks becomes the root
  * "jacks" array; @p manual the root "manual" block — the auto path
  * always emits the manual block (stock preset help at minimum), and a
- * manual tagline rides into module{}.  Returns the descriptor length,
- * or 0 on any drift, overflow, or describer failure.
+ * manual tagline rides into module{}.  @p factory, when given, is a
+ * pre-BootLoad SerializeLive image: field defs decode from it, so the
+ * render may run after presets load.  Returns the descriptor length; a
+ * failed build returns a minimal error descriptor (see above), and 0
+ * only when even that overflows @p cap.
  */
 uint32_t RenderDescriptor(char* buf, size_t cap,
                           const DescriptorBuilder::ModuleInfo& info,
@@ -86,7 +92,9 @@ uint32_t RenderDescriptor(char* buf, size_t cap,
                           uint8_t num_root_fragments = 0u,
                           const Jack* const* jacks = nullptr,
                           uint8_t num_jacks = 0u,
-                          const Manual* manual = nullptr);
+                          const Manual* manual = nullptr,
+                          const uint8_t* factory = nullptr,
+                          size_t factory_len = 0u);
 
 } // namespace hostlink
 } // namespace alchemy

--- a/framework/include/alchemy/host_link/describe.h
+++ b/framework/include/alchemy/host_link/describe.h
@@ -40,6 +40,8 @@ class Page;
 class Presets;
 class Serializable;
 class VirtualButton;
+class Jack;
+class Manual;
 
 namespace hostlink {
 
@@ -66,8 +68,11 @@ struct PageSet
  * @p buttons, and @p root_fragments are optional (pass nullptr / 0).
  * Buttons become the top-level "buttons" array (protocol §5.3); root
  * fragments are `"key":value` splices merged into the root object
- * (§5.2, e.g. the storage advertisement).  Returns the descriptor
- * length, or 0 on any drift, overflow, or describer failure.
+ * (§5.2, e.g. the storage advertisement).  @p jacks becomes the root
+ * "jacks" array; @p manual the root "manual" block — the auto path
+ * always emits the manual block (stock preset help at minimum), and a
+ * manual tagline rides into module{}.  Returns the descriptor length,
+ * or 0 on any drift, overflow, or describer failure.
  */
 uint32_t RenderDescriptor(char* buf, size_t cap,
                           const DescriptorBuilder::ModuleInfo& info,
@@ -78,7 +83,10 @@ uint32_t RenderDescriptor(char* buf, size_t cap,
                           const VirtualButton* buttons = nullptr,
                           uint8_t num_buttons = 0u,
                           const char* const* root_fragments = nullptr,
-                          uint8_t num_root_fragments = 0u);
+                          uint8_t num_root_fragments = 0u,
+                          const Jack* jacks = nullptr,
+                          uint8_t num_jacks = 0u,
+                          const Manual* manual = nullptr);
 
 } // namespace hostlink
 } // namespace alchemy

--- a/framework/include/alchemy/host_link/descriptor.h
+++ b/framework/include/alchemy/host_link/descriptor.h
@@ -33,6 +33,7 @@
 #include <cstddef>
 #include <cstdint>
 #include "alchemy/host_link/json_writer.h"
+#include "alchemy/surface/see_ref.h"
 
 namespace alchemy {
 
@@ -41,6 +42,8 @@ class Pager;
 class Settings;
 class Serializable;
 class VirtualButton;
+class Jack;
+class Manual;
 
 namespace hostlink {
 
@@ -58,6 +61,7 @@ class DescriptorBuilder
         const char* git;     /* short git hash                    */
         const char* sdk;     /* SDK version                       */
         const char* board;   /* "v1" / "v2"                       */
+        const char* tagline = nullptr; /* one-line identity (manual) */
     };
 
     DescriptorBuilder(char* buf, size_t cap, const Presets& presets);
@@ -75,12 +79,17 @@ class DescriptorBuilder
      */
     bool BeginPager(const char* id, const Pager& pager,
                     const char* const* page_names  = nullptr,
-                    const char* const* page_colors = nullptr);
+                    const char* const* page_colors = nullptr,
+                    const char* const* page_help   = nullptr);
     /** One field per (page, pot); disp_json may be nullptr for a plain
-     *  percent readout.  def is captured from the pager's stored value. */
+     *  percent readout.  def is captured from the pager's stored value.
+     *  help/see are the manual prose keys (protocol §5, additive) — see
+     *  refs resolve + validate at Finish(). */
     bool PagerField(uint8_t page, uint8_t pot,
                     const char* field_id, const char* name,
-                    const char* disp_json);
+                    const char* disp_json,
+                    const char* help = nullptr,
+                    const SeeRef* see = nullptr, uint8_t num_see = 0u);
     /** Optional alternate position→field mapping (row-major page-major
      *  array of pages×pots field ids), active when the enum field named
      *  @p layout_from selects zone 1.  @p count must equal
@@ -132,17 +141,22 @@ class DescriptorBuilder
     bool GenericField(const char* id, const char* name, uint32_t off,
                       FieldType type, float def, uint16_t zones,
                       const char* disp_json,
-                      int16_t page = -1, int16_t pot = -1);
+                      int16_t page = -1, int16_t pot = -1,
+                      const char* help = nullptr,
+                      const SeeRef* see = nullptr, uint8_t num_see = 0u);
     bool EndComponent();
 
     /* ── Settings component ─────────────────────────────────────── */
-    /** Page names/colors as in BeginPager (Settings::NumPages() entries). */
+    /** Page names/colors/help as in BeginPager (Settings::NumPages() entries). */
     bool BeginSettings(const char* id, const Settings& settings,
                        const char* const* page_names  = nullptr,
-                       const char* const* page_colors = nullptr);
+                       const char* const* page_colors = nullptr,
+                       const char* const* page_help   = nullptr);
     bool SettingsField(uint8_t page, uint8_t pot,
                        const char* field_id, const char* name,
-                       const char* disp_json);
+                       const char* disp_json,
+                       const char* help = nullptr,
+                       const SeeRef* see = nullptr, uint8_t num_see = 0u);
     bool EndSettings();
 
     /* ── Buttons component (kind "buttons", protocol §5.5) ──────────
@@ -173,6 +187,19 @@ class DescriptorBuilder
         return Buttons(buttons, static_cast<uint8_t>(N));
     }
 
+    /* ── Jacks (top-level, optional) ────────────────────────────── */
+    bool Jacks(const Jack* jacks, uint8_t count);
+
+    template <size_t N>
+    bool Jacks(const Jack (&jacks)[N])
+    {
+        return Jacks(jacks, static_cast<uint8_t>(N));
+    }
+
+    /* ── Manual root block (top-level, optional) ────────────────────
+     * "manual":{preamble, sections[], presets:{help}}. */
+    bool ManualBlock(const Manual* manual);
+
     /* ── Raw root fragments (top-level, optional) ───────────────────
      * Splice a `"key":value` fragment (no surrounding braces) into the
      * descriptor's root object — the mechanism behind optional root
@@ -195,6 +222,9 @@ class DescriptorBuilder
 
     bool GenericMetaUInt(const char* key, uint32_t value);
 
+    /** String meta, JSON-escaped (component-level "help"). */
+    bool GenericMetaStr(const char* key, const char* value);
+
     /** Close all structures and validate totals — including that every
      *  cross-field ref (a button's anchor, a root-array controls entry)
      *  names a field some component emitted; Manage() order is
@@ -210,19 +240,31 @@ class DescriptorBuilder
     static constexpr uint8_t  kMaxSettingsPages = 4u;
     static constexpr uint8_t  kMaxPots          = 8u;
     static constexpr uint16_t kMaxFieldIds      = 192u;
-    static constexpr uint8_t  kMaxRefs          = 24u;
+    static constexpr uint8_t  kMaxRefs          = 96u;
 
     bool CheckManaged(const Serializable& s);
     void OpenComponent(const char* id, const char* kind,
                        const Serializable& s);
     void EmitPageMeta(const char* const* names, const char* const* colors,
-                      uint8_t num_pages);
+                      const char* const* help, uint8_t num_pages);
     void EmitRootButtons();
+    void EmitRootJacks();
+    void EmitManualBlock();
 
     bool Fail(const char* msg);
     bool FailRef(const char* kind, const char* target, const char* what);
     bool RecordFieldId(const char* id);
-    bool RecordRef(const char* kind, const char* target);
+    /** Non-field ids (buttons, jacks, "presets"): see/norm targets,
+     *  never anchor/controls targets. */
+    bool RecordExtraId(const char* id);
+    bool RecordRef(const char* kind, const char* target,
+                   bool fields_only = false);
+
+    /** Resolved id, or nullptr (build failed with a clear message). */
+    const char* ResolveSee(const SeeRef& r, char* buf, size_t cap);
+    /** Emit "help"/"see" for the open object; records refs for Finish(). */
+    bool EmitHelpSee(const char* help, const SeeRef* see, uint8_t num_see);
+    bool EmitButtonManual(const VirtualButton& b);
 
     /** Field ids are hashed, never retained: callers may build an id in
      *  a scratch buffer (the pager's positional "p<page>.<pot>"), so a
@@ -257,17 +299,25 @@ class DescriptorBuilder
     const VirtualButton* buttons_     = nullptr;
     uint8_t              num_buttons_ = 0u;
 
+    /* Stashed for Finish(); non-owning like buttons. */
+    const Jack*   jacks_       = nullptr;
+    uint8_t       num_jacks_   = 0u;
+    const Manual* manual_      = nullptr;
+    bool          emit_manual_ = false;
+
     /* Raw root fragments stashed for emission during Finish(). */
     const char* root_fragments_[kMaxRootFragments] = {};
     uint8_t     num_root_fragments_                = 0u;
 
-    /* Ref validation: hashes of every emitted field id, plus every
-     * cross-field ref, matched in Finish().  Ref targets come from
-     * VirtualButton, whose strings are static by contract, so those
-     * pointers are safe to hold for the error message. */
-    struct Ref { const char* kind; const char* target; };
+    /* Ref hashes are taken at record time (scratch-buffer ids stay
+     * valid); `target` is for the error message only, may be nullptr. */
+    struct Ref { const char* kind; const char* target; uint32_t hash;
+                 bool fields_only; };
+    static constexpr uint8_t kMaxExtraIds = 64u;
     uint32_t field_ids_[kMaxFieldIds] = {};
     uint16_t num_field_ids_           = 0u;
+    uint32_t extra_ids_[kMaxExtraIds] = {};
+    uint8_t  num_extra_ids_           = 0u;
     Ref      refs_[kMaxRefs]          = {};
     uint8_t  num_refs_                = 0u;
     const char* err_                  = nullptr;

--- a/framework/include/alchemy/host_link/descriptor.h
+++ b/framework/include/alchemy/host_link/descriptor.h
@@ -180,6 +180,7 @@ class DescriptorBuilder
      * a no-op — the key is omitted entirely, preserving descriptor
      * bytes on modules that expose no button metadata. */
     bool Buttons(const VirtualButton* buttons, uint8_t count);
+    bool Buttons(const VirtualButton* const* buttons, uint8_t count);
 
     template <size_t N>
     bool Buttons(const VirtualButton (&buttons)[N])
@@ -189,6 +190,7 @@ class DescriptorBuilder
 
     /* ── Jacks (top-level, optional) ────────────────────────────── */
     bool Jacks(const Jack* jacks, uint8_t count);
+    bool Jacks(const Jack* const* jacks, uint8_t count);
 
     template <size_t N>
     bool Jacks(const Jack (&jacks)[N])
@@ -294,16 +296,16 @@ class DescriptorBuilder
     const Settings* settings_ = nullptr;
     int16_t         offsets_[kMaxSettingsPages][kMaxPots];
 
-    /* Buttons stashed for emission during Finish().  Pointer is
-     * non-owning — the caller keeps the array alive. */
-    const VirtualButton* buttons_     = nullptr;
-    uint8_t              num_buttons_ = 0u;
+    static constexpr uint8_t kMaxRootButtons = 8u;
+    static constexpr uint8_t kMaxJacks       = 16u;
 
-    /* Stashed for Finish(); non-owning like buttons. */
-    const Jack*   jacks_       = nullptr;
-    uint8_t       num_jacks_   = 0u;
-    const Manual* manual_      = nullptr;
-    bool          emit_manual_ = false;
+    /* Stashed for emission during Finish(); non-owning. */
+    const VirtualButton* btn_ptrs_[kMaxRootButtons] = {};
+    uint8_t              num_buttons_               = 0u;
+    const Jack*          jack_ptrs_[kMaxJacks]      = {};
+    uint8_t              num_jacks_                 = 0u;
+    const Manual*        manual_                    = nullptr;
+    bool                 emit_manual_               = false;
 
     /* Raw root fragments stashed for emission during Finish(). */
     const char* root_fragments_[kMaxRootFragments] = {};

--- a/framework/include/alchemy/host_link/descriptor.h
+++ b/framework/include/alchemy/host_link/descriptor.h
@@ -7,11 +7,12 @@
  * surfaces serialize with (Pager page/pot grid, Settings slot kinds), and
  * verifies at every stage that its arithmetic matches SerializedSize()
  * and the Presets Manage() order.  Any mismatch latches an error and
- * Finish() returns 0 — the firmware then simply reports "no descriptor"
- * instead of shipping a wrong one.
+ * Finish() returns 0 — never a wrong descriptor.  The RenderDescriptor
+ * wrapper (describe.h) degrades that to a minimal error descriptor so
+ * hosts can show LastError()'s reason.
  *
  * Usage (app code, once at boot, after controls are declared and defaults
- * seeded, before BootLoad):
+ * seeded — before BootLoad, or any time given a Defaults() image):
  *
  *   alchemy::hostlink::DescriptorBuilder db(buf, sizeof buf, presets);
  *   db.Begin({.id="echoa", .name="Echoa", .fw=..., .git=..., .sdk=..., .board="v1"});
@@ -65,6 +66,11 @@ class DescriptorBuilder
     };
 
     DescriptorBuilder(char* buf, size_t cap, const Presets& presets);
+
+    /** Factory-state image (a pre-BootLoad SerializeLive blob): field
+     *  defs decode from it, so the render may run after a preset loads.
+     *  Without it defs read live values (factory until the first load). */
+    void Defaults(const uint8_t* blob, size_t len);
 
     bool Begin(const ModuleInfo& m);
 
@@ -262,6 +268,9 @@ class DescriptorBuilder
     bool RecordRef(const char* kind, const char* target,
                    bool fields_only = false);
 
+    bool DefF32(uint32_t abs_off, float* v);
+    bool DefByte(uint32_t abs_off, uint8_t* v);
+
     /** Resolved id, or nullptr (build failed with a clear message). */
     const char* ResolveSee(const SeeRef& r, char* buf, size_t cap);
     /** Emit "help"/"see" for the open object; records refs for Finish(). */
@@ -275,6 +284,9 @@ class DescriptorBuilder
 
     JsonWriter     w_;
     const Presets& presets_;
+
+    const uint8_t* defs_     = nullptr;
+    size_t         defs_len_ = 0u;
 
     bool     error_       = false;
     uint8_t  comp_index_  = 0u;

--- a/framework/include/alchemy/host_link/host.h
+++ b/framework/include/alchemy/host_link/host.h
@@ -19,7 +19,7 @@
  *       loop.Use(pager).Use(settings).Use(page_a).Use(page_b).Use(host);
  *
  *       presets.Init();
- *       presets.BootLoad();      // host starts here: descriptor + USB up
+ *       presets.BootLoad();      // factory defaults snapshot here
  *       ...
  *   }
  *
@@ -33,12 +33,11 @@
  *   - uid / reboot: MCU unique id, bootloader/System reset (.Uid(),
  *     .OnReboot())
  *
- * Start timing: the host arms itself via the Presets pre-BootLoad hook,
- * so the descriptor's captured defaults are factory defaults regardless
- * of call order — attach pages (loop.Use) before presets.BootLoad() and
- * there is nothing else to sequence.  Without a ControlLoop, call
- * Poll(t_ms) from your own loop (same thread as preset mutations) —
- * the first Poll starts the link if BootLoad never did.
+ * Start timing: nothing to sequence.  The pre-BootLoad hook only
+ * snapshots factory state; the descriptor renders and the link comes up
+ * at the first Poll(), after main() has attached pages, jacks, buttons,
+ * and manual content — in any order.  Without a ControlLoop, call
+ * Poll(t_ms) from your own loop (same thread as preset mutations).
  *
  * One Host per system (the CDC receive callback is a hardware
  * singleton).  Target-only; host builds exercise the descriptor layer
@@ -182,8 +181,8 @@ class Host : public HostService
 
     /* ── Lifecycle ───────────────────────────────────────────────────── */
 
-    /** Bring the link up (idempotent).  Called automatically from the
-     *  Presets pre-BootLoad hook and from the first Poll(). */
+    /** Bring the link up (idempotent).  Runs at the first Poll(), once
+     *  everything main() declares is attached. */
     void Start();
 
     /** HostService: pump + execute (ControlLoop calls this at 1 ms). */
@@ -201,6 +200,7 @@ class Host : public HostService
     static constexpr uint8_t kMaxJacks     = 16u;
 
     static void PreBootTrampoline(void* self);
+    void CaptureFactory();
     void AddPage(const Page& p);
     void AddButton(const VirtualButton& b)
     {
@@ -251,8 +251,9 @@ class Host : public HostService
     IHostlinkExtension* extensions_[HostLink::kMaxExtensions] = {};
     uint8_t             num_extensions_                       = 0u;
 
-    HostLink* link_    = nullptr;
-    bool      started_ = false;
+    HostLink* link_        = nullptr;
+    bool      started_     = false;
+    size_t    factory_len_ = 0u;
     alignas(HostLink) uint8_t link_storage_[sizeof(HostLink)];
 };
 

--- a/framework/include/alchemy/host_link/host.h
+++ b/framework/include/alchemy/host_link/host.h
@@ -57,6 +57,8 @@
 namespace alchemy {
 
 class ControlLoop;
+class Jack;
+class Manual;
 class Page;
 class Presets;
 class VirtualButton;
@@ -87,7 +89,7 @@ class Host : public HostService
      *  @p cap must be ≥ the module's live serialized size. */
     Host& Buffers(uint8_t* staging, uint8_t* snapshot, size_t cap);
 
-    /** Custom descriptor buffer (default: SDK-owned 8 KiB in SDRAM). */
+    /** Custom descriptor buffer (default: SDK-owned 24 KiB in SDRAM). */
     Host& DescriptorBuffer(char* buf, size_t cap);
 
     /** Custom byte transport (default: CDC on the panel USB-C). */
@@ -136,6 +138,20 @@ class Host : public HostService
     {
         return Buttons(buttons, static_cast<uint8_t>(N));
     }
+
+    /** Declare the module's jacks (root "jacks" array).  Same lifetime
+     *  rule as Buttons(). */
+    Host& Jacks(const Jack* jacks, uint8_t count);
+
+    template <size_t N>
+    Host& Jacks(const Jack (&jacks)[N])
+    {
+        return Jacks(jacks, static_cast<uint8_t>(N));
+    }
+
+    /** Attach module-level manual content (tagline / preamble / sections).
+     *  Without it the descriptor still carries the stock preset help. */
+    Host& Attach(const Manual& manual);
 
     /**
      * Attach a protocol extension (see extension.h) — e.g. the SD
@@ -200,6 +216,9 @@ class Host : public HostService
 
     const VirtualButton* buttons_       = nullptr;
     uint8_t              num_buttons_   = 0u;
+    const Jack*          jacks_         = nullptr;
+    uint8_t              num_jacks_     = 0u;
+    const Manual*        manual_        = nullptr;
 
     IHostlinkExtension* extensions_[HostLink::kMaxExtensions] = {};
     uint8_t             num_extensions_                       = 0u;

--- a/framework/include/alchemy/host_link/host.h
+++ b/framework/include/alchemy/host_link/host.h
@@ -139,6 +139,15 @@ class Host : public HostService
         return Buttons(buttons, static_cast<uint8_t>(N));
     }
 
+    template <typename... Rest>
+    Host& Buttons(const VirtualButton& first, const Rest&... rest)
+    {
+        num_buttons_ = 0u;
+        AddButton(first);
+        (AddButton(rest), ...);
+        return *this;
+    }
+
     /** Declare the module's jacks (root "jacks" array).  Same lifetime
      *  rule as Buttons(). */
     Host& Jacks(const Jack* jacks, uint8_t count);
@@ -147,6 +156,15 @@ class Host : public HostService
     Host& Jacks(const Jack (&jacks)[N])
     {
         return Jacks(jacks, static_cast<uint8_t>(N));
+    }
+
+    template <typename... Rest>
+    Host& Jacks(const Jack& first, const Rest&... rest)
+    {
+        num_jacks_ = 0u;
+        AddJack(first);
+        (AddJack(rest), ...);
+        return *this;
     }
 
     /** Attach module-level manual content (tagline / preamble / sections).
@@ -179,9 +197,19 @@ class Host : public HostService
   private:
     static constexpr uint8_t kMaxOverrides = 8u;
     static constexpr uint8_t kMaxPageRefs  = 8u;
+    static constexpr uint8_t kMaxButtons   = 8u;
+    static constexpr uint8_t kMaxJacks     = 16u;
 
     static void PreBootTrampoline(void* self);
     void AddPage(const Page& p);
+    void AddButton(const VirtualButton& b)
+    {
+        if (num_buttons_ < kMaxButtons) btn_ptrs_[num_buttons_++] = &b;
+    }
+    void AddJack(const Jack& j)
+    {
+        if (num_jacks_ < kMaxJacks) jack_ptrs_[num_jacks_++] = &j;
+    }
 
     Presets&    presets_;
     const char* id_;
@@ -214,11 +242,11 @@ class Host : public HostService
     const Page*  pages_[kMaxPageRefs]   = {};
     uint8_t      num_pages_             = 0u;
 
-    const VirtualButton* buttons_       = nullptr;
-    uint8_t              num_buttons_   = 0u;
-    const Jack*          jacks_         = nullptr;
-    uint8_t              num_jacks_     = 0u;
-    const Manual*        manual_        = nullptr;
+    const VirtualButton* btn_ptrs_[kMaxButtons] = {};
+    uint8_t              num_buttons_            = 0u;
+    const Jack*          jack_ptrs_[kMaxJacks]   = {};
+    uint8_t              num_jacks_              = 0u;
+    const Manual*        manual_                 = nullptr;
 
     IHostlinkExtension* extensions_[HostLink::kMaxExtensions] = {};
     uint8_t             num_extensions_                       = 0u;

--- a/framework/include/alchemy/storage/fs_extension.h
+++ b/framework/include/alchemy/storage/fs_extension.h
@@ -37,10 +37,13 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 
 #include "alchemy/host_link/extension.h"
+#include "alchemy/host_link/json_writer.h"
 #include "alchemy/host_link/wire.h"
 #include "alchemy/storage/sd_card.h"
+#include "alchemy/surface/manual.h"
 
 namespace alchemy {
 namespace hostlink {
@@ -58,9 +61,32 @@ class FsExtension : public IHostlinkExtension
     void Handle(const ParsedFrame& f, FrameWriter& w, uint32_t now_ms) override;
     void Tick(uint32_t now_ms) override;
 
+    /** Storage help override (default: stock_help::kStorage).  Set
+     *  before the descriptor renders. */
+    FsExtension& Help(const char* md)
+    {
+        help_ = md;
+        return *this;
+    }
+
     const char* DescriptorRootJson() const override
     {
-        return "\"storage\":{\"sd\":true,\"fsv\":1}";
+        /* Escape help into the member buffer; on overflow degrade to
+         * the bare advertisement. */
+        JsonWriter jw(frag_, sizeof frag_ - 12u); /* room for "storage": */
+        jw.BeginObj();
+        jw.Key("sd");   jw.Bool(true);
+        jw.Key("fsv");  jw.UInt(1u);
+        jw.Key("help"); jw.Str(help_ ? help_ : stock_help::kStorage);
+        jw.EndObj();
+        if (!jw.Ok() || !jw.Terminate())
+            return "\"storage\":{\"sd\":true,\"fsv\":1}";
+        /* Prepend the root key around the value we just built. */
+        const size_t vlen = jw.Length();
+        std::memmove(frag_ + 10u, frag_, vlen);
+        std::memcpy(frag_, "\"storage\":", 10u);
+        frag_[10u + vlen] = '\0';
+        return frag_;
     }
 
     /** Drop all session state (open transfer, listing cursor) WITHOUT
@@ -106,6 +132,11 @@ class FsExtension : public IHostlinkExtension
     bool CollidesWithTransfer(const char* path) const;
 
     SdCard& card_;
+
+    /* Manual prose + rendered root fragment (built lazily per render;
+     * mutable because DescriptorRootJson() is const in the interface). */
+    const char*  help_      = nullptr;
+    mutable char frag_[768] = {};
 
     /* ── Open transfer (at most one, read or write) ─────────────────── */
     XferMode mode_        = XferMode::None;

--- a/framework/include/alchemy/surface/jack.h
+++ b/framework/include/alchemy/surface/jack.h
@@ -1,0 +1,92 @@
+/**
+ * @file alchemy/surface/jack.h
+ * @brief alchemy::Jack — pure descriptor metadata for a panel jack.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "alchemy/surface/see_ref.h"
+
+namespace alchemy {
+
+/** Closed signal vocabulary (wire strings via Jack::SigName). */
+enum class JackSig : uint8_t
+{
+    AudioIn,  //  "audio-in"   → host renders "Audio In"
+    AudioOut, //  "audio-out"  → "Audio Out"
+    CvBi,     //  "cv-bi"      → "±5 V"
+    CvUni,    //  "cv-uni"     → "0–5 V"
+    Voct,     //  "voct"       → "1 V/oct"
+    Gate,     //  "gate"       → "Gate"
+    Trig,     //  "trig"       → "Trig"
+};
+
+class Jack
+{
+  public:
+    constexpr Jack(const char* id, const char* name, JackSig sig)
+        : id_(id), name_(name), sig_(sig) {}
+
+    /** Short silk label for panel drawings; hosts fall back to name. */
+    constexpr Jack& Short(const char* silk) { short_ = silk; return *this; }
+
+    /** Input normalled from @p from when unpatched. */
+    constexpr Jack& Normalled(const Jack& from) { norm_ = &from; return *this; }
+
+    constexpr Jack& Help(const char* md) { help_ = md; return *this; }
+
+    template <typename... Refs>
+    constexpr Jack& SeeAlso(const Refs&... refs)
+    {
+        (AddSee(SeeRef(refs)), ...);
+        return *this;
+    }
+
+    constexpr const char* Id()    const { return id_; }
+    constexpr const char* Name()  const { return name_; }
+    constexpr const char* Silk()  const { return short_; }
+    constexpr JackSig     Sig()   const { return sig_; }
+    constexpr const Jack* Norm()  const { return norm_; }
+    constexpr const char* ManualHelp() const { return help_; }
+    constexpr const SeeRef* SeeRefs() const { return see_; }
+    constexpr uint8_t NumSeeRefs() const { return num_see_; }
+    constexpr bool    SeeOverflowed() const { return see_overflow_; }
+
+    /** Wire string for a signal class. */
+    static constexpr const char* SigName(JackSig s)
+    {
+        switch (s)
+        {
+            case JackSig::AudioIn:  return "audio-in";
+            case JackSig::AudioOut: return "audio-out";
+            case JackSig::CvBi:     return "cv-bi";
+            case JackSig::CvUni:    return "cv-uni";
+            case JackSig::Voct:     return "voct";
+            case JackSig::Gate:     return "gate";
+            case JackSig::Trig:     /* fall through */
+            default:                return "trig";
+        }
+    }
+
+  private:
+    constexpr void AddSee(const SeeRef& r)
+    {
+        if (num_see_ < kMaxSeeRefs) see_[num_see_++] = r;
+        else                        see_overflow_ = true;
+    }
+
+    const char* id_;
+    const char* name_;
+    const char* short_ = nullptr;
+    JackSig     sig_;
+    const Jack* norm_  = nullptr;
+
+    const char* help_  = nullptr;
+    SeeRef      see_[kMaxSeeRefs] = {};
+    uint8_t     num_see_          = 0u;
+    bool        see_overflow_     = false;
+};
+
+} // namespace alchemy

--- a/framework/include/alchemy/surface/manual.h
+++ b/framework/include/alchemy/surface/manual.h
@@ -1,0 +1,106 @@
+/**
+ * @file alchemy/surface/manual.h
+ * @brief alchemy::Manual — module-level manual content (tagline, preamble,
+ *        sections, preset-help override), plus the thin stock help texts.
+ *
+ * Entity-scoped prose attaches to the entity itself (.Help()); Manual
+ * carries only what has no object.  Stock defaults exist ONLY for the
+ * SDK-owned features (presets, locks, SD, brightness) — nothing else ever
+ * gets default prose.  One layer of CommonMark+GFM; never restate
+ * structured facts (ranges, defaults, slot counts).
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace alchemy {
+
+/* ── Stock help — the SDK-owned feature texts, override via .Help() ──── */
+
+namespace stock_help {
+
+/* Count-free on purpose — counts are structured facts hosts render. */
+
+inline constexpr const char* kPresets =
+    "Preset slots store the complete state of the module — every page, "
+    "every setting marked as preset material, and everything else the "
+    "firmware manages. Slot 0 is the boot slot: it loads automatically at "
+    "power-up. Presets are saved and named from the web programmer, or "
+    "from the panel using the module's preset gestures. Slots written by "
+    "a different firmware version are flagged in the programmer and can "
+    "be migrated with **Back up all**.";
+
+inline constexpr const char* kLocks =
+    "Parameter locks are short automation loops recorded from the panel: "
+    "hold the lock gesture and move a knob to capture the motion, and the "
+    "module replays it as part of the patch.";
+
+inline constexpr const char* kStorage =
+    "The SD card holds files the firmware reads and writes. Browse and "
+    "manage them from the web programmer's file panel. Avoid removing the "
+    "card while the module is writing; everything else is safe at any "
+    "time.";
+
+inline constexpr const char* kBrightness =
+    "Global LED brightness control in safe ranges. Uses more power.";
+
+} // namespace stock_help
+
+/* ── Manual root ─────────────────────────────────────────────────────── */
+
+class Manual
+{
+  public:
+    static constexpr uint8_t kMaxSections = 8u;
+
+    struct SectionDecl
+    {
+        const char* id    = nullptr; /* slug, becomes the deep-link id */
+        const char* title = nullptr;
+        const char* body  = nullptr; /* markdown */
+    };
+
+    constexpr Manual() = default;
+
+    /** One-line identity; rides the descriptor's module{} block. */
+    constexpr Manual& Tagline(const char* t) { tagline_ = t; return *this; }
+
+    /** Opening prose at the top of the manual page (markdown). */
+    constexpr Manual& Preamble(const char* md) { preamble_ = md; return *this; }
+
+    /** Long-form section; overflow fails the descriptor build. */
+    constexpr Manual& Section(const char* id, const char* title,
+                              const char* body_md)
+    {
+        if (num_sections_ < kMaxSections)
+            sections_[num_sections_++] = {id, title, body_md};
+        else
+            overflow_ = true;
+        return *this;
+    }
+
+    /** Override the stock preset-system help (stock_help::kPresets). */
+    constexpr Manual& PresetsHelp(const char* md)
+    {
+        presets_help_ = md;
+        return *this;
+    }
+
+    constexpr const char* TaglineText()  const { return tagline_; }
+    constexpr const char* PreambleText() const { return preamble_; }
+    constexpr uint8_t NumSections() const { return num_sections_; }
+    constexpr const SectionDecl& SectionAt(uint8_t i) const { return sections_[i]; }
+    constexpr const char* PresetsHelpText() const { return presets_help_; }
+    constexpr bool Overflowed() const { return overflow_; }
+
+  private:
+    const char* tagline_      = nullptr;
+    const char* preamble_     = nullptr;
+    const char* presets_help_ = nullptr;
+    SectionDecl sections_[kMaxSections] = {};
+    uint8_t     num_sections_ = 0u;
+    bool        overflow_     = false;
+};
+
+} // namespace alchemy

--- a/framework/include/alchemy/surface/page.h
+++ b/framework/include/alchemy/surface/page.h
@@ -115,6 +115,9 @@ class Page
     Page& Name (const char* name)    { name_  = name;  return *this; }
     Page& Color(const char* css_hex) { color_ = css_hex; return *this; }
 
+    /** Manual prose for this page (markdown; descriptor-only). */
+    Page& Help(const char* md) { help_ = md; return *this; }
+
     /* ── Read accessors ───────────────────────────────────────────────── */
 
     uint8_t      Index() const { return idx_; }
@@ -130,12 +133,14 @@ class Page
     }
     const char*  TabName () const { return name_; }
     const char*  TabColor() const { return color_; }
+    const char*  HelpText() const { return help_; }
 
   private:
     uint8_t      idx_;
     uint8_t      count_         = 0;
     const char*  name_          = nullptr;
     const char*  color_         = nullptr;
+    const char*  help_          = nullptr;
     VirtualKnob* knobs_[kMaxKnobs] = {};
 
     VirtualButton* buttons_[kMaxButtons] = {};

--- a/framework/include/alchemy/surface/param_lock.h
+++ b/framework/include/alchemy/surface/param_lock.h
@@ -100,6 +100,10 @@ template<uint8_t kSlots, class Len = DefaultLockLength>
 class ParamLock : public Serializable, public LockSource
 {
   public:
+    /** Locks help override (default: stock_help::kLocks). */
+    ParamLock& Help(const char* md) { help_ = md; return *this; }
+    const char* ManualHelp() const { return help_; }
+
     /* ── Configuration ───────────────────────────────────────────────
      * Compile-time constants — print at boot or static_assert against. */
 
@@ -332,6 +336,8 @@ class ParamLock : public Serializable, public LockSource
     }
 
   private:
+    const char* help_ = nullptr;
+
     /** Shared constructor tail — binds the manager to slots + arena. */
     void Bind(uint16_t* arena, uint8_t gesture_width)
     {

--- a/framework/include/alchemy/surface/see_ref.h
+++ b/framework/include/alchemy/surface/see_ref.h
@@ -1,0 +1,48 @@
+/**
+ * @file alchemy/surface/see_ref.h
+ * @brief alchemy::SeeRef — typed manual cross-reference (.SeeAlso targets).
+ *
+ * Holds the referenced object, not a string id; the descriptor build
+ * resolves and validates it, so a dead link is a build failure.  Knobs and
+ * settings handles must carry .Ident() to be referenced; buttons and jacks
+ * always resolve.  The raw-string form ("presets") covers non-object
+ * entities.  Storage only — resolution lives in the builder.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace alchemy {
+
+class VirtualKnob;
+class VirtualButton;
+class Jack;
+struct SettingsSlot;
+
+/** Max SeeAlso refs per entity; overflow fails the descriptor build. */
+constexpr uint8_t kMaxSeeRefs = 4u;
+
+class SeeRef
+{
+  public:
+    enum class Kind : uint8_t { None, Raw, Knob, Button, Jack, Slot };
+
+    constexpr SeeRef() = default;
+    constexpr SeeRef(const char* raw_id) : kind_(Kind::Raw), raw_(raw_id) {}
+    constexpr SeeRef(const VirtualKnob& k) : kind_(Kind::Knob), ptr_(&k) {}
+    constexpr SeeRef(const VirtualButton& b) : kind_(Kind::Button), ptr_(&b) {}
+    constexpr SeeRef(const Jack& j) : kind_(Kind::Jack), ptr_(&j) {}
+    constexpr SeeRef(const SettingsSlot& s) : kind_(Kind::Slot), ptr_(&s) {}
+
+    constexpr Kind        K()   const { return kind_; }
+    constexpr const void* Ptr() const { return ptr_; }
+    constexpr const char* Raw() const { return raw_; }
+
+  private:
+    Kind        kind_ = Kind::None;
+    const void* ptr_  = nullptr;
+    const char* raw_  = nullptr;
+};
+
+} // namespace alchemy

--- a/framework/include/alchemy/surface/settings.h
+++ b/framework/include/alchemy/surface/settings.h
@@ -99,6 +99,13 @@ class Settings : public Serializable
         SelectorHandle   Selector(uint8_t num_zones);
         CustomHandle     Custom ();
 
+        /** Labeled selector: zones deduced from the array. */
+        template <size_t N>
+        SelectorHandle Selector(const char* const (&labels)[N])
+        {
+            return Selector(static_cast<uint8_t>(N)).Labels(labels);
+        }
+
       private:
         Settings& s_;
         uint8_t   page_;
@@ -115,6 +122,13 @@ class Settings : public Serializable
         PageBuilder& Name(const char* name)
         {
             s_.page_names_[page_] = name;
+            return *this;
+        }
+
+        /** Manual prose for this page (markdown; descriptor-only). */
+        PageBuilder& Help(const char* md)
+        {
+            s_.page_help_[page_] = md;
             return *this;
         }
 
@@ -192,13 +206,64 @@ class Settings : public Serializable
         return (page < kSettingsMaxPages) ? page_names_[page] : nullptr;
     }
 
+    /** Page help declared via Page(pg).Help(...); nullptr when unset. */
+    const char* PageHelpAt(uint8_t page) const
+    {
+        return (page < kSettingsMaxPages) ? page_help_[page] : nullptr;
+    }
+
+    /* Per-slot identity + prose (nullptr/zero when undecorated). */
+    const char* IdentAt(uint8_t page, uint8_t pot) const
+    {
+        const SettingsSlot* s = SlotAt(page, pot);
+        return s ? s->ident : nullptr;
+    }
+    const char* DisplayNameAt(uint8_t page, uint8_t pot) const
+    {
+        const SettingsSlot* s = SlotAt(page, pot);
+        return s ? s->display_name : nullptr;
+    }
+    const char* const* LabelsAt(uint8_t page, uint8_t pot) const
+    {
+        const SettingsSlot* s = SlotAt(page, pot);
+        return s ? s->labels : nullptr;
+    }
+    uint8_t NumLabelsAt(uint8_t page, uint8_t pot) const
+    {
+        const SettingsSlot* s = SlotAt(page, pot);
+        return s ? s->num_labels : 0u;
+    }
+    const char* HelpAt(uint8_t page, uint8_t pot) const
+    {
+        const SettingsSlot* s = SlotAt(page, pot);
+        return s ? s->help : nullptr;
+    }
+    const SeeRef* SeeRefsAt(uint8_t page, uint8_t pot, uint8_t* n) const
+    {
+        const SettingsSlot* s = SlotAt(page, pot);
+        if (n) *n = s ? s->num_see : 0u;
+        return s ? s->see : nullptr;
+    }
+    bool SeeOverflowedAt(uint8_t page, uint8_t pot) const
+    {
+        const SettingsSlot* s = SlotAt(page, pot);
+        return s ? s->see_overflow : false;
+    }
+
     DescKind DescribeKind() const override { return DescKind::Settings; }
 
   private:
     friend class PotBuilder;
 
-    /* HostLink tab labels (set via PageBuilder::Name). */
+    const SettingsSlot* SlotAt(uint8_t page, uint8_t pot) const
+    {
+        if (page >= kSettingsMaxPages || pot >= kNumPots) return nullptr;
+        return &slots_[page][pot];
+    }
+
+    /* HostLink tab labels + page help (set via PageBuilder). */
     const char* page_names_[kSettingsMaxPages] = {};
+    const char* page_help_ [kSettingsMaxPages] = {};
 
     /* Mode-flag gesture state. */
     IButton*       b2_              = nullptr;

--- a/framework/include/alchemy/surface/settings_control.h
+++ b/framework/include/alchemy/surface/settings_control.h
@@ -22,11 +22,13 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include "alchemy/control/pot_catch.h"
 #include "alchemy/led/anims/fill.h"
 #include "alchemy/led/anims/selector.h"
 #include "alchemy/led/panel.h"
+#include "alchemy/surface/see_ref.h"
 
 namespace alchemy {
 
@@ -93,9 +95,28 @@ struct SettingsSlot
     SettingsTickFn   custom_tick   = nullptr;
     SettingsRenderFn custom_render = nullptr;
     void*            custom_ctx    = nullptr;
+
+    /* Host identity + manual prose.  Descriptor-only — never serialized
+     * or hashed, so decorating a control cannot invalidate presets.
+     * Unset → positional id / kind-derived label, as before. */
+    const char*        ident        = nullptr; /* stable field id        */
+    const char*        display_name = nullptr; /* host label             */
+    const char* const* labels       = nullptr; /* selector zone labels   */
+    uint8_t            num_labels   = 0;
+    const char*        help         = nullptr; /* markdown               */
+    SeeRef             see[kMaxSeeRefs] = {};
+    uint8_t            num_see      = 0;
+    bool               see_overflow = false;
 };
 
 /* ── Builder handles ────────────────────────────────────────────────── */
+
+/** SeeAlso() storage shared by every handle kind. */
+inline void AddSlotSee(SettingsSlot& s, const SeeRef& r)
+{
+    if (s.num_see < kMaxSeeRefs) s.see[s.num_see++] = r;
+    else                         s.see_overflow = true;
+}
 
 class BrightnessHandle
 {
@@ -109,6 +130,20 @@ class BrightnessHandle
     { if (!s_) return *this; s_->value = v; s_->pot.stored = ValueToPot(v); return *this; }
     BrightnessHandle& Color  (LedPanel::Rgb c)
     { if (!s_) return *this; s_->color = c; return *this; }
+
+    /* Identity + prose (see SettingsSlot).  The SeeRef conversion lets
+     * other entities reference this control; referenced controls need
+     * .Ident(). */
+    BrightnessHandle& Ident(const char* id)
+    { if (s_) s_->ident = id; return *this; }
+    BrightnessHandle& Name(const char* n)
+    { if (s_) s_->display_name = n; return *this; }
+    BrightnessHandle& Help(const char* md)
+    { if (s_) s_->help = md; return *this; }
+    template <typename... Refs>
+    BrightnessHandle& SeeAlso(const Refs&... refs)
+    { if (s_) (AddSlotSee(*s_, SeeRef(refs)), ...); return *this; }
+    operator SeeRef() const { return s_ ? SeeRef(*s_) : SeeRef(); }
 
     /** Current logical brightness (already mapped to [range_lo..range_hi]). */
     float Value() const { return s_ ? s_->value : 0.0f; }
@@ -149,6 +184,15 @@ class KnobHandle
     KnobHandle& Anim   (FillAnim a)
     { if (!s_) return *this; s_->anim  = a; return *this; }
 
+    /* Identity + prose — see BrightnessHandle. */
+    KnobHandle& Ident(const char* id) { if (s_) s_->ident = id; return *this; }
+    KnobHandle& Name (const char* n)  { if (s_) s_->display_name = n; return *this; }
+    KnobHandle& Help (const char* md) { if (s_) s_->help = md; return *this; }
+    template <typename... Refs>
+    KnobHandle& SeeAlso(const Refs&... refs)
+    { if (s_) (AddSlotSee(*s_, SeeRef(refs)), ...); return *this; }
+    operator SeeRef() const { return s_ ? SeeRef(*s_) : SeeRef(); }
+
     float Value() const { return s_ ? s_->value : 0.0f; }
 
     /** Read-only access to the underlying slot — see BrightnessHandle::Slot. */
@@ -181,6 +225,15 @@ class BipolarHandle
     { if (!s_) return *this; s_->alt_color    = c; return *this; }
     BipolarHandle& CenterColor (LedPanel::Rgb c)
     { if (!s_) return *this; s_->center_color = c; return *this; }
+
+    /* Identity + prose — see BrightnessHandle. */
+    BipolarHandle& Ident(const char* id) { if (s_) s_->ident = id; return *this; }
+    BipolarHandle& Name (const char* n)  { if (s_) s_->display_name = n; return *this; }
+    BipolarHandle& Help (const char* md) { if (s_) s_->help = md; return *this; }
+    template <typename... Refs>
+    BipolarHandle& SeeAlso(const Refs&... refs)
+    { if (s_) (AddSlotSee(*s_, SeeRef(refs)), ...); return *this; }
+    operator SeeRef() const { return s_ ? SeeRef(*s_) : SeeRef(); }
 
     /** Current logical value in [-1..+1]. */
     float Value() const { return s_ ? s_->value : 0.0f; }
@@ -228,6 +281,23 @@ class SelectorHandle
     SelectorHandle& Geometry      (ZoneGeometry g)
     { if (!s_) return *this; s_->zone_geo       = g;       return *this; }
 
+    /** Zone labels; count validated against zones at descriptor build. */
+    SelectorHandle& Labels(const char* const* labels, uint8_t n)
+    { if (!s_) return *this; s_->labels = labels; s_->num_labels = n; return *this; }
+
+    template <size_t N>
+    SelectorHandle& Labels(const char* const (&labels)[N])
+    { return Labels(labels, static_cast<uint8_t>(N)); }
+
+    /* Identity + prose — see BrightnessHandle. */
+    SelectorHandle& Ident(const char* id) { if (s_) s_->ident = id; return *this; }
+    SelectorHandle& Name (const char* n)  { if (s_) s_->display_name = n; return *this; }
+    SelectorHandle& Help (const char* md) { if (s_) s_->help = md; return *this; }
+    template <typename... Refs>
+    SelectorHandle& SeeAlso(const Refs&... refs)
+    { if (s_) (AddSlotSee(*s_, SeeRef(refs)), ...); return *this; }
+    operator SeeRef() const { return s_ ? SeeRef(*s_) : SeeRef(); }
+
     /** Current selected zone index, 0..num_zones-1. */
     uint8_t Value() const { return s_ ? s_->value_idx : 0u; }
 
@@ -269,6 +339,15 @@ class CustomHandle
     { if (!s_) return *this; s_->custom_render = fn; return *this; }
     CustomHandle& Ctx    (void* p)
     { if (!s_) return *this; s_->custom_ctx    = p;  return *this; }
+
+    /* Identity + prose — see BrightnessHandle. */
+    CustomHandle& Ident(const char* id) { if (s_) s_->ident = id; return *this; }
+    CustomHandle& Name (const char* n)  { if (s_) s_->display_name = n; return *this; }
+    CustomHandle& Help (const char* md) { if (s_) s_->help = md; return *this; }
+    template <typename... Refs>
+    CustomHandle& SeeAlso(const Refs&... refs)
+    { if (s_) (AddSlotSee(*s_, SeeRef(refs)), ...); return *this; }
+    operator SeeRef() const { return s_ ? SeeRef(*s_) : SeeRef(); }
 
     float Value() const { return s_ ? s_->value : 0.0f; }
     SettingsSlot& Slot() const { return *s_; }

--- a/framework/include/alchemy/surface/virtual_button.h
+++ b/framework/include/alchemy/surface/virtual_button.h
@@ -51,6 +51,7 @@
 #include <cstdint>
 
 #include "alchemy/led/panel.h"   /* LedPanel::Rgb */
+#include "alchemy/surface/see_ref.h"
 
 namespace alchemy {
 
@@ -89,6 +90,7 @@ class VirtualButton
         uint8_t     set_zone = 0;
         uint16_t    hold_ms  = 0;
         const char* label    = nullptr;
+        const char* help     = nullptr;   /* manual prose; descriptor-only */
         TapFn       fn       = nullptr;
         void*       fn_ctx   = nullptr;
     };
@@ -334,6 +336,48 @@ class VirtualButton
         return *this;
     }
 
+    /* ── Manual prose ─────────────────────────────────────────────────
+     * GestureHelp keys on the gesture string: Action()'s free-form name,
+     * or "tap"/"hold" for the structured slots.  An unmatched key fails
+     * the descriptor build — text must never silently vanish. */
+
+    constexpr VirtualButton& Help(const char* md)
+    {
+        help_ = md;
+        return *this;
+    }
+
+    template <typename... Refs>
+    constexpr VirtualButton& SeeAlso(const Refs&... refs)
+    {
+        (AddSee(SeeRef(refs)), ...);
+        return *this;
+    }
+
+    constexpr VirtualButton& GestureHelp(const char* key, const char* md)
+    {
+        if (StrEq(key, "tap") && tap_.used)
+        {
+            tap_.help = md;
+            return *this;
+        }
+        if (StrEq(key, "hold") && hold_.used)
+        {
+            hold_.help = md;
+            return *this;
+        }
+        for (uint8_t i = 0; i < num_actions_; i++)
+        {
+            if (actions_[i].gesture && StrEq(key, actions_[i].gesture))
+            {
+                actions_[i].help = md;
+                return *this;
+            }
+        }
+        bad_gesture_help_ = key;   /* latched; fails the descriptor build */
+        return *this;
+    }
+
     /* ── Reads (ISR-safe; state lives in the ButtonBank) ─────────────── */
 
     /** Current zone (Default() until a bank adopts this button). */
@@ -354,6 +398,14 @@ class VirtualButton
     constexpr uint8_t     NumActions() const { return num_actions_; }
     constexpr const char* ActionGesture(uint8_t i) const { return actions_[i].gesture; }
     constexpr const char* ActionLabel  (uint8_t i) const { return actions_[i].label;   }
+    constexpr const char* ActionHelp   (uint8_t i) const { return actions_[i].help;    }
+
+    constexpr const char*   ManualHelp() const { return help_; }
+    constexpr const SeeRef* SeeRefs()    const { return see_; }
+    constexpr uint8_t       NumSeeRefs() const { return num_see_; }
+    constexpr bool          SeeOverflowed() const { return see_overflow_; }
+    /** Unmatched GestureHelp key, or nullptr — checked at descriptor build. */
+    constexpr const char*   BadGestureHelpKey() const { return bad_gesture_help_; }
 
     constexpr uint8_t     NumControls() const { return num_controls_; }
     constexpr const char* ControlField (uint8_t i) const { return controls_[i].field;  }
@@ -424,7 +476,21 @@ class VirtualButton
         return (ms > 0xFFFFu) ? 0xFFFFu : static_cast<uint16_t>(ms);
     }
 
-    struct ActionEntry  { const char* gesture = nullptr; const char* label = nullptr; };
+    static constexpr bool StrEq(const char* a, const char* b)
+    {
+        if (!a || !b) return false;
+        while (*a && *a == *b) { ++a; ++b; }
+        return *a == *b;
+    }
+
+    constexpr void AddSee(const SeeRef& r)
+    {
+        if (num_see_ < kMaxSeeRefs) see_[num_see_++] = r;
+        else                        see_overflow_ = true;
+    }
+
+    struct ActionEntry  { const char* gesture = nullptr; const char* label = nullptr;
+                          const char* help    = nullptr; };
     struct ControlEntry { const char* field   = nullptr; enum Action action = Action::Cycle; };
 
     const char*  ident_;
@@ -460,6 +526,13 @@ class VirtualButton
     /* Host metadata. */
     const char* anchor_ = nullptr;
     const char* disp_ = nullptr;
+
+    /* Manual prose (descriptor-only, never hashed). */
+    const char* help_             = nullptr;
+    const char* bad_gesture_help_ = nullptr;
+    SeeRef      see_[kMaxSeeRefs] = {};
+    uint8_t     num_see_          = 0;
+    bool        see_overflow_     = false;
 
     /* Wiring (set by ButtonBank). */
     const uint8_t* zone_ptr_    = nullptr;

--- a/framework/include/alchemy/surface/virtual_knob.h
+++ b/framework/include/alchemy/surface/virtual_knob.h
@@ -36,6 +36,7 @@
 #include "alchemy/surface/cv_source.h"
 #include "alchemy/surface/knob_storage.h"
 #include "alchemy/surface/lock_source.h"
+#include "alchemy/surface/see_ref.h"
 
 namespace alchemy {
 
@@ -383,6 +384,20 @@ class VirtualKnob
     /** Raw display-hint JSON (protocol §5); overrides the derived hint. */
     VirtualKnob& Disp(const char* disp_json) { disp_json_ = disp_json; return *this; }
 
+    /* ── Manual prose (typically one manual.cpp) ──────────────────────
+     * One markdown layer; never restate structured facts.  SeeAlso takes
+     * the referenced objects (mixed kinds); refs are validated at the
+     * descriptor build — referenced knobs need .Ident(). */
+
+    VirtualKnob& Help(const char* md) { help_ = md; return *this; }
+
+    template <typename... Refs>
+    VirtualKnob& SeeAlso(const Refs&... refs)
+    {
+        (AddSee(SeeRef(refs)), ...);
+        return *this;
+    }
+
     /* ── Read accessors (ISR-safe; cheap) ────────────────────────────── */
 
     /**
@@ -422,6 +437,10 @@ class VirtualKnob
     const char* const* Labels()    const { return labels_; }
     uint8_t            NumLabels() const { return num_labels_; }
     const char*        DispJson()  const { return disp_json_; }
+    const char*        ManualHelp() const { return help_; }
+    const SeeRef*      SeeRefs()   const { return see_; }
+    uint8_t            NumSeeRefs() const { return num_see_; }
+    bool               SeeOverflowed() const { return see_overflow_; }
     Xform              Transform() const { return xform_; }
     float              XformMin()  const { return xform_min_; }
     float              XformMax()  const { return xform_max_; }
@@ -485,6 +504,12 @@ class VirtualKnob
     void*  OverdrawCtx()    const { return overdraw_ctx_; }
 
   private:
+    void AddSee(const SeeRef& r)
+    {
+        if (num_see_ < kMaxSeeRefs) see_[num_see_++] = r;
+        else                        see_overflow_ = true;
+    }
+
     /* Read helpers — all ISR-safe. */
 
     float StoredValue() const
@@ -549,6 +574,12 @@ class VirtualKnob
     const char*        disp_json_  = nullptr;
     const char* const* labels_     = nullptr;
     uint8_t            num_labels_ = 0;
+
+    /* Manual prose (optional; descriptor-only, never hashed). */
+    const char* help_             = nullptr;
+    SeeRef      see_[kMaxSeeRefs] = {};
+    uint8_t     num_see_          = 0;
+    bool        see_overflow_     = false;
 
     /* Transform. */
     Xform xform_     = Xform::Linear;

--- a/framework/src/host_link/describe.cpp
+++ b/framework/src/host_link/describe.cpp
@@ -8,6 +8,8 @@
 #include <cstdio>
 
 #include "alchemy/surface/button_bank.h"
+#include "alchemy/surface/jack.h"
+#include "alchemy/surface/manual.h"
 #include "alchemy/surface/page.h"
 #include "alchemy/surface/pager.h"
 #include "alchemy/surface/presets.h"
@@ -68,11 +70,13 @@ bool ComponentWriter::Open()
 
 bool ComponentWriter::Field(const char* id, const char* name, uint32_t off,
                             FieldType type, float def, const char* disp_json,
-                            uint16_t zones, int16_t page, int16_t pot)
+                            uint16_t zones, int16_t page, int16_t pot,
+                            const char* help, const SeeRef* see,
+                            uint8_t num_see)
 {
     if (!Open()) return false;
     ok_ = db_.GenericField(id, name, off, type, def, zones, disp_json,
-                           page, pot)
+                           page, pot, help, see, num_see)
           && ok_;
     return ok_;
 }
@@ -88,6 +92,13 @@ bool ComponentWriter::MetaUInt(const char* key, uint32_t value)
 {
     if (!Open()) return false;
     ok_ = db_.GenericMetaUInt(key, value) && ok_;
+    return ok_;
+}
+
+bool ComponentWriter::MetaStr(const char* key, const char* value)
+{
+    if (!Open()) return false;
+    ok_ = db_.GenericMetaStr(key, value) && ok_;
     return ok_;
 }
 
@@ -181,10 +192,11 @@ const char* DeriveKnobDisp(const VirtualKnob& k, char* buf, size_t cap)
 bool DescribePager(DescriptorBuilder& db, const Pager& pager,
                    const PageSet* pages, const char* id)
 {
-    /* Tab labels/colors from the declared Pages (sparse ok). */
+    /* Tab labels/colors/help from the declared Pages (sparse ok). */
     const char* names [Pager::kMaxPages] = {};
     const char* colors[Pager::kMaxPages] = {};
-    bool any_name = false, any_color = false;
+    const char* help  [Pager::kMaxPages] = {};
+    bool any_name = false, any_color = false, any_help = false;
     if (pages)
     {
         for (uint8_t i = 0; i < pages->count; i++)
@@ -193,18 +205,21 @@ bool DescribePager(DescriptorBuilder& db, const Pager& pager,
             if (!p || p->Index() >= pager.NumPages()) continue;
             if (p->TabName())  { names [p->Index()] = p->TabName();  any_name  = true; }
             if (p->TabColor()) { colors[p->Index()] = p->TabColor(); any_color = true; }
+            if (p->HelpText()) { help  [p->Index()] = p->HelpText(); any_help  = true; }
         }
     }
 
     bool ok = db.BeginPager(id, pager,
                             any_name  ? names  : nullptr,
-                            any_color ? colors : nullptr);
+                            any_color ? colors : nullptr,
+                            any_help  ? help   : nullptr);
 
     for (uint8_t pg = 0; ok && pg < pager.NumPages(); pg++)
     {
         for (uint8_t pot = 0; ok && pot < pager.NumPots(); pot++)
         {
             const VirtualKnob* k = FindKnob(pages, pg, pot);
+            if (k && k->SeeOverflowed()) return false;
 
             char idbuf[16], namebuf[16], dispbuf[192];
             const char* fid = (k && k->Ident()) ? k->Ident() : idbuf;
@@ -218,7 +233,10 @@ bool DescribePager(DescriptorBuilder& db, const Pager& pager,
 
             const char* disp =
                 k ? DeriveKnobDisp(*k, dispbuf, sizeof dispbuf) : nullptr;
-            ok = db.PagerField(pg, pot, fid, nm, disp);
+            ok = db.PagerField(pg, pot, fid, nm, disp,
+                               k ? k->ManualHelp() : nullptr,
+                               k ? k->SeeRefs()    : nullptr,
+                               k ? k->NumSeeRefs() : 0u);
         }
     }
     return ok && db.EndPager();
@@ -254,11 +272,16 @@ bool DescribeSettings(DescriptorBuilder& db, const Settings& st,
                       const char* id)
 {
     const char* names[kSettingsMaxPages] = {};
-    bool any_name = false;
+    const char* help [kSettingsMaxPages] = {};
+    bool any_name = false, any_help = false;
     for (uint8_t pg = 0; pg < st.NumPages() && pg < kSettingsMaxPages; pg++)
+    {
         if (st.PageNameAt(pg)) { names[pg] = st.PageNameAt(pg); any_name = true; }
+        if (st.PageHelpAt(pg)) { help [pg] = st.PageHelpAt(pg); any_help = true; }
+    }
 
-    bool ok = db.BeginSettings(id, st, any_name ? names : nullptr, nullptr);
+    bool ok = db.BeginSettings(id, st, any_name ? names : nullptr, nullptr,
+                               any_help ? help : nullptr);
 
     /* Count persisted controls per kind so a unique control gets a plain
      * name ("Brightness") and repeats get position suffixes. */
@@ -277,6 +300,7 @@ bool DescribeSettings(DescriptorBuilder& db, const Settings& st,
         {
             const SettingsKind k = st.KindAt(pg, pot);
             if (Settings::PersistedBytesFor(k) == 0u) continue;
+            if (st.SeeOverflowedAt(pg, pot)) return false;
 
             char fid[12], nm[24];
             std::snprintf(fid, sizeof fid, "s%u.%u", pg, pot);
@@ -286,8 +310,20 @@ bool DescribeSettings(DescriptorBuilder& db, const Settings& st,
             else
                 std::snprintf(nm, sizeof nm, "%s", SettingsKindName(k));
 
-            ok = db.SettingsField(pg, pot, fid, nm,
-                                  nullptr /* derive from kind */);
+            /* Declared identity wins; brightness ships stock help. */
+            const char* ident = st.IdentAt(pg, pot);
+            const char* name  = st.DisplayNameAt(pg, pot);
+            const char* h     = st.HelpAt(pg, pot);
+            if (!h && k == SettingsKind::Brightness)
+                h = stock_help::kBrightness;
+
+            uint8_t       num_see = 0u;
+            const SeeRef* see     = st.SeeRefsAt(pg, pot, &num_see);
+
+            ok = db.SettingsField(pg, pot, ident ? ident : fid,
+                                  name ? name : nm,
+                                  nullptr /* derive from kind/labels */,
+                                  h, see, num_see);
         }
     }
     return ok && db.EndSettings();
@@ -306,11 +342,21 @@ uint32_t RenderDescriptor(char* buf, size_t cap,
                           const VirtualButton* buttons,
                           uint8_t num_buttons,
                           const char* const* root_fragments,
-                          uint8_t num_root_fragments)
+                          uint8_t num_root_fragments,
+                          const Jack* jacks,
+                          uint8_t num_jacks,
+                          const Manual* manual)
 {
+    /* A manual tagline rides the module{} block. */
+    DescriptorBuilder::ModuleInfo mi = info;
+    if (manual && manual->TaglineText() && !mi.tagline)
+        mi.tagline = manual->TaglineText();
+
     DescriptorBuilder db(buf, cap, presets);
-    bool ok = db.Begin(info);
+    bool ok = db.Begin(mi);
     if (ok) ok = db.Buttons(buttons, num_buttons);
+    if (ok) ok = db.Jacks(jacks, num_jacks);
+    if (ok) ok = db.ManualBlock(manual);   /* stock preset help at minimum */
     for (uint8_t i = 0u; ok && i < num_root_fragments; i++)
         ok = db.RawRoot(root_fragments[i]);
 

--- a/framework/src/host_link/describe.cpp
+++ b/framework/src/host_link/describe.cpp
@@ -339,11 +339,11 @@ uint32_t RenderDescriptor(char* buf, size_t cap,
                           const PageSet* pages,
                           const DescribeOverride* overrides,
                           uint8_t num_overrides,
-                          const VirtualButton* buttons,
+                          const VirtualButton* const* buttons,
                           uint8_t num_buttons,
                           const char* const* root_fragments,
                           uint8_t num_root_fragments,
-                          const Jack* jacks,
+                          const Jack* const* jacks,
                           uint8_t num_jacks,
                           const Manual* manual)
 {

--- a/framework/src/host_link/describe.cpp
+++ b/framework/src/host_link/describe.cpp
@@ -329,6 +329,35 @@ bool DescribeSettings(DescriptorBuilder& db, const Settings& st,
     return ok && db.EndSettings();
 }
 
+/* A failed build degrades to a minimal descriptor carrying the reason:
+ * identity intact, no state (empty components, zero size/hash), "error"
+ * root key — hosts show the cause instead of a silent "no descriptor". */
+uint32_t RenderErrorDescriptor(char* buf, size_t cap,
+                               const DescriptorBuilder::ModuleInfo& m,
+                               const char* reason)
+{
+    JsonWriter w(buf, cap);
+    w.BeginObj();
+    w.Key("dv");     w.UInt(1u);
+    w.Key("module");
+    w.BeginObj();
+    w.Key("id");     w.Str(m.id);
+    w.Key("name");   w.Str(m.name);
+    w.Key("fw");     w.Str(m.fw);
+    w.Key("git");    w.Str(m.git);
+    w.Key("sdk");    w.Str(m.sdk);
+    w.Key("board");  w.Str(m.board);
+    if (m.tagline) { w.Key("tagline"); w.Str(m.tagline); }
+    w.EndObj();
+    w.Key("schemaHash"); w.UInt(0u);
+    w.Key("size");       w.UInt(0u);
+    w.Key("components"); w.BeginArr(); w.EndArr();
+    w.Key("error");
+    w.Str(reason && reason[0] ? reason : "descriptor build failed");
+    w.EndObj();
+    return w.Ok() ? static_cast<uint32_t>(w.Length()) : 0u;
+}
+
 } // namespace
 
 /* ── RenderDescriptor ───────────────────────────────────────────────── */
@@ -345,7 +374,9 @@ uint32_t RenderDescriptor(char* buf, size_t cap,
                           uint8_t num_root_fragments,
                           const Jack* const* jacks,
                           uint8_t num_jacks,
-                          const Manual* manual)
+                          const Manual* manual,
+                          const uint8_t* factory,
+                          size_t factory_len)
 {
     /* A manual tagline rides the module{} block. */
     DescriptorBuilder::ModuleInfo mi = info;
@@ -353,6 +384,7 @@ uint32_t RenderDescriptor(char* buf, size_t cap,
         mi.tagline = manual->TaglineText();
 
     DescriptorBuilder db(buf, cap, presets);
+    if (factory && factory_len) db.Defaults(factory, factory_len);
     bool ok = db.Begin(mi);
     if (ok) ok = db.Buttons(buttons, num_buttons);
     if (ok) ok = db.Jacks(jacks, num_jacks);
@@ -420,7 +452,9 @@ uint32_t RenderDescriptor(char* buf, size_t cap,
         }
     }
 
-    return ok ? db.Finish() : 0u;
+    const uint32_t len = ok ? db.Finish() : 0u;
+    if (len) return len;
+    return RenderErrorDescriptor(buf, cap, mi, db.LastError());
 }
 
 } // namespace hostlink

--- a/framework/src/host_link/descriptor.cpp
+++ b/framework/src/host_link/descriptor.cpp
@@ -9,11 +9,14 @@
 #include <cstring>
 
 #include "alchemy/host_link/json_check.h"
+#include "alchemy/surface/jack.h"
+#include "alchemy/surface/manual.h"
 #include "alchemy/surface/pager.h"
 #include "alchemy/surface/presets.h"
 #include "alchemy/surface/settings.h"
 #include "alchemy/surface/serializable.h"
 #include "alchemy/surface/virtual_button.h"
+#include "alchemy/surface/virtual_knob.h"
 
 namespace alchemy {
 namespace hostlink {
@@ -39,6 +42,7 @@ bool DescriptorBuilder::Begin(const ModuleInfo& m)
     w_.Key("git");    w_.Str(m.git);
     w_.Key("sdk");    w_.Str(m.sdk);
     w_.Key("board");  w_.Str(m.board);
+    if (m.tagline) { w_.Key("tagline"); w_.Str(m.tagline); }
     w_.EndObj();
     w_.Key("schemaHash"); w_.UInt(presets_.LiveSchemaHash());
     w_.Key("size");       w_.UInt(static_cast<uint32_t>(presets_.LiveSize()));
@@ -100,13 +104,91 @@ bool DescriptorBuilder::RecordFieldId(const char* id)
     return true;
 }
 
-bool DescriptorBuilder::RecordRef(const char* kind, const char* target)
+bool DescriptorBuilder::RecordExtraId(const char* id)
+{
+    if (!id) return Fail("entity id null");
+    if (num_extra_ids_ >= kMaxExtraIds)
+        return Fail("too many entity ids for ref validation");
+    extra_ids_[num_extra_ids_++] = IdHash(id);
+    return true;
+}
+
+bool DescriptorBuilder::RecordRef(const char* kind, const char* target,
+                                  bool fields_only)
 {
     if (num_refs_ >= kMaxRefs) return Fail("too many field refs");
-    refs_[num_refs_].kind   = kind;
-    refs_[num_refs_].target = target;
+    refs_[num_refs_].kind        = kind;
+    refs_[num_refs_].target      = target;
+    refs_[num_refs_].hash        = IdHash(target);
+    refs_[num_refs_].fields_only = fields_only;
     num_refs_++;
     return true;
+}
+
+/* ── SeeAlso resolution + prose emission ────────────────────────────── */
+
+const char* DescriptorBuilder::ResolveSee(const SeeRef& r, char* buf,
+                                          size_t cap)
+{
+    switch (r.K())
+    {
+        case SeeRef::Kind::Raw:
+            return r.Raw();
+        case SeeRef::Kind::Jack:
+            return static_cast<const Jack*>(r.Ptr())->Id();
+        case SeeRef::Kind::Button:
+        {
+            const VirtualButton* b = static_cast<const VirtualButton*>(r.Ptr());
+            if (b->Ident()) return b->Ident();
+            std::snprintf(buf, cap, "b%u", b->HwIndex());
+            return buf;
+        }
+        case SeeRef::Kind::Knob:
+        {
+            const VirtualKnob* k = static_cast<const VirtualKnob*>(r.Ptr());
+            if (k->Ident()) return k->Ident();
+            FailRef("see", k->Name(), "targets a knob without Ident()");
+            return nullptr;
+        }
+        case SeeRef::Kind::Slot:
+        {
+            const SettingsSlot* s = static_cast<const SettingsSlot*>(r.Ptr());
+            if (s->ident) return s->ident;
+            FailRef("see", s->display_name ? s->display_name : "(settings)",
+                    "targets a control without Ident()");
+            return nullptr;
+        }
+        case SeeRef::Kind::None:
+        default:
+            Fail("see: empty reference");
+            return nullptr;
+    }
+}
+
+bool DescriptorBuilder::EmitHelpSee(const char* help, const SeeRef* see,
+                                    uint8_t num_see)
+{
+    if (help && help[0]) { w_.Key("help"); w_.Str(help); }
+    if (see && num_see > 0u)
+    {
+        w_.Key("see");
+        w_.BeginArr();
+        for (uint8_t i = 0; i < num_see; i++)
+        {
+            char        buf[8];
+            const char* id = ResolveSee(see[i], buf, sizeof buf);
+            if (!id) return false;
+            if (num_refs_ >= kMaxRefs) return Fail("too many field refs");
+            refs_[num_refs_].kind        = "see";
+            refs_[num_refs_].target      = (id == buf) ? nullptr : id;
+            refs_[num_refs_].hash        = IdHash(id);
+            refs_[num_refs_].fields_only = false;
+            num_refs_++;
+            w_.Str(id);
+        }
+        w_.EndArr();
+    }
+    return !error_;
 }
 
 void DescriptorBuilder::OpenComponent(const char* id, const char* kind,
@@ -125,7 +207,8 @@ void DescriptorBuilder::OpenComponent(const char* id, const char* kind,
 
 bool DescriptorBuilder::BeginPager(const char* id, const Pager& pager,
                                    const char* const* page_names,
-                                   const char* const* page_colors)
+                                   const char* const* page_colors,
+                                   const char* const* page_help)
 {
     if (!CheckManaged(pager)) return false;
 
@@ -140,18 +223,19 @@ bool DescriptorBuilder::BeginPager(const char* id, const Pager& pager,
 
     w_.Key("pages"); w_.UInt(pager.NumPages());
     w_.Key("pots");  w_.UInt(pager.NumPots());
-    EmitPageMeta(page_names, page_colors, pager.NumPages());
+    EmitPageMeta(page_names, page_colors, page_help, pager.NumPages());
     w_.Key("fields");
     w_.BeginArr();
     fields_open_ = true;
     return !error_;
 }
 
-/* Optional per-page tab labels/colors ("pageNames" / "pageColors").
- * Null array pointers emit nothing; null entries emit "" so hosts fall
- * back to a generic label for just that page. */
+/* Optional per-page tab labels/colors/help ("pageNames" / "pageColors" /
+ * "pageHelp" — parallel arrays, protocol §5).  Null array pointers emit
+ * nothing; null entries emit "" so hosts fall back per page. */
 void DescriptorBuilder::EmitPageMeta(const char* const* names,
                                      const char* const* colors,
+                                     const char* const* help,
                                      uint8_t num_pages)
 {
     if (names)
@@ -168,11 +252,20 @@ void DescriptorBuilder::EmitPageMeta(const char* const* names,
         for (uint8_t i = 0; i < num_pages; i++) w_.Str(colors[i] ? colors[i] : "");
         w_.EndArr();
     }
+    if (help)
+    {
+        w_.Key("pageHelp");
+        w_.BeginArr();
+        for (uint8_t i = 0; i < num_pages; i++) w_.Str(help[i] ? help[i] : "");
+        w_.EndArr();
+    }
 }
 
 bool DescriptorBuilder::PagerField(uint8_t page, uint8_t pot,
                                    const char* field_id, const char* name,
-                                   const char* disp_json)
+                                   const char* disp_json,
+                                   const char* help,
+                                   const SeeRef* see, uint8_t num_see)
 {
     if (!pager_ || !fields_open_) return Fail("pager: field before BeginPager");
     if (page >= pager_->NumPages() || pot >= pager_->NumPots())
@@ -193,6 +286,7 @@ bool DescriptorBuilder::PagerField(uint8_t page, uint8_t pot,
     w_.Key("disp");
     if (disp_json) w_.RawValue(disp_json);
     else           w_.RawValue("{\"kind\":\"norm\"}");
+    if (!EmitHelpSee(help, see, num_see)) return false;
     w_.EndObj();
     return !error_;
 }
@@ -298,14 +392,16 @@ bool DescriptorBuilder::ComponentPageMeta(const char* const* names,
                                           uint8_t num_pages)
 {
     if (!generic_open_ || fields_open_) return Fail("component: page meta after fields");
-    EmitPageMeta(names, colors, num_pages);
+    EmitPageMeta(names, colors, nullptr, num_pages);
     return !error_;
 }
 
 bool DescriptorBuilder::GenericField(const char* id, const char* name,
                                      uint32_t off, FieldType type, float def,
                                      uint16_t zones, const char* disp_json,
-                                     int16_t page, int16_t pot)
+                                     int16_t page, int16_t pot,
+                                     const char* help,
+                                     const SeeRef* see, uint8_t num_see)
 {
     if (!generic_open_) return Fail("component: field before Begin");
     if (!fields_open_)
@@ -344,6 +440,7 @@ bool DescriptorBuilder::GenericField(const char* id, const char* name,
         w_.Key("disp");
         w_.RawValue(disp_json ? disp_json : "{\"kind\":\"norm\"}");
     }
+    if (!EmitHelpSee(help, see, num_see)) return false;
     w_.EndObj();
     return !error_;
 }
@@ -384,6 +481,15 @@ bool DescriptorBuilder::GenericMetaUInt(const char* key, uint32_t value)
     if (!key || !key[0]) return Fail("component: meta key empty");
     w_.Key(key);
     w_.UInt(value);
+    return !error_;
+}
+
+bool DescriptorBuilder::GenericMetaStr(const char* key, const char* value)
+{
+    if (!generic_open_ || fields_open_) return Fail("component: meta after fields");
+    if (!key || !key[0] || !value) return Fail("component: meta key/value empty");
+    w_.Key(key);
+    w_.Str(value);
     return !error_;
 }
 
@@ -457,11 +563,12 @@ static const char* DeriveGestureLabel(const VirtualButton& b,
 }
 
 static void EmitGestureEntry(JsonWriter& w, const char* gesture,
-                             const char* label)
+                             const char* label, const char* help = nullptr)
 {
     w.BeginObj();
     w.Key("gesture"); w.Str(gesture);
     w.Key("label");   w.Str(label ? label : "");
+    if (help && help[0]) { w.Key("help"); w.Str(help); }
     w.EndObj();
 }
 
@@ -474,7 +581,8 @@ static void EmitGestures(JsonWriter& w, const VirtualButton& b,
     w.BeginArr();
     if (b.TapGesture().used)
         EmitGestureEntry(w, "tap",
-                         DeriveGestureLabel(b, b.TapGesture(), buf, sizeof buf));
+                         DeriveGestureLabel(b, b.TapGesture(), buf, sizeof buf),
+                         b.TapGesture().help);
     else if (implicit_tap)
     {
         VirtualButton::Gesture g;
@@ -483,11 +591,24 @@ static void EmitGestures(JsonWriter& w, const VirtualButton& b,
     }
     if (b.HoldGesture().used)
         EmitGestureEntry(w, "hold",
-                         DeriveGestureLabel(b, b.HoldGesture(), buf, sizeof buf));
+                         DeriveGestureLabel(b, b.HoldGesture(), buf, sizeof buf),
+                         b.HoldGesture().help);
     for (uint8_t i = 0; i < b.NumActions(); i++)
         EmitGestureEntry(w, b.ActionGesture(i) ? b.ActionGesture(i) : "",
-                         b.ActionLabel(i));
+                         b.ActionLabel(i), b.ActionHelp(i));
     w.EndArr();
+}
+
+/* Latched declaration errors fail the build; text never silently drops. */
+bool DescriptorBuilder::EmitButtonManual(const VirtualButton& b)
+{
+    if (b.BadGestureHelpKey())
+        return FailRef("gestureHelp", b.BadGestureHelpKey(),
+                       "matches no declared gesture");
+    if (b.SeeOverflowed())
+        return FailRef("see", b.Name() ? b.Name() : "(button)",
+                       "has too many SeeAlso refs");
+    return EmitHelpSee(b.ManualHelp(), b.SeeRefs(), b.NumSeeRefs());
 }
 
 bool DescriptorBuilder::ButtonsModal(const VirtualButton& b, int16_t page)
@@ -502,13 +623,16 @@ bool DescriptorBuilder::ButtonsModal(const VirtualButton& b, int16_t page)
         modal_open_ = true;
     }
     char idbuf[8];
+    const char* eff = ButtonEffectiveId(b, idbuf, sizeof idbuf);
+    if (!RecordExtraId(eff)) return false;
     w_.BeginObj();
-    w_.Key("id");   w_.Str(ButtonEffectiveId(b, idbuf, sizeof idbuf));
+    w_.Key("id");   w_.Str(eff);
     w_.Key("name"); w_.Str(b.Name() ? b.Name() : "");
     if (b.HasHw()) { w_.Key("index"); w_.UInt(b.HwIndex()); }
     if (page >= 0) { w_.Key("page");  w_.UInt(static_cast<uint32_t>(page)); }
     w_.Key("gestures");
     EmitGestures(w_, b, false);
+    if (!EmitButtonManual(b)) return false;
     w_.EndObj();
     return !error_;
 }
@@ -542,7 +666,7 @@ bool DescriptorBuilder::ButtonsField(const VirtualButton& b, uint32_t off,
     {
         if (std::strcmp(b.AnchorField(), eff) == 0)
             return FailRef("anchor", b.AnchorField(), "is the field itself");
-        if (!RecordRef("anchor", b.AnchorField())) return false;
+        if (!RecordRef("anchor", b.AnchorField(), /*fields_only=*/true)) return false;
     }
 
     w_.BeginObj();
@@ -603,6 +727,7 @@ bool DescriptorBuilder::ButtonsField(const VirtualButton& b, uint32_t off,
         EmitGestures(w_, b, implicit_tap);
         w_.EndObj();
     }
+    if (!EmitButtonManual(b)) return false;
     w_.EndObj();
     return !error_;
 }
@@ -625,13 +750,14 @@ bool DescriptorBuilder::EndButtons()
 
 bool DescriptorBuilder::BeginSettings(const char* id, const Settings& settings,
                                       const char* const* page_names,
-                                      const char* const* page_colors)
+                                      const char* const* page_colors,
+                                      const char* const* page_help)
 {
     if (!CheckManaged(settings)) return false;
 
     settings_ = &settings;
     OpenComponent(id, "settings", settings);
-    EmitPageMeta(page_names, page_colors, settings.NumPages());
+    EmitPageMeta(page_names, page_colors, page_help, settings.NumPages());
 
     /* Gesture-owned pots (the UsePresets save/load surface) persist no
      * bytes, so they can never be SettingsFields — but they ARE part of
@@ -688,7 +814,9 @@ bool DescriptorBuilder::BeginSettings(const char* id, const Settings& settings,
 
 bool DescriptorBuilder::SettingsField(uint8_t page, uint8_t pot,
                                       const char* field_id, const char* name,
-                                      const char* disp_json)
+                                      const char* disp_json,
+                                      const char* help,
+                                      const SeeRef* see, uint8_t num_see)
 {
     if (!settings_ || !fields_open_) return Fail("settings: field before BeginSettings");
     if (page >= kMaxSettingsPages || pot >= kMaxPots)
@@ -707,12 +835,35 @@ bool DescriptorBuilder::SettingsField(uint8_t page, uint8_t pot,
 
     if (kind == SettingsKind::Selector)
     {
+        const uint8_t zones = settings_->ZonesAt(page, pot);
+        const char* const* labels = settings_->LabelsAt(page, pot);
+        const uint8_t num_labels  = settings_->NumLabelsAt(page, pot);
+        if (labels && num_labels != zones)
+            return Fail("settings: selector labels != zones");
+
         w_.Key("type");  w_.Str("enum");
-        w_.Key("zones"); w_.UInt(settings_->ZonesAt(page, pot));
+        w_.Key("zones"); w_.UInt(zones);
         w_.Key("def");   w_.UInt(settings_->SelectorIdxAt(page, pot));
         w_.Key("disp");
-        if (disp_json) w_.RawValue(disp_json);
-        else           w_.RawValue("{\"kind\":\"enum\"}");
+        if (disp_json)
+        {
+            w_.RawValue(disp_json);
+        }
+        else if (labels)
+        {
+            w_.BeginObj();
+            w_.Key("kind"); w_.Str("enum");
+            w_.Key("labels");
+            w_.BeginArr();
+            for (uint8_t i = 0; i < num_labels; i++)
+                w_.Str(labels[i] ? labels[i] : "");
+            w_.EndArr();
+            w_.EndObj();
+        }
+        else
+        {
+            w_.RawValue("{\"kind\":\"enum\"}");
+        }
     }
     else
     {
@@ -740,6 +891,7 @@ bool DescriptorBuilder::SettingsField(uint8_t page, uint8_t pot,
             w_.RawValue("{\"kind\":\"norm\"}");
         }
     }
+    if (!EmitHelpSee(help, see, num_see)) return false;
     w_.EndObj();
     return !error_;
 }
@@ -782,6 +934,26 @@ bool DescriptorBuilder::Buttons(const VirtualButton* buttons, uint8_t count)
     return !error_;
 }
 
+bool DescriptorBuilder::Jacks(const Jack* jacks, uint8_t count)
+{
+    if (pager_ || settings_ || generic_open_ || buttons_open_)
+        return Fail("jacks table while component open");
+    if (count > 0u && !jacks)
+        return Fail("jacks table null with nonzero count");
+    jacks_     = jacks;
+    num_jacks_ = count;
+    return !error_;
+}
+
+bool DescriptorBuilder::ManualBlock(const Manual* manual)
+{
+    if (pager_ || settings_ || generic_open_ || buttons_open_)
+        return Fail("manual block while component open");
+    manual_      = manual;
+    emit_manual_ = true;
+    return !error_;
+}
+
 /* Emit the stashed button table as a top-level "buttons":[...] array.
  * Called from Finish() between the components array close and the root
  * object close.  No-op when the caller stashed nothing.  Controls
@@ -794,6 +966,7 @@ void DescriptorBuilder::EmitRootButtons()
     for (uint8_t i = 0; i < num_buttons_; i++)
     {
         const VirtualButton& b = buttons_[i];
+        if (b.Ident()) RecordExtraId(b.Ident());
         w_.BeginObj();
         w_.Key("id");   w_.Str(b.Ident() ? b.Ident() : "");
         w_.Key("name"); w_.Str(b.Name()  ? b.Name()  : "");
@@ -808,6 +981,7 @@ void DescriptorBuilder::EmitRootButtons()
                 w_.BeginObj();
                 w_.Key("gesture"); w_.Str(b.ActionGesture(j) ? b.ActionGesture(j) : "");
                 w_.Key("label");   w_.Str(b.ActionLabel  (j) ? b.ActionLabel  (j) : "");
+                if (b.ActionHelp(j)) { w_.Key("help"); w_.Str(b.ActionHelp(j)); }
                 w_.EndObj();
             }
             w_.EndArr();
@@ -821,15 +995,91 @@ void DescriptorBuilder::EmitRootButtons()
                 const char* f = b.ControlField(j);
                 w_.BeginObj();
                 w_.Key("field");  w_.Str(f ? f : "");
-                if (f && f[0]) RecordRef("controls", f);
+                if (f && f[0]) RecordRef("controls", f, /*fields_only=*/true);
                 w_.Key("action"); w_.Str(VirtualButton::ActionName(b.ControlAction(j)));
                 w_.EndObj();
             }
             w_.EndArr();
         }
+        EmitButtonManual(b);
         w_.EndObj();
     }
     w_.EndArr();
+}
+
+void DescriptorBuilder::EmitRootJacks()
+{
+    if (num_jacks_ == 0u || jacks_ == nullptr) return;
+    w_.Key("jacks");
+    w_.BeginArr();
+    for (uint8_t i = 0; i < num_jacks_; i++)
+    {
+        const Jack& j = jacks_[i];
+        if (!j.Id() || !j.Id()[0]) { Fail("jack: empty id"); return; }
+        RecordExtraId(j.Id());
+        if (j.SeeOverflowed())
+        {
+            FailRef("see", j.Id(), "has too many SeeAlso refs");
+            return;
+        }
+        w_.BeginObj();
+        w_.Key("id");   w_.Str(j.Id());
+        w_.Key("name"); w_.Str(j.Name() ? j.Name() : "");
+        if (j.Silk()) { w_.Key("short"); w_.Str(j.Silk()); }
+        w_.Key("sig"); w_.Str(Jack::SigName(j.Sig()));
+        if (j.Norm())
+        {
+            w_.Key("norm");
+            w_.Str(j.Norm()->Id());
+            RecordRef("norm", j.Norm()->Id());
+        }
+        EmitHelpSee(j.ManualHelp(), j.SeeRefs(), j.NumSeeRefs());
+        w_.EndObj();
+    }
+    w_.EndArr();
+}
+
+void DescriptorBuilder::EmitManualBlock()
+{
+    if (!emit_manual_) return;
+    if (manual_ && manual_->Overflowed()) { Fail("manual: too many sections"); return; }
+
+    RecordExtraId("presets");   /* SeeAlso("presets") is always valid */
+
+    w_.Key("manual");
+    w_.BeginObj();
+    if (manual_ && manual_->PreambleText())
+    {
+        w_.Key("preamble");
+        w_.Str(manual_->PreambleText());
+    }
+    if (manual_ && manual_->NumSections() > 0u)
+    {
+        w_.Key("sections");
+        w_.BeginArr();
+        for (uint8_t i = 0; i < manual_->NumSections(); i++)
+        {
+            const Manual::SectionDecl& s = manual_->SectionAt(i);
+            if (!s.id || !s.title || !s.body)
+            {
+                Fail("manual: section missing id/title/body");
+                return;
+            }
+            w_.BeginObj();
+            w_.Key("id");    w_.Str(s.id);
+            w_.Key("title"); w_.Str(s.title);
+            w_.Key("body");  w_.Str(s.body);
+            w_.EndObj();
+        }
+        w_.EndArr();
+    }
+    w_.Key("presets");
+    w_.BeginObj();
+    w_.Key("help");
+    w_.Str((manual_ && manual_->PresetsHelpText()) ? manual_->PresetsHelpText()
+                                                   : stock_help::kPresets);
+    w_.EndObj();
+    w_.EndObj();
 }
 
 /* ── Finish ─────────────────────────────────────────────────────────── */
@@ -838,19 +1088,26 @@ uint32_t DescriptorBuilder::Finish()
 {
     w_.EndArr();   /* components */
     EmitRootButtons();
+    EmitRootJacks();
     for (uint8_t i = 0u; i < num_root_fragments_; i++)
         w_.RawValue(root_fragments_[i]);
+    EmitManualBlock();
     w_.EndObj();   /* root */
 
     /* Cross-field refs match against the full id table only now — a
      * ref may precede its target in Manage() order or follow it. */
     for (uint8_t i = 0u; i < num_refs_; i++)
     {
-        const uint32_t want  = IdHash(refs_[i].target);
-        bool           found = false;
+        bool found = false;
         for (uint16_t k = 0u; !found && k < num_field_ids_; k++)
-            found = field_ids_[k] == want;
-        if (!found) FailRef(refs_[i].kind, refs_[i].target, "names no field");
+            found = field_ids_[k] == refs_[i].hash;
+        for (uint8_t k = 0u; !found && !refs_[i].fields_only
+                             && k < num_extra_ids_; k++)
+            found = extra_ids_[k] == refs_[i].hash;
+        if (!found)
+            FailRef(refs_[i].kind,
+                    refs_[i].target ? refs_[i].target : "(positional)",
+                    "names no field");
     }
 
     if (error_) return 0u;

--- a/framework/src/host_link/descriptor.cpp
+++ b/framework/src/host_link/descriptor.cpp
@@ -923,24 +923,57 @@ bool DescriptorBuilder::RawRoot(const char* fragment)
 
 bool DescriptorBuilder::Buttons(const VirtualButton* buttons, uint8_t count)
 {
-    if (pager_ || settings_ || generic_open_ || buttons_open_)
-        return Fail("buttons table while component open");
-    /* Passing a null pointer with a nonzero count would emit dangling
-     * commas in Finish(); reject up front. */
     if (count > 0u && !buttons)
         return Fail("buttons table null with nonzero count");
-    buttons_     = buttons;
+    if (count > kMaxRootButtons) return Fail("too many buttons");
+    if (pager_ || settings_ || generic_open_ || buttons_open_)
+        return Fail("buttons table while component open");
+    for (uint8_t i = 0; i < count; i++) btn_ptrs_[i] = &buttons[i];
+    num_buttons_ = count;
+    return !error_;
+}
+
+bool DescriptorBuilder::Buttons(const VirtualButton* const* buttons,
+                                uint8_t count)
+{
+    if (count > 0u && !buttons)
+        return Fail("buttons table null with nonzero count");
+    if (count > kMaxRootButtons) return Fail("too many buttons");
+    if (pager_ || settings_ || generic_open_ || buttons_open_)
+        return Fail("buttons table while component open");
+    for (uint8_t i = 0; i < count; i++)
+    {
+        if (!buttons[i]) return Fail("buttons table has null entry");
+        btn_ptrs_[i] = buttons[i];
+    }
     num_buttons_ = count;
     return !error_;
 }
 
 bool DescriptorBuilder::Jacks(const Jack* jacks, uint8_t count)
 {
-    if (pager_ || settings_ || generic_open_ || buttons_open_)
-        return Fail("jacks table while component open");
     if (count > 0u && !jacks)
         return Fail("jacks table null with nonzero count");
-    jacks_     = jacks;
+    if (count > kMaxJacks) return Fail("too many jacks");
+    if (pager_ || settings_ || generic_open_ || buttons_open_)
+        return Fail("jacks table while component open");
+    for (uint8_t i = 0; i < count; i++) jack_ptrs_[i] = &jacks[i];
+    num_jacks_ = count;
+    return !error_;
+}
+
+bool DescriptorBuilder::Jacks(const Jack* const* jacks, uint8_t count)
+{
+    if (count > 0u && !jacks)
+        return Fail("jacks table null with nonzero count");
+    if (count > kMaxJacks) return Fail("too many jacks");
+    if (pager_ || settings_ || generic_open_ || buttons_open_)
+        return Fail("jacks table while component open");
+    for (uint8_t i = 0; i < count; i++)
+    {
+        if (!jacks[i]) return Fail("jacks table has null entry");
+        jack_ptrs_[i] = jacks[i];
+    }
     num_jacks_ = count;
     return !error_;
 }
@@ -960,12 +993,12 @@ bool DescriptorBuilder::ManualBlock(const Manual* manual)
  * entries are cross-field refs — collected for the Finish() match. */
 void DescriptorBuilder::EmitRootButtons()
 {
-    if (num_buttons_ == 0u || buttons_ == nullptr) return;
+    if (num_buttons_ == 0u) return;
     w_.Key("buttons");
     w_.BeginArr();
     for (uint8_t i = 0; i < num_buttons_; i++)
     {
-        const VirtualButton& b = buttons_[i];
+        const VirtualButton& b = *btn_ptrs_[i];
         if (b.Ident()) RecordExtraId(b.Ident());
         w_.BeginObj();
         w_.Key("id");   w_.Str(b.Ident() ? b.Ident() : "");
@@ -1009,12 +1042,12 @@ void DescriptorBuilder::EmitRootButtons()
 
 void DescriptorBuilder::EmitRootJacks()
 {
-    if (num_jacks_ == 0u || jacks_ == nullptr) return;
+    if (num_jacks_ == 0u) return;
     w_.Key("jacks");
     w_.BeginArr();
     for (uint8_t i = 0; i < num_jacks_; i++)
     {
-        const Jack& j = jacks_[i];
+        const Jack& j = *jack_ptrs_[i];
         if (!j.Id() || !j.Id()[0]) { Fail("jack: empty id"); return; }
         RecordExtraId(j.Id());
         if (j.SeeOverflowed())

--- a/framework/src/host_link/descriptor.cpp
+++ b/framework/src/host_link/descriptor.cpp
@@ -30,6 +30,26 @@ DescriptorBuilder::DescriptorBuilder(char* buf, size_t cap,
             offsets_[pg][p] = -1;
 }
 
+void DescriptorBuilder::Defaults(const uint8_t* blob, size_t len)
+{
+    defs_     = blob;
+    defs_len_ = len;
+}
+
+bool DescriptorBuilder::DefF32(uint32_t abs_off, float* v)
+{
+    if (abs_off + 4u > defs_len_) return Fail("defaults image short");
+    std::memcpy(v, defs_ + abs_off, 4u);
+    return true;
+}
+
+bool DescriptorBuilder::DefByte(uint32_t abs_off, uint8_t* v)
+{
+    if (abs_off >= defs_len_) return Fail("defaults image short");
+    *v = defs_[abs_off];
+    return true;
+}
+
 bool DescriptorBuilder::Begin(const ModuleInfo& m)
 {
     w_.BeginObj();
@@ -275,6 +295,9 @@ bool DescriptorBuilder::PagerField(uint8_t page, uint8_t pot,
     const uint32_t off =
         (static_cast<uint32_t>(page) * pager_->NumPots() + pot) * 4u;
 
+    float def = pager_->Stored(page, pot);
+    if (defs_ && !DefF32(cum_off_ + off, &def)) return false;
+
     w_.BeginObj();
     w_.Key("id");   w_.Str(field_id);
     w_.Key("name"); w_.Str(name);
@@ -282,7 +305,7 @@ bool DescriptorBuilder::PagerField(uint8_t page, uint8_t pot,
     w_.Key("type"); w_.Str("f32");
     w_.Key("page"); w_.UInt(page);
     w_.Key("pot");  w_.UInt(pot);
-    w_.Key("def");  w_.Float(pager_->Stored(page, pot));
+    w_.Key("def");  w_.Float(def);
     w_.Key("disp");
     if (disp_json) w_.RawValue(disp_json);
     else           w_.RawValue("{\"kind\":\"norm\"}");
@@ -833,6 +856,9 @@ bool DescriptorBuilder::SettingsField(uint8_t page, uint8_t pot,
     w_.Key("page"); w_.UInt(page);
     w_.Key("pot");  w_.UInt(pot);
 
+    const uint32_t abs_off =
+        cum_off_ + static_cast<uint32_t>(offsets_[page][pot]);
+
     if (kind == SettingsKind::Selector)
     {
         const uint8_t zones = settings_->ZonesAt(page, pot);
@@ -841,9 +867,12 @@ bool DescriptorBuilder::SettingsField(uint8_t page, uint8_t pot,
         if (labels && num_labels != zones)
             return Fail("settings: selector labels != zones");
 
+        uint8_t def = settings_->SelectorIdxAt(page, pot);
+        if (defs_ && !DefByte(abs_off, &def)) return false;
+
         w_.Key("type");  w_.Str("enum");
         w_.Key("zones"); w_.UInt(zones);
-        w_.Key("def");   w_.UInt(settings_->SelectorIdxAt(page, pot));
+        w_.Key("def");   w_.UInt(def);
         w_.Key("disp");
         if (disp_json)
         {
@@ -867,8 +896,11 @@ bool DescriptorBuilder::SettingsField(uint8_t page, uint8_t pot,
     }
     else
     {
+        float def = settings_->StoredNormAt(page, pot);
+        if (defs_ && !DefF32(abs_off, &def)) return false;
+
         w_.Key("type"); w_.Str("f32");
-        w_.Key("def");  w_.Float(settings_->StoredNormAt(page, pot));
+        w_.Key("def");  w_.Float(def);
         w_.Key("disp");
         if (disp_json)
         {

--- a/framework/src/host_link/host.cpp
+++ b/framework/src/host_link/host.cpp
@@ -23,9 +23,10 @@ namespace alchemy {
 namespace hostlink {
 
 /* One Host per system (the CDC callback is a hardware singleton), so
- * SDK-owned default buffers are safe to share.  SDRAM: big, cold, only
- * touched during host transactions — and not zeroed by startup, hence
- * the memsets in Start(). */
+ * SDK-owned default buffers are safe to share.  SDRAM: big, cold, not
+ * zeroed by startup — hence the memsets in Start().  s_snapshot needs
+ * none: every reader stays within the length last serialized into it
+ * (the factory image, then GET_LIVE). */
 static char    DSY_SDRAM_BSS s_descriptor[24u * 1024u];
 static uint8_t DSY_SDRAM_BSS s_staging [kPresetBlobCapacity];
 static uint8_t DSY_SDRAM_BSS s_snapshot[kPresetBlobCapacity];
@@ -46,14 +47,21 @@ Host::Host(Presets& presets, const char* id, const char* name,
            const char* fw_version, const char* git_hash)
     : presets_(presets), id_(id), name_(name), fw_(fw_version), git_(git_hash)
 {
-    /* Arm the pre-BootLoad hook: the descriptor renders while components
-     * still hold factory defaults, whatever the app's call order. */
+    /* Pre-BootLoad hook: snapshot factory state before the boot preset
+     * lands.  The descriptor renders later, at the first Poll(), when
+     * everything main() declares is attached — call order never matters. */
     presets_.SetPreBootHook(&PreBootTrampoline, this);
 }
 
 void Host::PreBootTrampoline(void* self)
 {
-    static_cast<Host*>(self)->Start();
+    static_cast<Host*>(self)->CaptureFactory();
+}
+
+void Host::CaptureFactory()
+{
+    if (factory_len_) return;
+    factory_len_ = presets_.SerializeLive(s_snapshot, sizeof s_snapshot);
 }
 
 Host& Host::Product(const char* usb_product) { product_ = usb_product; return *this; }
@@ -140,8 +148,9 @@ void Host::Start()
 
     if (!staging_)
     {
+        /* s_snapshot may hold the factory image — consumed below, then
+         * free for the link's GET_LIVE scratch. */
         std::memset(s_staging, 0, sizeof s_staging);
-        std::memset(s_snapshot, 0, sizeof s_snapshot);
         staging_  = s_staging;
         snapshot_ = s_snapshot;
         buf_cap_  = sizeof s_staging;
@@ -216,7 +225,8 @@ void Host::Start()
             overrides_, num_overrides_,
             num_buttons_ ? btn_ptrs_ : nullptr, num_buttons_,
             num_frags ? frags : nullptr, num_frags,
-            num_jacks_ ? jack_ptrs_ : nullptr, num_jacks_, manual_);
+            num_jacks_ ? jack_ptrs_ : nullptr, num_jacks_, manual_,
+            factory_len_ ? s_snapshot : nullptr, factory_len_);
         link_->SetDescriptor(desc_buf_, len);
     }
 

--- a/framework/src/host_link/host.cpp
+++ b/framework/src/host_link/host.cpp
@@ -13,8 +13,10 @@
 
 #include "alchemy/host_link/cdc_transport.h"
 #include "alchemy/surface/control_loop.h"
+#include "alchemy/surface/jack.h"
 #include "alchemy/surface/page.h"
 #include "alchemy/surface/presets.h"
+#include "alchemy/surface/virtual_button.h"
 #include "alchemy/version.h"
 
 namespace alchemy {
@@ -104,8 +106,8 @@ void Host::AddPage(const Page& p)
 
 Host& Host::Jacks(const Jack* jacks, uint8_t count)
 {
-    jacks_     = jacks;
-    num_jacks_ = count;
+    num_jacks_ = 0u;
+    for (uint8_t i = 0; jacks && i < count; i++) AddJack(jacks[i]);
     return *this;
 }
 
@@ -117,8 +119,8 @@ Host& Host::Attach(const Manual& manual)
 
 Host& Host::Buttons(const VirtualButton* buttons, uint8_t count)
 {
-    buttons_     = buttons;
-    num_buttons_ = count;
+    num_buttons_ = 0u;
+    for (uint8_t i = 0; buttons && i < count; i++) AddButton(buttons[i]);
     return *this;
 }
 
@@ -212,9 +214,9 @@ void Host::Start()
                                           ALCHEMY_SDK_VERSION, board_name},
             presets_, num_pages_ ? &set : nullptr,
             overrides_, num_overrides_,
-            buttons_, num_buttons_,
+            num_buttons_ ? btn_ptrs_ : nullptr, num_buttons_,
             num_frags ? frags : nullptr, num_frags,
-            jacks_, num_jacks_, manual_);
+            num_jacks_ ? jack_ptrs_ : nullptr, num_jacks_, manual_);
         link_->SetDescriptor(desc_buf_, len);
     }
 

--- a/framework/src/host_link/host.cpp
+++ b/framework/src/host_link/host.cpp
@@ -24,7 +24,7 @@ namespace hostlink {
  * SDK-owned default buffers are safe to share.  SDRAM: big, cold, only
  * touched during host transactions — and not zeroed by startup, hence
  * the memsets in Start(). */
-static char    DSY_SDRAM_BSS s_descriptor[8u * 1024u];
+static char    DSY_SDRAM_BSS s_descriptor[24u * 1024u];
 static uint8_t DSY_SDRAM_BSS s_staging [kPresetBlobCapacity];
 static uint8_t DSY_SDRAM_BSS s_snapshot[kPresetBlobCapacity];
 
@@ -100,6 +100,19 @@ Host& Host::Descriptor(const void* json, uint32_t len)
 void Host::AddPage(const Page& p)
 {
     if (num_pages_ < kMaxPageRefs) pages_[num_pages_++] = &p;
+}
+
+Host& Host::Jacks(const Jack* jacks, uint8_t count)
+{
+    jacks_     = jacks;
+    num_jacks_ = count;
+    return *this;
+}
+
+Host& Host::Attach(const Manual& manual)
+{
+    manual_ = &manual;
+    return *this;
 }
 
 Host& Host::Buttons(const VirtualButton* buttons, uint8_t count)
@@ -200,7 +213,8 @@ void Host::Start()
             presets_, num_pages_ ? &set : nullptr,
             overrides_, num_overrides_,
             buttons_, num_buttons_,
-            num_frags ? frags : nullptr, num_frags);
+            num_frags ? frags : nullptr, num_frags,
+            jacks_, num_jacks_, manual_);
         link_->SetDescriptor(desc_buf_, len);
     }
 

--- a/tests/host/button_tests.cpp
+++ b/tests/host/button_tests.cpp
@@ -729,8 +729,9 @@ void TestAnchorValidation()
         Presets    presets{s_dummy_qspi};
         presets.Manage(cutoff);
         static char buf[8192];
+        const VirtualButton* good_refs[1] = {&good};
         BCHECK(RenderDescriptor(buf, sizeof buf, kVInfo, presets, nullptr,
-                                nullptr, 0, &good, 1)
+                                nullptr, 0, good_refs, 1)
                > 0u);
 
         VirtualButton bad =
@@ -741,8 +742,9 @@ void TestAnchorValidation()
         Presets    p2{s_dummy_qspi};
         p2.Manage(cutoff2);
         static char buf2[8192];
+        const VirtualButton* bad_refs[1] = {&bad};
         BCHECK_EQ(RenderDescriptor(buf2, sizeof buf2, kVInfo, p2, nullptr,
-                                   nullptr, 0, &bad, 1),
+                                   nullptr, 0, bad_refs, 1),
                   0u);
     }
 }

--- a/tests/host/button_tests.cpp
+++ b/tests/host/button_tests.cpp
@@ -59,6 +59,15 @@ static int s_failures = 0;
 
 namespace {
 
+/* Failed builds degrade to a minimal error descriptor, not 0. */
+bool IsErrorDescriptor(const char* buf, uint32_t len)
+{
+    if (len == 0u) return false;
+    const std::string j(buf, len);
+    return j.find("\"error\":") != std::string::npos
+        && j.find("\"components\":[]") != std::string::npos;
+}
+
 /* ── Fakes and drivers ─────────────────────────────────────────────── */
 
 /** Debounced-button stub.  Counts the consume-on-read edge calls so the
@@ -561,11 +570,12 @@ void TestDescriptorEmission()
     Presets p2{s_dummy_qspi};
     p2.Manage(broken);
     static char buf2[8192];
-    BCHECK_EQ(RenderDescriptor(buf2, sizeof buf2,
-                               {"btnbank", "Bank", "0.0.1", "gitbtn",
-                                "0.1.0", "v1"},
-                               p2, nullptr, nullptr, 0),
-              0u);
+    BCHECK(IsErrorDescriptor(buf2, RenderDescriptor(buf2, sizeof buf2,
+                                                    {"btnbank", "Bank",
+                                                     "0.0.1", "gitbtn",
+                                                     "0.1.0", "v1"},
+                                                    p2, nullptr,
+                                                    nullptr, 0)));
 }
 
 /* ── Anchor / controls ref validation ──────────────────────────────── */
@@ -695,9 +705,10 @@ void TestAnchorValidation()
         Presets presets{s_dummy_qspi};
         presets.Manage(bank);
         static char buf[8192];
-        BCHECK_EQ(RenderDescriptor(buf, sizeof buf, kVInfo, presets, nullptr,
-                                   nullptr, 0),
-                  0u);
+        BCHECK(IsErrorDescriptor(buf, RenderDescriptor(buf, sizeof buf,
+                                                       kVInfo, presets,
+                                                       nullptr,
+                                                       nullptr, 0)));
     }
     {
         /* Self-anchor. */
@@ -714,9 +725,10 @@ void TestAnchorValidation()
         Presets presets{s_dummy_qspi};
         presets.Manage(bank);
         static char buf[8192];
-        BCHECK_EQ(RenderDescriptor(buf, sizeof buf, kVInfo, presets, nullptr,
-                                   nullptr, 0),
-                  0u);
+        BCHECK(IsErrorDescriptor(buf, RenderDescriptor(buf, sizeof buf,
+                                                       kVInfo, presets,
+                                                       nullptr,
+                                                       nullptr, 0)));
     }
     {
         /* Legacy root-array Controls: a resolving ref passes, a dangling
@@ -743,9 +755,10 @@ void TestAnchorValidation()
         p2.Manage(cutoff2);
         static char buf2[8192];
         const VirtualButton* bad_refs[1] = {&bad};
-        BCHECK_EQ(RenderDescriptor(buf2, sizeof buf2, kVInfo, p2, nullptr,
-                                   nullptr, 0, bad_refs, 1),
-                  0u);
+        BCHECK(IsErrorDescriptor(buf2, RenderDescriptor(buf2, sizeof buf2,
+                                                        kVInfo, p2, nullptr,
+                                                        nullptr, 0,
+                                                        bad_refs, 1)));
     }
 }
 

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -1096,6 +1096,16 @@ static void TestAutoDescribe()
     }
 }
 
+/* A failed build degrades to a minimal error descriptor (identity +
+ * reason) instead of returning 0 — probe the shape, never the text. */
+static bool IsErrorDescriptor(const char* buf, uint32_t len)
+{
+    if (len == 0u) return false;
+    const std::string j(buf, len);
+    return j.find("\"error\":") != std::string::npos
+        && j.find("\"components\":[]") != std::string::npos;
+}
+
 static void TestAutoDescribeGenericAndOverrides()
 {
     RamFlash flash;
@@ -1161,9 +1171,9 @@ static void TestAutoDescribeGenericAndOverrides()
             nullptr,
         }};
         static char buf[8192];
-        CHECK_EQ(RenderDescriptor(buf, sizeof buf, kAutoInfo, presets,
-                                  nullptr, ovr, 1),
-                 0u);
+        CHECK(IsErrorDescriptor(buf, RenderDescriptor(buf, sizeof buf,
+                                                      kAutoInfo, presets,
+                                                      nullptr, ovr, 1)));
     }
 
     /* Metadata after the first field is a misuse, not a silent no-op. */
@@ -1179,9 +1189,9 @@ static void TestAutoDescribeGenericAndOverrides()
             nullptr,
         }};
         static char buf[8192];
-        CHECK_EQ(RenderDescriptor(buf, sizeof buf, kAutoInfo, presets,
-                                  nullptr, ovr, 1),
-                 0u);
+        CHECK(IsErrorDescriptor(buf, RenderDescriptor(buf, sizeof buf,
+                                                      kAutoInfo, presets,
+                                                      nullptr, ovr, 1)));
     }
 }
 
@@ -1252,6 +1262,7 @@ static void TestManualEmission()
     };
     for (const char* k : kKeys)
         CHECK(json.find(k) != std::string::npos);
+    CHECK(json.find("\"error\":") == std::string::npos);
 }
 
 static void TestManualValidation()
@@ -1267,9 +1278,9 @@ static void TestManualValidation()
         const Page*   refs[1] = {&p0};
         const PageSet pages{refs, 1};
         static char buf[16384];
-        CHECK_EQ(RenderDescriptor(buf, sizeof buf, kAutoInfo, sf.presets,
-                                  &pages, nullptr, 0),
-                 0u);
+        CHECK(IsErrorDescriptor(buf, RenderDescriptor(buf, sizeof buf,
+                                                      kAutoInfo, sf.presets,
+                                                      &pages, nullptr, 0)));
     }
     /* Dangling raw see id fails at Finish(). */
     {
@@ -1280,9 +1291,9 @@ static void TestManualValidation()
         const Page*   refs[1] = {&p0};
         const PageSet pages{refs, 1};
         static char buf[16384];
-        CHECK_EQ(RenderDescriptor(buf, sizeof buf, kAutoInfo, sf.presets,
-                                  &pages, nullptr, 0),
-                 0u);
+        CHECK(IsErrorDescriptor(buf, RenderDescriptor(buf, sizeof buf,
+                                                      kAutoInfo, sf.presets,
+                                                      &pages, nullptr, 0)));
     }
     /* GestureHelp key matching no declared gesture fails. */
     {
@@ -1293,9 +1304,10 @@ static void TestManualValidation()
                 .GestureHelp("Tp", "typo'd key");
         static const VirtualButton* kBad[1] = {&bad_btn};
         static char buf[16384];
-        CHECK_EQ(RenderDescriptor(buf, sizeof buf, kAutoInfo, sf.presets,
-                                  nullptr, nullptr, 0, kBad, 1),
-                 0u);
+        CHECK(IsErrorDescriptor(buf, RenderDescriptor(buf, sizeof buf,
+                                                      kAutoInfo, sf.presets,
+                                                      nullptr, nullptr, 0,
+                                                      kBad, 1)));
     }
 }
 
@@ -1333,6 +1345,49 @@ static void TestManualHashStability()
     CHECK(h1 != std::string::npos && h2 != std::string::npos);
     CHECK(j1.substr(h1, j1.find(',', h1) - h1)
           == j2.substr(h2, j2.find(',', h2) - h2));
+}
+
+/* Ordering independence: defs decode from a factory image captured
+ * before any preset load, so a render taken after a load is
+ * byte-identical to one taken at factory state. */
+static void TestFactoryDefaultsImage()
+{
+    SurfaceFixture sf;
+
+    static char b1[16384];
+    const uint32_t len1 = RenderDescriptor(b1, sizeof b1, kAutoInfo,
+                                           sf.presets, nullptr, nullptr, 0);
+    CHECK(len1 > 0u);
+
+    static uint8_t img[kPresetBlobCapacity];
+    const size_t n = sf.presets.SerializeLive(img, sizeof img);
+    CHECK_EQ(n, sf.presets.LiveSize());
+
+    /* Simulate BootLoad: move live state away from factory. */
+    static const float kPhys[8] = {};
+    sf.pager.SetStored(0, 0, 0.9f, kPhys);
+
+    static char b2[16384];
+    const uint32_t len2 = RenderDescriptor(b2, sizeof b2, kAutoInfo,
+                                           sf.presets, nullptr, nullptr, 0,
+                                           nullptr, 0, nullptr, 0,
+                                           nullptr, 0, nullptr, img, n);
+    CHECK_EQ(len2, len1);
+    CHECK(std::memcmp(b1, b2, len1) == 0);
+
+    /* Without the image the moved value leaks into def. */
+    static char b3[16384];
+    const uint32_t len3 = RenderDescriptor(b3, sizeof b3, kAutoInfo,
+                                           sf.presets, nullptr, nullptr, 0);
+    CHECK(len3 != len1 || std::memcmp(b1, b3, len1) != 0);
+
+    /* Truncated image fails loudly. */
+    static char b4[16384];
+    CHECK(IsErrorDescriptor(b4, RenderDescriptor(b4, sizeof b4, kAutoInfo,
+                                                 sf.presets, nullptr,
+                                                 nullptr, 0, nullptr, 0,
+                                                 nullptr, 0, nullptr, 0,
+                                                 nullptr, img, 2u)));
 }
 
 /* ── Buttons + custom-component meta ──────────────────────────────── */
@@ -1427,7 +1482,7 @@ static void TestButtonsEmission()
         buf3, sizeof buf3,
         {"btnmod", "Buttons", "0.0.1", "gitbtn", "0.1.0", "v1"},
         presets, nullptr, nullptr, 0, nullptr, 2);
-    CHECK_EQ(len3, 0u);
+    CHECK(IsErrorDescriptor(buf3, len3));
 }
 
 /** Custom Serializable that emits per-kind metadata via ComponentWriter::Meta
@@ -1493,10 +1548,11 @@ static void TestComponentMeta()
         presetsE.Manage(em);
         presetsE.Init(flashE.Ops(), flashE.Base());
         static char bufE[8192];
-        CHECK_EQ(RenderDescriptor(bufE, sizeof bufE,
-                                  {"m", "m", "0", "g", "s", "v1"},
-                                  presetsE, nullptr, nullptr, 0),
-                 0u);
+        CHECK(IsErrorDescriptor(bufE, RenderDescriptor(bufE, sizeof bufE,
+                                                       {"m", "m", "0", "g",
+                                                        "s", "v1"},
+                                                       presetsE, nullptr,
+                                                       nullptr, 0)));
     }
 
     /* Meta after a field is malformed JSON — must fail the build. */
@@ -1518,10 +1574,11 @@ static void TestComponentMeta()
     presets2.Manage(bad);
     presets2.Init(flash2.Ops(), flash2.Base());
     static char buf2[8192];
-    CHECK_EQ(RenderDescriptor(buf2, sizeof buf2,
-                              {"m", "m", "0", "g", "s", "v1"},
-                              presets2, nullptr, nullptr, 0),
-             0u);
+    CHECK(IsErrorDescriptor(buf2, RenderDescriptor(buf2, sizeof buf2,
+                                                   {"m", "m", "0", "g",
+                                                    "s", "v1"},
+                                                   presets2, nullptr,
+                                                   nullptr, 0)));
 }
 
 static void TestJsonCheck()
@@ -1581,10 +1638,11 @@ static void TestDescriptorJsonValidation()
         presets.Manage(c);
         presets.Init(flash.Ops(), flash.Base());
         static char buf[8192];
-        CHECK_EQ(RenderDescriptor(buf, sizeof buf,
-                                  {"m", "m", "0", "g", "s", "v1"},
-                                  presets, nullptr, nullptr, 0),
-                 0u);
+        CHECK(IsErrorDescriptor(buf, RenderDescriptor(buf, sizeof buf,
+                                                      {"m", "m", "0", "g",
+                                                       "s", "v1"},
+                                                      presets, nullptr,
+                                                      nullptr, 0)));
     }
 
     struct TruncMeta : TestComp<4>
@@ -1603,10 +1661,11 @@ static void TestDescriptorJsonValidation()
         presets.Manage(c);
         presets.Init(flash.Ops(), flash.Base());
         static char buf[8192];
-        CHECK_EQ(RenderDescriptor(buf, sizeof buf,
-                                  {"m", "m", "0", "g", "s", "v1"},
-                                  presets, nullptr, nullptr, 0),
-                 0u);
+        CHECK(IsErrorDescriptor(buf, RenderDescriptor(buf, sizeof buf,
+                                                      {"m", "m", "0", "g",
+                                                       "s", "v1"},
+                                                      presets, nullptr,
+                                                      nullptr, 0)));
     }
 
     struct TrailMeta : TestComp<4>
@@ -1625,10 +1684,11 @@ static void TestDescriptorJsonValidation()
         presets.Manage(c);
         presets.Init(flash.Ops(), flash.Base());
         static char buf[8192];
-        CHECK_EQ(RenderDescriptor(buf, sizeof buf,
-                                  {"m", "m", "0", "g", "s", "v1"},
-                                  presets, nullptr, nullptr, 0),
-                 0u);
+        CHECK(IsErrorDescriptor(buf, RenderDescriptor(buf, sizeof buf,
+                                                      {"m", "m", "0", "g",
+                                                       "s", "v1"},
+                                                      presets, nullptr,
+                                                      nullptr, 0)));
     }
 
     struct UIntMeta : TestComp<4>
@@ -2019,6 +2079,7 @@ int main(int argc, char** argv)
     TestManualEmission();
     TestManualValidation();
     TestManualHashStability();
+    TestFactoryDefaultsImage();
     TestButtonsEmission();
     TestComponentMeta();
     TestJsonCheck();

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -1201,7 +1201,7 @@ static void TestManualEmission()
     static Jack clk  = Jack("J8", "CLK", JackSig::Trig)
                            .Short("CLK")
                            .Help("External clock input.");
-    static const Jack kJacks[3] = {in_l, in_r, clk};
+    static const Jack* kJacks[3] = {&in_l, &in_r, &clk};
 
     VirtualKnob cutoff = VirtualKnob(0, "Cutoff")
                              .Exp(20.f, 12000.f)
@@ -1219,12 +1219,13 @@ static void TestManualEmission()
     const PageSet pages{refs, 1};
 
     /* Root-array button: free-form gesture key, per-gesture help. */
-    static VirtualButton kRootBtns[1] = {
+    static VirtualButton root_btn =
         VirtualButton("bx", "Extra")
             .Action("Long Press", "Panic + reinit")
             .Help("The rescue button.")
-            .GestureHelp("Long Press", "Held for a second.")};
-    kRootBtns[0].SeeAlso(clk);
+            .GestureHelp("Long Press", "Held for a second.");
+    root_btn.SeeAlso(clk);
+    static const VirtualButton* kRootBtns[1] = {&root_btn};
 
     /* Bank button: structured tap slot keys as "tap". */
     sf.trig.Help("Fires the voice.").GestureHelp("tap", "Fires once.");
@@ -1286,10 +1287,11 @@ static void TestManualValidation()
     /* GestureHelp key matching no declared gesture fails. */
     {
         SurfaceFixture sf;
-        static VirtualButton kBad[1] = {
+        static VirtualButton bad_btn =
             VirtualButton("bx", "X")
                 .Action("Tap", "Fire")
-                .GestureHelp("Tp", "typo'd key")};
+                .GestureHelp("Tp", "typo'd key");
+        static const VirtualButton* kBad[1] = {&bad_btn};
         static char buf[16384];
         CHECK_EQ(RenderDescriptor(buf, sizeof buf, kAutoInfo, sf.presets,
                                   nullptr, nullptr, 0, kBad, 1),
@@ -1373,12 +1375,13 @@ static void TestButtonsEmission()
             .Controls("mode.sub", B::Action::Toggle),
     };
 
+    static const B* kButtonRefs[2] = {&kButtons[0], &kButtons[1]};
+
     static char buf[8192];
     const uint32_t len = RenderDescriptor(
         buf, sizeof buf,
         {"btnmod", "Buttons", "0.0.1", "gitbtn", "0.1.0", "v1"},
-        presets, nullptr, nullptr, 0,
-        kButtons, sizeof(kButtons) / sizeof(kButtons[0]));
+        presets, nullptr, nullptr, 0, kButtonRefs, 2);
     CHECK(len > 0u);
     const std::string json(buf, len);
 
@@ -1414,7 +1417,7 @@ static void TestButtonsEmission()
     const uint32_t len2 = RenderDescriptor(
         buf2, sizeof buf2,
         {"btnmod", "Buttons", "0.0.1", "gitbtn", "0.1.0", "v1"},
-        presets, nullptr, nullptr, 0, kButtons, 0);
+        presets, nullptr, nullptr, 0, kButtonRefs, 0);
     CHECK(len2 > 0u);
     CHECK(std::string(buf2, len2).find("\"buttons\"") == std::string::npos);
 

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -32,6 +32,8 @@
 #include "alchemy/surface/pager.h"
 #include "alchemy/surface/param_lock.h"
 #include "alchemy/surface/button_bank.h"
+#include "alchemy/surface/jack.h"
+#include "alchemy/surface/manual.h"
 #include "alchemy/surface/preset_name.h"
 #include "alchemy/surface/presets.h"
 #include "alchemy/surface/settings.h"
@@ -1183,6 +1185,154 @@ static void TestAutoDescribeGenericAndOverrides()
     }
 }
 
+/* ── Manual layer: help / SeeAlso / jacks / manual block ──────────── */
+
+static void TestManualEmission()
+{
+    SurfaceFixture sf;
+    sf.settings.Page(0).Name("Setup").Help("Setup page help.");
+
+    static const char* kModeLabels[4] = {"A", "B", "C", "D"};
+    sf.mode.Ident("set.mode").Name("Mode Select").Labels(kModeLabels)
+           .Help("Selects the mode.");
+
+    static Jack in_l = Jack("IN_L", "In L", JackSig::AudioIn);
+    static Jack in_r = Jack("IN_R", "In R", JackSig::AudioIn).Normalled(in_l);
+    static Jack clk  = Jack("J8", "CLK", JackSig::Trig)
+                           .Short("CLK")
+                           .Help("External clock input.");
+    static const Jack kJacks[3] = {in_l, in_r, clk};
+
+    VirtualKnob cutoff = VirtualKnob(0, "Cutoff")
+                             .Exp(20.f, 12000.f)
+                             .Ident("flt.cutoff")
+                             .Help("Filter cutoff. **Sweep** it.")
+                             .SeeAlso(in_r, "presets");
+    /* Pot 2: the fixture's route button anchors positional "p0.1", so
+     * pots 0/1 must keep their positional ids. */
+    VirtualKnob drive = VirtualKnob(2, "Drive").Ident("drv");
+    drive.SeeAlso(cutoff, sf.mode, clk);
+
+    Page p0 = Page(0).Name("Time").Help("Page zero help.");
+    p0.Knobs(cutoff, drive);
+    const Page*   refs[1] = {&p0};
+    const PageSet pages{refs, 1};
+
+    /* Root-array button: free-form gesture key, per-gesture help. */
+    static VirtualButton kRootBtns[1] = {
+        VirtualButton("bx", "Extra")
+            .Action("Long Press", "Panic + reinit")
+            .Help("The rescue button.")
+            .GestureHelp("Long Press", "Held for a second.")};
+    kRootBtns[0].SeeAlso(clk);
+
+    /* Bank button: structured tap slot keys as "tap". */
+    sf.trig.Help("Fires the voice.").GestureHelp("tap", "Fires once.");
+
+    static const Manual kManual = Manual()
+                                      .Tagline("Test tagline")
+                                      .Preamble("**Preamble.**")
+                                      .Section("flow", "Signal Flow", "Body text.");
+
+    static char buf[32768];
+    const uint32_t len = RenderDescriptor(buf, sizeof buf, kAutoInfo,
+                                          sf.presets, &pages, nullptr, 0,
+                                          kRootBtns, 1, nullptr, 0,
+                                          kJacks, 3, &kManual);
+    CHECK(len > 0u);
+    const std::string json(buf, len);
+
+    /* Wiring only: every manual emission path produced its key.  No
+     * content, ordering, or adjacency pins — text is free to change. */
+    static const char* kKeys[] = {
+        "\"tagline\":", "\"pageHelp\":", "\"help\":", "\"see\":",
+        "\"jacks\":",   "\"sig\":",      "\"norm\":", "\"short\":",
+        "\"manual\":",  "\"preamble\":", "\"sections\":", "\"presets\":",
+    };
+    for (const char* k : kKeys)
+        CHECK(json.find(k) != std::string::npos);
+}
+
+static void TestManualValidation()
+{
+    /* SeeAlso → knob without Ident() fails the build. */
+    {
+        SurfaceFixture sf;
+        VirtualKnob a = VirtualKnob(0, "A").Ident("a");
+        VirtualKnob b = VirtualKnob(1, "B"); /* no ident */
+        a.SeeAlso(b);
+        Page p0{0};
+        p0.Knobs(a, b);
+        const Page*   refs[1] = {&p0};
+        const PageSet pages{refs, 1};
+        static char buf[16384];
+        CHECK_EQ(RenderDescriptor(buf, sizeof buf, kAutoInfo, sf.presets,
+                                  &pages, nullptr, 0),
+                 0u);
+    }
+    /* Dangling raw see id fails at Finish(). */
+    {
+        SurfaceFixture sf;
+        VirtualKnob a = VirtualKnob(0, "A").Ident("a").SeeAlso("no.such");
+        Page p0{0};
+        p0.Knobs(a);
+        const Page*   refs[1] = {&p0};
+        const PageSet pages{refs, 1};
+        static char buf[16384];
+        CHECK_EQ(RenderDescriptor(buf, sizeof buf, kAutoInfo, sf.presets,
+                                  &pages, nullptr, 0),
+                 0u);
+    }
+    /* GestureHelp key matching no declared gesture fails. */
+    {
+        SurfaceFixture sf;
+        static VirtualButton kBad[1] = {
+            VirtualButton("bx", "X")
+                .Action("Tap", "Fire")
+                .GestureHelp("Tp", "typo'd key")};
+        static char buf[16384];
+        CHECK_EQ(RenderDescriptor(buf, sizeof buf, kAutoInfo, sf.presets,
+                                  nullptr, nullptr, 0, kBad, 1),
+                 0u);
+    }
+}
+
+static void TestManualHashStability()
+{
+    SurfaceFixture sf;
+    static char b1[16384], b2[32768];
+    const uint32_t len1 = RenderDescriptor(b1, sizeof b1, kAutoInfo,
+                                           sf.presets, nullptr, nullptr, 0);
+    CHECK(len1 > 0u);
+    const uint32_t hash_before = sf.presets.LiveSchemaHash();
+
+    /* Decorate everything decoratable; state shape untouched. */
+    static const char* kL[4] = {"A", "B", "C", "D"};
+    sf.mode.Ident("set.mode").Name("Mode").Labels(kL).Help("Mode help.");
+    sf.bright.Help("Bright help.");
+    sf.bip.Ident("set.bip").Help("Bip help.");
+    sf.settings.Page(0).Help("Page help.");
+    sf.trig.Help("Trig help.").GestureHelp("tap", "Tap help.");
+
+    static const Manual kManual =
+        Manual().Tagline("T").Preamble("P").Section("s", "S", "B");
+    const uint32_t len2 = RenderDescriptor(b2, sizeof b2, kAutoInfo,
+                                           sf.presets, nullptr, nullptr, 0,
+                                           nullptr, 0, nullptr, 0,
+                                           nullptr, 0, &kManual);
+    CHECK(len2 > len1);
+    CHECK_EQ(sf.presets.LiveSchemaHash(), hash_before);
+
+    /* The emitted schemaHash and every component hash are byte-identical:
+     * prose lives only in the descriptor, never in any SchemaHash(). */
+    const std::string j1(b1, len1), j2(b2, len2);
+    const size_t h1 = j1.find("\"schemaHash\":");
+    const size_t h2 = j2.find("\"schemaHash\":");
+    CHECK(h1 != std::string::npos && h2 != std::string::npos);
+    CHECK(j1.substr(h1, j1.find(',', h1) - h1)
+          == j2.substr(h2, j2.find(',', h2) - h2));
+}
+
 /* ── Buttons + custom-component meta ──────────────────────────────── */
 
 static void TestButtonsEmission()
@@ -1863,6 +2013,9 @@ int main(int argc, char** argv)
     TestSettingsGesturesEmission();
     TestAutoDescribe();
     TestAutoDescribeGenericAndOverrides();
+    TestManualEmission();
+    TestManualValidation();
+    TestManualHashStability();
     TestButtonsEmission();
     TestComponentMeta();
     TestJsonCheck();


### PR DESCRIPTION
## Interactive manual support

Firmware can now carry its own manual. `.Help()` attaches prose to knobs, buttons, settings, pages, and jacks; `.SeeAlso()` makes typed cross-references that resolve and validate at build time. `Jack` arrives as pure descriptor metadata, `Manual` carries the module-level tagline, preamble, and sections, and the SDK ships stock text for the features it owns.

Two behavioral fixes also. Descriptor rendering no longer depends on the order of calls in `main()`: factory defaults are captured before the boot preset loads, and the descriptor renders once everything is declared. And a failed descriptor build now reports its reason over the wire instead of returning zero, so a bad cross-reference shows up in the browser rather than as a module that silently claims to have no descriptor.

### What's in it

| Area | Change |
|---|---|
| `surface/see_ref.h` | Typed cross-reference. Knobs and settings handles need `.Ident()` to be referenced; buttons and jacks always resolve. |
| `surface/jack.h` | `Jack` entity: id, name, silk label, signal class, normalling. No runtime behavior, no state, no schema-hash impact. |
| `surface/manual.h` | `Manual` root plus `stock_help` for presets, locks, storage, and brightness. |
| `virtual_knob` / `virtual_button` | `.Help()`, `.SeeAlso()`, and `GestureHelp(key, md)` keyed on the gesture string. |
| `settings` / `settings_control` | Slot identity: `.Ident()`, `.Name()`, `.Help()`, labeled `Selector`, page help. |
| `host_link` | Emission for every new key, `Host::Jacks/Buttons/Attach`, and `Finish()` validation of every reference. |

### Validation

A dead cross-reference, a `GestureHelp` key matching no declared gesture, an over-cap `SeeAlso` list, or prose that overflows the buffer all fail the descriptor build rather than shipping a broken manual. The failure is no longer silent: the module emits a minimal descriptor carrying the reason, and the host renders that instead of the editor.

### Compatibility

Additive on the wire, `dv` stays 1. Prose never reaches any schema hash, so adding, editing, or deleting help text cannot invalidate a saved preset. Existing firmware recompiles unchanged and produces a byte-identical descriptor; the golden vectors confirm it.

Docs: protocol §5.2 covers the error descriptor.
