### PR TITLE
Use the calibrated VDDA for CV input volts

### DIFF
--- a/hardware/alchemy-lab/v2/include/alchemy/hw/cv_input.h
+++ b/hardware/alchemy-lab/v2/include/alchemy/hw/cv_input.h
@@ -18,6 +18,8 @@
 
 #include "daisy_seed.h"
 
+#include "alchemy/hw/v2_calibration.h"
+
 namespace alchemy {
 
 class CvInput
@@ -28,17 +30,18 @@ class CvInput
         ac_.Init(adcptr, sample_rate, flip, invert, slew);
     }
 
-    /** Apply per-channel calibration (zero code from the idle pass, VDDA
-     *  from VREFINT). Called by AlchemyLabV2::Init(); harmless to call
-     *  with design-fallback values (32768 / 3.30) — that reproduces the
+    /** Apply per-channel calibration: zero code from the idle pass and
+     *  the board VDDA, both out of the V2Calibration record. Reached via
+     *  CvJack::Init* during AlchemyLabV2::Init(); harmless to call with
+     *  design-fallback values (32768 / 3.30) — that reproduces the
      *  uncalibrated transfer exactly. */
     void SetCalibration(uint16_t adc_zero_code, float vdda)
     {
         /* With flip=true, Value() = 1 − raw/65535. Jack volts:
-         *   v = (zero_raw − raw) × vdda / 65535 / 0.165
-         *     = (Value() − (1 − zero_raw/65535)) × vdda / 0.165        */
+         *   v = (zero_raw − raw) × vdda / 65535 / kV2CvInGainDesign
+         *     = (Value() − (1 − zero_raw/65535)) × vdda / kV2CvInGainDesign */
         cal_offset_ = 1.0f - static_cast<float>(adc_zero_code) / 65535.0f;
-        cal_scale_  = vdda / 0.165f;
+        cal_scale_  = vdda / kV2CvInGainDesign;
         calibrated_ = true;
     }
 
@@ -56,13 +59,17 @@ class CvInput
     {
         if (calibrated_)
             return (ac_.Value() - cal_offset_) * cal_scale_;
-        return (ac_.Value() - 0.5f) * 20.0f;
+        return (ac_.Value() - 0.5f) * kDesignScale;
     }
 
   private:
+    /* Design-nominal jack scale, VDDA/gain = 3.30/0.165 → 20 V per unit
+     * of Value(). Same constants the factory-cal fit is derived from. */
+    static constexpr float kDesignScale = kV2VddaDesign / kV2CvInGainDesign;
+
     daisy::AnalogControl ac_;
     float cal_offset_ = 0.5f;
-    float cal_scale_  = 20.0f;
+    float cal_scale_  = kDesignScale;
     bool  calibrated_ = false;
 };
 

--- a/hardware/alchemy-lab/v2/include/alchemy/hw/cv_jack.h
+++ b/hardware/alchemy-lab/v2/include/alchemy/hw/cv_jack.h
@@ -81,10 +81,13 @@ class CvJack
 
     /** MCP4728 jack (J3..J6). `shadow_slot` points into the shared
      *  4-channel shadow array; `mcp_shadow_dirty` is unused for now (kept
-     *  for future batched-flush). */
+     *  for future batched-flush). `vdda` is the board VDDA out of the cal
+     *  record — the reference the record's zero codes and DAC fits were
+     *  measured against (kV2VddaDesign when uncalibrated). */
     void InitMcp(uint16_t*           adc_ptr,
                  float               sample_rate,
                  const V2JackCal*    cal,
+                 float               vdda,
                  Mcp4728*            mcp,
                  uint8_t             mcp_channel,
                  uint16_t*           shadow_slot,
@@ -93,10 +96,11 @@ class CvJack
                  uint8_t             select_io,
                  uint8_t             ldac_io);
 
