### PR TITLE
Batch MCP4728 CV writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,20 @@ The set volts functions apply calibration transparently - `hw.j3.SetVolts(volts)
 [`v2_calibration.h`](hardware/alchemy-lab/v2/include/alchemy/hw/v2_calibration.h) for details and
 [`examples/v2_cal_test`](examples/v2_cal_test/v2_cal_test.cpp) for a toggle calibration test app.
 
+`SetVolts()` writes and latches on every call. On J3..J6 that is a full I2C
+round each time. Instead, stage them all and latch once:
+
+```cpp
+hw.j3.StageVolts(a);
+hw.j4.StageVolts(b);
+hw.FlushCvOutputs();   // one WriteAll + one LDAC pulse, ~430 us
+```
+
+`FlushCvOutputs()` returns immediately when nothing is staged, so a control
+loop can end every tick with it. `StageVolts()` on J7..J10 is just
+`SetVolts()` — those backends have no latch to defer — so you can stage
+uniformly across jacks without branching on which one you hold.
+
 ## Expansion Header
 
 There is an expansion header on the back of the unit. In the future,

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,7 +7,7 @@
 | [`clock_sync/`](clock_sync/) | External 24 PPQN clock follower amplitude-modulating an audio passthrough. | Minimal `MusicalClock` + `ClockFollower` wiring for phase-aware tempo sync. |
 | [`ring_demo/`](ring_demo/) | A stereo tremolo whose rings render the LFO itself: a comet pip on the rate ring, a carved notch + shimmer on the depth ring. | Ring composition — `RingFrame`, `Pip`, `Field`, and the publish-DSP-state pattern for signal-driven animation. |
 | [`v2_cal_test/`](v2_cal_test/) *(V2 only)* | Scope-driven calibration acceptance test: B1 steps all jacks −5..+5 V, B2 toggles calibration on/off, the rings show the target voltage. | The calibrated CV-out API end-to-end, plus the LED panel as a bench instrument. |
-| [`v2_cv_demo/`](v2_cv_demo/) *(V2 only)* | All six jacks auto-cycling ±4 V with cal status on the Seed LED. | The minimal calibrated CV-out wiring — `RouteCvOut` + `SetCvOutVolts` in ~60 lines. |
+| [`v2_cv_demo/`](v2_cv_demo/) *(V2 only)* | All six jacks auto-cycling ±4 V with cal status on the Seed LED. | The minimal calibrated CV-out wiring — `EnableCvOutput` + `SetVolts` in ~60 lines. |
 | [`hostlink/`](hostlink/) *(V2 only)* | A minimal preset-bearing module manageable from the browser over USB CDC. | The HostLink recipe — one `hostlink::Host` declaration + `loop.Use(host)`; the web editor's layout is derived from the declared surfaces, including a custom self-describing component. |
 
 ---

--- a/hardware/alchemy-lab/v2/include/alchemy/hw/alchemy_lab_v2.h
+++ b/hardware/alchemy-lab/v2/include/alchemy/hw/alchemy_lab_v2.h
@@ -158,15 +158,6 @@ class AlchemyLabV2
      *  codec-CV shim around it transparently. */
     void StartAudio(daisy::AudioHandle::AudioCallback cb);
 
-    /**
-     * Latch everything staged by CvJack::StageVolts() — one `WriteAll` plus
-     * one `PulseLdac` for all four MCP4728 jacks (J3..J6), about 430 µs at
-     * 400 kHz, versus roughly 1.7 ms for four separate `SetVolts` calls.
-     * Returns immediately when nothing is staged.
-     *
-     * @return false if the MCP or the expander isn't up, or the I²C write
-     *         fails; the staged values stay pending for the next attempt.
-     */
     bool FlushCvOutputs();
 
     /* ── Accessors ─────────────────────────────────────────────────────── */
@@ -207,9 +198,6 @@ class AlchemyLabV2
      *  channel so per-jack SetVolts doesn't disturb the others. */
     uint16_t mcp_shadow_[kMcp4728NumChannels] = { 2048u, 2048u, 2048u, 2048u };
 
-    /** Set by CvJack::StageVolts when mcp_shadow_ moves ahead of the chip;
-     *  cleared by whichever latch pushes it out (FlushCvOutputs, or any
-     *  immediate SetVolts, which sends the whole shadow anyway). */
     bool mcp_dirty_ = false;
 
     /* ── Audio shim plumbing ─────────────────────────────────────────── */

--- a/hardware/alchemy-lab/v2/include/alchemy/hw/alchemy_lab_v2.h
+++ b/hardware/alchemy-lab/v2/include/alchemy/hw/alchemy_lab_v2.h
@@ -9,7 +9,7 @@
  *                            routed through the PCA9557 expander)
  *   - strip, leds            WS2812 + LedPanel
  *   - sdmmc, fatfs           SDMMC1 (1-bit, MEDIUM_SLOW) + FatFS volume "0:"
- *   - Init(), ProcessAllControls(), StartAudio()
+ *   - Init(), ProcessAllControls(), StartAudio(), FlushCvOutputs()
  *   - Layout(), Arc(), SampleRate(), BlockSize()
  *   - I2cReady(), ExpanderReady(), Mcp4728Ready(), StmDacReady()
  *
@@ -158,6 +158,17 @@ class AlchemyLabV2
      *  codec-CV shim around it transparently. */
     void StartAudio(daisy::AudioHandle::AudioCallback cb);
 
+    /**
+     * Latch everything staged by CvJack::StageVolts() — one `WriteAll` plus
+     * one `PulseLdac` for all four MCP4728 jacks (J3..J6), about 430 µs at
+     * 400 kHz, versus roughly 1.7 ms for four separate `SetVolts` calls.
+     * Returns immediately when nothing is staged.
+     *
+     * @return false if the MCP or the expander isn't up, or the I²C write
+     *         fails; the staged values stay pending for the next attempt.
+     */
+    bool FlushCvOutputs();
+
     /* ── Accessors ─────────────────────────────────────────────────────── */
 
     const HardwareLayout& Layout() const { return kAlchemyLabV2Layout; }
@@ -195,6 +206,11 @@ class AlchemyLabV2
     /** MCP4728 writes are all-four-channels; shadow the last value per
      *  channel so per-jack SetVolts doesn't disturb the others. */
     uint16_t mcp_shadow_[kMcp4728NumChannels] = { 2048u, 2048u, 2048u, 2048u };
+
+    /** Set by CvJack::StageVolts when mcp_shadow_ moves ahead of the chip;
+     *  cleared by whichever latch pushes it out (FlushCvOutputs, or any
+     *  immediate SetVolts, which sends the whole shadow anyway). */
+    bool mcp_dirty_ = false;
 
     /* ── Audio shim plumbing ─────────────────────────────────────────── */
 

--- a/hardware/alchemy-lab/v2/include/alchemy/hw/cv_jack.h
+++ b/hardware/alchemy-lab/v2/include/alchemy/hw/cv_jack.h
@@ -66,16 +66,10 @@ class CvJack
      *  unavailable. */
     bool SetVolts(float volts);
 
-    /** Stage `volts` without latching
-     * 
-     *  J3..J6  — writes the shared MCP shadow and marks it dirty; the value
-     *            reaches the chip on the next AlchemyLabV2::FlushCvOutputs().
-     *            Volts() and the panel both lag until that flush.
-     *  J7..J10 — nothing to batch (the STM DAC write is memory-mapped, the
-     *            codec target is read per audio block), so this is exactly
-     *            SetVolts and the later flush is a no-op for them.
-     *
-     *  Returns false on backend unavailable. */
+    /** Stage `volts` without latching. J3..J6 write the shared MCP shadow,
+     *  applied on the next AlchemyLabV2::FlushCvOutputs(); J7..J10 have
+     *  nothing to batch, so this is exactly SetVolts. Returns false on
+     *  backend unavailable. */
     bool StageVolts(float volts);
 
     /* ── Direction ───────────────────────────────────────────────────── */
@@ -134,9 +128,6 @@ class CvJack
      *  AnalogControl for jacks that have one. Cheap no-op for codec out. */
     void Process();
 
-    /** Volts to DAC code via this jack's linear fit. SetVolts and
-     *  StageVolts both go through here so they round identically.
-     *  Requires cal_ — callers check. */
     uint16_t VoltsToCode(float volts) const;
 
     /* ── Common state ─────────────────────────────────────────────────── */

--- a/hardware/alchemy-lab/v2/include/alchemy/hw/cv_jack.h
+++ b/hardware/alchemy-lab/v2/include/alchemy/hw/cv_jack.h
@@ -19,6 +19,12 @@
  *
  *   hw.j9.EnableCvOutput();      // claim codec out channel
  *   hw.j9.SetVolts(precise);     // 24-bit DC, audio-block latency
+ *
+ * Driving several MCP jacks in one control tick: stage each, latch once.
+ *
+ *   hw.j3.StageVolts(a);
+ *   hw.j4.StageVolts(b);
+ *   hw.FlushCvOutputs();         // one WriteAll + one LDAC pulse
  */
 
 #pragma once
@@ -60,6 +66,18 @@ class CvJack
      *  unavailable. */
     bool SetVolts(float volts);
 
+    /** Stage `volts` without latching
+     * 
+     *  J3..J6  — writes the shared MCP shadow and marks it dirty; the value
+     *            reaches the chip on the next AlchemyLabV2::FlushCvOutputs().
+     *            Volts() and the panel both lag until that flush.
+     *  J7..J10 — nothing to batch (the STM DAC write is memory-mapped, the
+     *            codec target is read per audio block), so this is exactly
+     *            SetVolts and the later flush is a no-op for them.
+     *
+     *  Returns false on backend unavailable. */
+    bool StageVolts(float volts);
+
     /* ── Direction ───────────────────────────────────────────────────── */
 
     /** Put this jack into CV-output mode.
@@ -80,10 +98,11 @@ class CvJack
     enum class Backend : uint8_t { Mcp, Stm, CodecOut };
 
     /** MCP4728 jack (J3..J6). `shadow_slot` points into the shared
-     *  4-channel shadow array; `mcp_shadow_dirty` is unused for now (kept
-     *  for future batched-flush). `vdda` is the board VDDA out of the cal
-     *  record — the reference the record's zero codes and DAC fits were
-     *  measured against (kV2VddaDesign when uncalibrated). */
+     *  4-channel shadow array and `dirty_flag` at the board's staged-write
+     *  flag — both owned by AlchemyLabV2, which outlives every jack.
+     *  `vdda` is the board VDDA out of the cal record — the reference the
+     *  record's zero codes and DAC fits were measured against
+     *  (kV2VddaDesign when uncalibrated). */
     void InitMcp(uint16_t*           adc_ptr,
                  float               sample_rate,
                  const V2JackCal*    cal,
@@ -92,6 +111,7 @@ class CvJack
                  uint8_t             mcp_channel,
                  uint16_t*           shadow_slot,
                  uint16_t*           shadow_array,
+                 bool*               dirty_flag,
                  Pca9557*            expander,
                  uint8_t             select_io,
                  uint8_t             ldac_io);
@@ -114,6 +134,11 @@ class CvJack
      *  AnalogControl for jacks that have one. Cheap no-op for codec out. */
     void Process();
 
+    /** Volts to DAC code via this jack's linear fit. SetVolts and
+     *  StageVolts both go through here so they round identically.
+     *  Requires cal_ — callers check. */
+    uint16_t VoltsToCode(float volts) const;
+
     /* ── Common state ─────────────────────────────────────────────────── */
 
     Backend          backend_   = Backend::Mcp;
@@ -130,6 +155,7 @@ class CvJack
     uint8_t   mcp_channel_      = 0;
     uint16_t* mcp_shadow_slot_  = nullptr;   /* points into shadow_array */
     uint16_t* mcp_shadow_array_ = nullptr;   /* whole 4-channel shadow   */
+    bool*     mcp_dirty_        = nullptr;   /* board's staged-write flag */
     uint8_t   ldac_io_          = 0;
 
     /* ── STM DAC-only ─────────────────────────────────────────────────── */

--- a/hardware/alchemy-lab/v2/src/alchemy_lab_v2.cpp
+++ b/hardware/alchemy-lab/v2/src/alchemy_lab_v2.cpp
@@ -1,6 +1,7 @@
 /**
  * @file alchemy_lab_v2.cpp
- * @brief alchemy::AlchemyLabV2 — Init / ProcessAllControls / StartAudio.
+ * @brief alchemy::AlchemyLabV2 — Init / ProcessAllControls / StartAudio /
+ *        FlushCvOutputs.
  *
  * Production scope: Seed + audio, ADC (pots + CV), B1/B2 on-MCU buttons,
  * I²C1 + PCA9557 expander + B3, WS2812 + LedPanel, MCP4728 quad DAC,
@@ -129,7 +130,7 @@ void AlchemyLabV2::Init(daisy::SaiHandle::Config::SampleRate sample_rate,
             cv_jacks[i].InitMcp(
                 seed.adc.GetPtr(kCvAdcOffset + i), sr, cal, cal_vdda,
                 &dac, src,
-                &mcp_shadow_[src], mcp_shadow_,
+                &mcp_shadow_[src], mcp_shadow_, &mcp_dirty_,
                 &expander, route.select_io, kPca9557IoLdac);
         }
         else
@@ -168,6 +169,23 @@ void AlchemyLabV2::Init(daisy::SaiHandle::Config::SampleRate sample_rate,
             (void)f_mount(&fatfs.GetSDFileSystem(), fatfs.GetSDPath(), 0);
         }
     }
+}
+
+bool AlchemyLabV2::FlushCvOutputs()
+{
+    if (!mcp_dirty_)
+        return true;
+    if (!mcp4728_ready_ || !expander_ready_)
+        return false;
+
+    if (!dac.WriteAll(mcp_shadow_[0], mcp_shadow_[1], mcp_shadow_[2], mcp_shadow_[3]))
+        return false;
+        
+    if (!dac.PulseLdac(expander, kPca9557IoLdac))
+        return false;
+
+    mcp_dirty_ = false;
+    return true;
 }
 
 void AlchemyLabV2::ProcessAllControls()

--- a/hardware/alchemy-lab/v2/src/cv_jack.cpp
+++ b/hardware/alchemy-lab/v2/src/cv_jack.cpp
@@ -110,12 +110,9 @@ float CvJack::Value() const
 
 uint16_t CvJack::VoltsToCode(float volts) const
 {
-    /* Invert the per-jack linear fit, clamp to the 12-bit hardware range.
-       Past the linear region (cal_->dac_{min,max}_linear_code) the output
-       compresses near the DAC's supply rails, so the jack stops tracking
-       the fit — but pushing to 0/4095 still gets us as close to ±5 V as
-       the analog stage physically allows, which matters more than
-       perfect linearity in the last ~100 mV. */
+    /* Invert the per-jack linear fit, clamped to 0..4095. Past the linear
+       region the output compresses near the rails, but full scale still
+       lands closest to ±5 V. */
     float code_f = (volts - cal_->dac_offset_v) / cal_->dac_gain_v_per_code;
     if (code_f < 0.0f)      code_f = 0.0f;
     if (code_f > 4095.0f)   code_f = 4095.0f;

--- a/hardware/alchemy-lab/v2/src/cv_jack.cpp
+++ b/hardware/alchemy-lab/v2/src/cv_jack.cpp
@@ -24,6 +24,7 @@ void CvJack::InitMcp(uint16_t*        adc_ptr,
                      uint8_t          mcp_channel,
                      uint16_t*        shadow_slot,
                      uint16_t*        shadow_array,
+                     bool*            dirty_flag,
                      Pca9557*         expander,
                      uint8_t          select_io,
                      uint8_t          ldac_io)
@@ -39,6 +40,7 @@ void CvJack::InitMcp(uint16_t*        adc_ptr,
     mcp_channel_      = mcp_channel;
     mcp_shadow_slot_  = shadow_slot;
     mcp_shadow_array_ = shadow_array;
+    mcp_dirty_        = dirty_flag;
     ldac_io_          = ldac_io;
     if (cal_) in_.SetCalibration(cal_->adc_zero_code, vdda);
 }
@@ -106,6 +108,20 @@ float CvJack::Value() const
 
 /* ── Write ──────────────────────────────────────────────────────────── */
 
+uint16_t CvJack::VoltsToCode(float volts) const
+{
+    /* Invert the per-jack linear fit, clamp to the 12-bit hardware range.
+       Past the linear region (cal_->dac_{min,max}_linear_code) the output
+       compresses near the DAC's supply rails, so the jack stops tracking
+       the fit — but pushing to 0/4095 still gets us as close to ±5 V as
+       the analog stage physically allows, which matters more than
+       perfect linearity in the last ~100 mV. */
+    float code_f = (volts - cal_->dac_offset_v) / cal_->dac_gain_v_per_code;
+    if (code_f < 0.0f)      code_f = 0.0f;
+    if (code_f > 4095.0f)   code_f = 4095.0f;
+    return static_cast<uint16_t>(code_f + 0.5f);
+}
+
 bool CvJack::SetVolts(float volts)
 {
     target_v_ = volts;
@@ -118,16 +134,7 @@ bool CvJack::SetVolts(float volts)
 
     if (!cal_) return false;
 
-    /* Invert the per-jack linear fit, clamp to the 12-bit hardware range.
-       Past the linear region (cal_->dac_{min,max}_linear_code) the output
-       compresses near the DAC's supply rails, so the jack stops tracking
-       the fit — but pushing to 0/4095 still gets us as close to ±5 V as
-       the analog stage physically allows, which matters more than
-       perfect linearity in the last ~100 mV. */
-    float code_f = (volts - cal_->dac_offset_v) / cal_->dac_gain_v_per_code;
-    if (code_f < 0.0f)      code_f = 0.0f;
-    if (code_f > 4095.0f)   code_f = 4095.0f;
-    const uint16_t code = static_cast<uint16_t>(code_f + 0.5f);
+    const uint16_t code = VoltsToCode(volts);
 
     if (backend_ == Backend::Mcp)
     {
@@ -138,12 +145,35 @@ bool CvJack::SetVolts(float volts)
         if (!mcp_->WriteAll(mcp_shadow_array_[0], mcp_shadow_array_[1],
                             mcp_shadow_array_[2], mcp_shadow_array_[3]))
             return false;
-        return mcp_->PulseLdac(*expander_, ldac_io_);
+        
+        if (!mcp_->PulseLdac(*expander_, ldac_io_))
+            return false;
+
+        /* WriteAll sends all for channels */
+        if (mcp_dirty_) *mcp_dirty_ = false;
+        return true;
     }
 
     /* STM DAC */
     if (!stm_) return false;
     return stm_->WriteValue(stm_ch_, code) == daisy::DacHandle::Result::OK;
+}
+
+bool CvJack::StageVolts(float volts)
+{
+    /* Only the MCP backend has a latch worth deferring; for the others the
+       write is already cheap, so stage == set and the flush is a no-op. */
+    if (backend_ != Backend::Mcp)
+        return SetVolts(volts);
+
+    target_v_ = volts;
+
+    if (!cal_ || !mcp_ || !mcp_->Ready() || !mcp_shadow_slot_ || !mcp_dirty_)
+        return false;
+
+    *mcp_shadow_slot_ = VoltsToCode(volts);
+    *mcp_dirty_       = true;
+    return true;
 }
 
 /* ── Direction ──────────────────────────────────────────────────────── */


### PR DESCRIPTION
SetVolts writes and latches on every call, so driving all four MCP4728 jacks costs four full write-plus-latch rounds.

CvJack::StageVolts writes the shared shadow and marks a board-owned dirty flag; AlchemyLabV2::FlushCvOutputs latches all channels with one WriteAll and one PulseLdac. It returns when nothing is staged.