-    /** STM DAC1 jack (J7, J8). */
+    /** STM DAC1 jack (J7, J8). `vdda` as in InitMcp. */
     void InitStm(uint16_t*                 adc_ptr,
                  float                     sample_rate,
                  const V2JackCal*          cal,
+                 float                     vdda,
                  daisy::DacHandle*         stm,
                  daisy::DacHandle::Channel stm_ch,
                  Pca9557*                  expander,

--- a/hardware/alchemy-lab/v2/src/alchemy_lab_v2.cpp
+++ b/hardware/alchemy-lab/v2/src/alchemy_lab_v2.cpp
@@ -107,6 +107,17 @@ void AlchemyLabV2::Init(daisy::SaiHandle::Config::SampleRate sample_rate,
      * cv_jacks[6..7] → J9, J10 codec output channels. Triggers bind to
      * codec input channels by index — actual sample-block processing
      * happens inside the audio shim. */
+
+    /* Input-side voltage reference. The record's VDDA is what the zero
+     * codes and the DAC fits were measured against (v2_factory_cal.cpp
+     * pass 1/3), so Volts() must use it too. Guard the persisted float:
+     * a CRC-valid but implausible value (bench-written record) must not
+     * poison every read — !(lo ≤ x ≤ hi) also rejects NaN. Window
+     * matches factory cal's own VREFINT validation. */
+    float cal_vdda = cal_.vdda_at_cal;
+    if (!(cal_vdda >= 3.0f && cal_vdda <= 3.6f))
+        cal_vdda = kV2VddaDesign;
+
     for (uint8_t i = 0; i < kNumCvInputs; i++)
     {
         const DacRoute& route = kDacRouting[i];
@@ -116,7 +127,7 @@ void AlchemyLabV2::Init(daisy::SaiHandle::Config::SampleRate sample_rate,
         if (src < kMcp4728NumChannels)
         {
             cv_jacks[i].InitMcp(
-                seed.adc.GetPtr(kCvAdcOffset + i), sr, cal,
+                seed.adc.GetPtr(kCvAdcOffset + i), sr, cal, cal_vdda,
                 &dac, src,
                 &mcp_shadow_[src], mcp_shadow_,
                 &expander, route.select_io, kPca9557IoLdac);
@@ -127,7 +138,7 @@ void AlchemyLabV2::Init(daisy::SaiHandle::Config::SampleRate sample_rate,
                 ? daisy::DacHandle::Channel::ONE
                 : daisy::DacHandle::Channel::TWO;
             cv_jacks[i].InitStm(
-                seed.adc.GetPtr(kCvAdcOffset + i), sr, cal,
+                seed.adc.GetPtr(kCvAdcOffset + i), sr, cal, cal_vdda,
                 &stm_dac, stm_ch,
                 &expander, route.select_io);
         }

--- a/hardware/alchemy-lab/v2/src/cv_jack.cpp
+++ b/hardware/alchemy-lab/v2/src/cv_jack.cpp
@@ -19,6 +19,7 @@ constexpr float kCodecFullScaleVolts = 5.0f;
 void CvJack::InitMcp(uint16_t*        adc_ptr,
                      float            sample_rate,
                      const V2JackCal* cal,
+                     float            vdda,
                      Mcp4728*         mcp,
                      uint8_t          mcp_channel,
                      uint16_t*        shadow_slot,
@@ -39,12 +40,13 @@ void CvJack::InitMcp(uint16_t*        adc_ptr,
     mcp_shadow_slot_  = shadow_slot;
     mcp_shadow_array_ = shadow_array;
     ldac_io_          = ldac_io;
-    if (cal_) in_.SetCalibration(cal_->adc_zero_code, /*vdda*/ 3.30f);
+    if (cal_) in_.SetCalibration(cal_->adc_zero_code, vdda);
 }
 
 void CvJack::InitStm(uint16_t*                 adc_ptr,
                      float                     sample_rate,
                      const V2JackCal*          cal,
+                     float                     vdda,
                      daisy::DacHandle*         stm,
                      daisy::DacHandle::Channel stm_ch,
                      Pca9557*                  expander,
@@ -59,7 +61,7 @@ void CvJack::InitStm(uint16_t*                 adc_ptr,
     target_v_  = 0.0f;
     stm_       = stm;
     stm_ch_    = stm_ch;
-    if (cal_) in_.SetCalibration(cal_->adc_zero_code, /*vdda*/ 3.30f);
+    if (cal_) in_.SetCalibration(cal_->adc_zero_code, vdda);
 }
 
 void CvJack::InitCodec(uint8_t codec_channel)

--- a/stubs/daisy_seed.h
+++ b/stubs/daisy_seed.h
@@ -78,10 +78,34 @@ struct QSPIHandle {
 
 /* ── AnalogControl ────────────────────────────────────────────────────── */
 
+/* Functional, not a no-op: host tests drive CvInput's transfer math
+ * through this. Instantaneous (slew ignored — the SDK's CV paths pass
+ * slew = 0). Matches the real control's documented semantics:
+ * Value() = raw/65535, flip → 1 − x, invert → 1 − x after flip.
+ * Callers that Init with a null ADC pointer keep the old sentinel 0. */
 struct AnalogControl {
-    void  Init(uint16_t*, float, bool, bool, float) {}
-    void  Process()                                 {}
-    float Value() const                             { return 0.f; }
+    void Init(uint16_t* adcptr, float, bool flip, bool invert, float)
+    {
+        raw_    = adcptr;
+        flip_   = flip;
+        invert_ = invert;
+        val_    = 0.f;
+    }
+    void Process()
+    {
+        if (!raw_) return;
+        float t = static_cast<float>(*raw_) / 65535.f;
+        if (flip_)   t = 1.f - t;
+        if (invert_) t = 1.f - t;
+        val_ = t;
+    }
+    float Value() const { return val_; }
+
+  private:
+    uint16_t* raw_    = nullptr;
+    bool      flip_   = false;
+    bool      invert_ = false;
+    float     val_    = 0.f;
 };
 
 /* ── Switch ───────────────────────────────────────────────────────────── */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,4 +7,14 @@ target_link_libraries(ring_frame_test PRIVATE alchemy::primitives)
 
 add_test(NAME ring_frame COMMAND ring_frame_test)
 
+# CvInput is fully inline, so its transfer math compiles on host from the
+# V2 headers alone — no V2 BSP target needed (that one is firmware-only).
+# Stubs (daisy_seed.h) arrive through alchemy::primitives' include paths.
+add_executable(cv_input_test cv_input_test.cpp)
+target_include_directories(cv_input_test PRIVATE
+    "${CMAKE_CURRENT_SOURCE_DIR}/../hardware/alchemy-lab/v2/include")
+target_link_libraries(cv_input_test PRIVATE alchemy::primitives)
+
+add_test(NAME cv_input COMMAND cv_input_test)
+
 add_subdirectory(host)

--- a/tests/cv_input_test.cpp
+++ b/tests/cv_input_test.cpp
@@ -1,0 +1,116 @@
+/**
+ * @file cv_input_test.cpp
+ * @brief Host tests for CvInput's Volts() transfer — design fallback and
+ *        the calibrated path (per-jack zero code + board VDDA).
+ * Drives the stub daisy::AnalogControl, which mirrors the real flip
+ * semantics: Value() = 1 − raw/65535.
+ */
+
+#include "alchemy/hw/cv_input.h"
+#include "alchemy/hw/v2_calibration.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+
+namespace {
+
+constexpr float kCtrlRate = 3000.f;  /* control rate; irrelevant to math */
+
+/* One CvInput wired to a settable raw ADC code, flip=true like CvJack. */
+struct Rig
+{
+    uint16_t         raw = 32768u;
+    alchemy::CvInput in;
+
+    Rig()
+    {
+        in.Init(&raw, kCtrlRate, /*flip=*/true, /*invert=*/false,
+                /*slew=*/0.0f);
+    }
+
+    float VoltsAt(uint16_t code)
+    {
+        raw = code;
+        in.Process();
+        return in.Volts();
+    }
+};
+
+/* Forward model of the V2 input chain (inverting summer into the ADC):
+ *   V_pin = bias − kV2CvInGainDesign × V_jack,  raw = V_pin/vdda × 65535 */
+uint16_t RawFor(float v_jack, float vdda, float bias_v)
+{
+    float v_pin = bias_v - alchemy::kV2CvInGainDesign * v_jack;
+    float n     = v_pin / vdda;
+    if (n < 0.f) n = 0.f;
+    if (n > 1.f) n = 1.f;
+    return static_cast<uint16_t>(n * 65535.f + 0.5f);
+}
+
+bool Near(float a, float b, float eps) { return std::fabs(a - b) <= eps; }
+
+/* Measured V-per-Value slope over an exact half-span: raw 16384 → 49152
+ * is ΔValue = 32768/65535; offsets cancel, leaving cal_scale_. */
+float MeasuredScale(Rig& r)
+{
+    const float hi = r.VoltsAt(16384u);  /* flip: lower raw = higher V */
+    const float lo = r.VoltsAt(49152u);
+    return (hi - lo) * 65535.f / 32768.f;
+}
+
+} // namespace
+
+int main()
+{
+    /* 1) Design fallback: full span ±10 V, 0 V at mid-scale, slope 20. */
+    {
+        Rig r;
+        assert(Near(r.VoltsAt(0u), 10.f, 1e-4f));
+        assert(Near(r.VoltsAt(65535u), -10.f, 1e-4f));
+        assert(Near(r.VoltsAt(32768u), 0.f, 1e-3f));
+        assert(Near(MeasuredScale(r), 20.f, 1e-3f));
+    }
+
+    /* 2) Calibrated slope is vdda/gain — NOT the design 20.0. This is
+     *    the regression pin: a hardcoded 3.30 V makes this 20.0 on
+     *    every board regardless of the record. */
+    {
+        Rig r;
+        r.in.SetCalibration(32768u, 3.20f);
+        const float scale = MeasuredScale(r);
+        assert(Near(scale, 3.20f / alchemy::kV2CvInGainDesign, 1e-3f));
+        assert(!Near(scale, 20.0f, 0.1f));
+    }
+
+    /* 3) The stored zero code maps to exactly 0 V, off-mid-scale too. */
+    {
+        Rig r;
+        r.in.SetCalibration(33500u, 3.26f);
+        assert(Near(r.VoltsAt(33500u), 0.f, 1e-3f));
+    }
+
+    /* 4) Round trip through the physical model at off-nominal VDDA and
+     *    bias: calibrating with that board's zero code + VDDA recovers
+     *    jack volts to well under an ADC LSB (~0.3 mV). */
+    {
+        const float vdda = 3.26f, bias = 1.66f;
+        Rig r;
+        r.in.SetCalibration(RawFor(0.f, vdda, bias), vdda);
+        const float probes[] = {-5.f, -2.f, -0.5f, 0.f, 0.75f, 3.f, 4.8f};
+        for (float v : probes)
+            assert(Near(r.VoltsAt(RawFor(v, vdda, bias)), v, 2e-3f));
+    }
+
+    /* 5) The field report that surfaced the bug: a board that tracks
+     *    1 V/oct at scale 19.75 ⇔ VDDA ≈ 3.259 V in its cal record. */
+    {
+        Rig r;
+        r.in.SetCalibration(32768u, 19.75f * alchemy::kV2CvInGainDesign);
+        assert(Near(MeasuredScale(r), 19.75f, 1e-3f));
+    }
+
+    std::printf("cv_input_test: all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
`CvJack::InitMcp`/`InitStm` passed a hardcoded 3.30 V into `SetCalibration`, so the calibrated scale was always the design 20.0. Now threads the record's `vdda_at_cal` through, falling back to 3.30 if out of range.

Calibrated boards shift 1 to 2 percent. Adds `tests/cv_input_test.cpp`.