### PR TITLE
ParamLock v2: Clocked mode, exit policies, LED styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,29 @@
-# Alchemy SDK — unreleased
+# Unreleased
+
+## Parameter locks v2
+
+- Clocked mode: `locks.UseClock(clock_)` plus a persisted Free/Clocked
+  selector via `settings.UseLocks(locks)` (P5). New recordings snap
+  their loop boundary to the nearest musical division (straight+triplet
+  default, `SnapGrid()` adds dotted) and
+  restart in time through tempo changes. Slot headers
+  `'PLK1'` → `'PLK2'` (5 → 7 B); older saved locks schema-gate to empty.
+- Gesture: arm at 0.5% (was 3%), clear stays 3%, `record_base` is the
+  pre-nudge origin; `ArmThreshold()` / `ClearThreshold()`.
+- `ExitMode(LockExit::Return)`: knob snaps back to the origin on
+  release and pot-catch re-arms; `Latch` (surface default) is today's
+  behavior. `UseLocks` also installs a persisted Return/Latch selector
+  (P6, Return default), completing the default settings stack: P1
+  brightness, P2 free, P3–P4 presets, P5–P6 locks.
+- `RecordStyle()` / `PlayStyle()` (Solid/Blink/Breathe/LoopPulse/Sweep,
+  red defaults), `ClearSlot()`, `Freeze()`, `PlayPhase()`, and
+  `BrightnessHandle::At()`.
+
+## Pager navigation bindings
 
 Shift layers are pages: page navigation became declarative button
 bindings on `Pager`, so a hold-layer gets pot-catch, presets, locks, CV,
 rings, and the descriptor for free (#16).
-
-## Pager navigation bindings
 
 - `Pager(num_pages, num_pots)` + fluent `.Cycle(btn, pages...)`,
   `.Shift(btn, page)`, `.Latch(btn, a, b)`, `.From(pages...)`.  The

--- a/docs/param-locks.md
+++ b/docs/param-locks.md
@@ -1,13 +1,11 @@
-# Parameter locks: length, rate, behavior, and what they cost
+# Parameter locks: capacity, rate, and behavior
 
-A parameter lock records a knob gesture and loops it. Recording arms the
-moment the knob moves (a 0.5% nudge), a firmer ~3% nudge on a knob that
-is already looping clears it, and an optional **Clocked** mode restarts
-every new loop on the musical grid. Capacity is a compile-time
-declaration.
+A parameter lock records a knob gesture and loops it. Recording arms
+when the knob moves 0.5% of travel. A 3% move on a knob that is already
+looping clears it. An optional **Clocked** mode restarts each loop on
+the musical grid. Capacity is a compile-time declaration.
 
-How long a gesture can be is your application's decision, declared once
-at the ParamLock declaration:
+Maximum gesture length is declared once, as a template argument:
 
 ```cpp
 alchemy::ParamLock<6>                       locks(hw.buttons[0]);  // 16 s (default)
@@ -41,43 +39,40 @@ using Locks = alchemy::ParamLock<6, alchemy::LockLength<20>>;
 Locks::kMaxSeconds       // 20
 Locks::kSampleRateHz     // 30
 Locks::kFramesPerSlot    // 600
-Locks::kArenaBytes       // 7'200   — motion storage
-Locks::RamBytes()        // 7'560   — arena + the object itself
-Locks::kPresetBytes      // 7'242   — taken from every preset slot
-Locks::kPresetBytesFree  // 13'206  — left for your other components
+Locks::kArenaBytes       // 7'200   (motion storage)
+Locks::RamBytes()        // 7'560   (arena + the object itself)
+Locks::kPresetBytes      // 7'242   (taken from every preset slot)
+Locks::kPresetBytesFree  // 13'206  (left for your other components)
 ```
 
 ## The two budgets
 
-**RAM.** Framework statics link into `DTCMRAM` — 128 KiB, shared with
-`.data` and the stack. ParamLock will not silently take a large bite out
-of that: past **16 KiB** of motion arena it refuses to hold its own
-storage and makes you place it (see *Large configurations* below). Raise
-the threshold with `-DALCHEMY_LOCK_INLINE_RAM_LIMIT=32768` if your
-application genuinely has the DTCM to spare.
+**RAM.** Framework statics link into `DTCMRAM` (128 KiB, shared with
+`.data` and the stack). Above **16 KiB** of motion arena the build fails
+unless you supply the arena yourself (see *Large configurations*). Raise
+the threshold with `-DALCHEMY_LOCK_INLINE_RAM_LIMIT=32768` if the DTCM
+is available.
 
 **Flash.** A preset slot holds **20,448 bytes** for *all* managed
-components combined. This ceiling is hard: the preset region is the top
-640 KiB of the QSPI chip, ending at the last byte of the device, so it
-cannot grow without taking space from firmware or giving up preset slots.
-A ParamLock configured past it is a compile error, not a `Save()` that
-returns `false` on the bench.
+components combined. The preset region is the top 640 KiB of the QSPI
+chip and cannot grow without taking space from firmware or dropping
+preset slots. A ParamLock configured past the ceiling is a compile
+error, not a runtime `Save()` failure.
 
 ## Picking a rate
 
 `kRateHz` is the rate the motion buffer is *stored* at, decoupled from
 the control-loop frame rate. Playback interpolates between stored
-samples and recording box-averages into them, so a low rate costs
-smoothness far more slowly than you would expect — a hand turning a knob
-carries no useful energy above about 8 Hz.
+samples and recording box-averages into them. Hand motion on a knob has
+negligible energy above about 8 Hz, so low rates lose little smoothness.
 
 | Rate | Use it when |
 |---|---|
-| 60 Hz | You want the buffer indistinguishable from the control loop. Costs 2× of 30. |
-| 30 Hz | The default. Smooth for anything a hand can do. |
-| 20 Hz | Still fine, and what makes the longest configurations fit in flash. |
+| 60 Hz | Near the 16 ms control-loop rate. Twice the cost of 30 Hz. |
+| 30 Hz | Default. Sufficient for hand motion. |
+| 20 Hz | Sufficient. Required for the longest configurations to fit in flash. |
 
-**Dropping the rate is almost always cheaper than dropping the length.**
+**Reduce the rate before reducing the length.**
 
 ## What fits in a preset slot
 
@@ -92,27 +87,27 @@ preset names):
 | 30 s @ 20 Hz | 7.2 KB ✅ | 14.5 KB ✅ | 19.3 KB ✅ |
 | 30 s @ 60 Hz | 21.6 KB ❌ | ❌ | ❌ |
 
-`LockStore::RamOnly` removes the flash ceiling entirely — see below.
+`LockStore::RamOnly` removes the flash ceiling entirely (see *RAM-only
+locks*).
 
-## Locks you don't need to save
+## RAM-only locks
 
-If you want long locks and don't need them to survive a power cycle,
-say so and the flash budget stops applying:
+Locks that need not survive a power cycle can be declared RAM-only,
+which removes them from the flash budget:
 
 ```cpp
 using Locks = alchemy::ParamLock<6,
     alchemy::LockLength<60, 60, alchemy::LockStore::RamOnly>>;
 ```
 
-`SerializedSize()` becomes 0, so `presets.Manage(locks)` costs nothing
-and the preset budget ignores them entirely. The raw byte form is still
-available by hand via `Save()` / `Restore()` — that's the route for
-writing locks to an SD card yourself.
+`SerializedSize()` returns 0, so `presets.Manage(locks)` adds nothing to
+the preset budget. `Save()` / `Restore()` still produce the raw byte
+form, for example for writing locks to an SD card.
 
 ## Large configurations
 
-Past `ALCHEMY_LOCK_INLINE_RAM_LIMIT` the arena has to be placed by you.
-The build tells you so, and this is the shape it's asking for:
+Above `ALCHEMY_LOCK_INLINE_RAM_LIMIT` you must supply the arena; the
+build fails with a message saying so. Required form:
 
 ```cpp
 using Locks = alchemy::ParamLock<12,
@@ -123,7 +118,7 @@ static Locks locks(hw.buttons[0], pager,
                    alchemy::LockArena{lock_arena, sizeof lock_arena});
 
 int main() {
-    hw.Init();       // brings up the FMC — SDRAM is unusable before this
+    hw.Init();       // brings up the FMC; SDRAM is unusable before this
     locks.Init();    // clears the arena; .sdram_bss is NOLOAD
     ...
 }
@@ -142,7 +137,7 @@ Two rules:
 A short arena is refused at runtime rather than overrun: `IsReady()`
 stays false and every read returns 0.
 
-## Seconds mean seconds
+## Length is wall-clock time
 
 The motion buffer is clocked in milliseconds, not frames. `ControlLoop`
 tells the surface its frame interval every frame, so:
@@ -159,28 +154,27 @@ default.
 
 `SchemaHash()` folds in the slot count, the buffer length, the sample
 rate, and the storage policy. Changing any of them makes existing preset
-slots **invisible** — they are treated as empty rather than replayed at
+slots **invisible**: they are treated as empty rather than replayed at
 the wrong speed or restored into a differently-shaped buffer.
 
 The v0.11 slot header grew from 5 to 7 bytes (`'PLK1'` → `'PLK2'`, adding
-the Clocked loop length), so locks saved by earlier firmware are invisible
-to v0.11 builds in the same deliberate way.
+the Clocked loop length), so v0.11 builds treat locks saved by earlier
+firmware as empty.
 
 ## Sample representation
 
-Samples are stored as `uint16` normalized 0..1. Pot positions arrive
-from a 16-bit ADC, so a 1/65535 grid is finer than the signal and three
-times finer than `kCatchTolerance`; storing `float` would double both
-budgets to represent noise.
+Samples are stored as `uint16` normalized 0..1. Pot positions come from
+a 16-bit ADC, so a 1/65535 grid matches the source resolution. `float`
+would double both budgets without adding information.
 
 ---
 
 # Behavior
 
-Everything below is optional.  The declaration alone gives you the stock
-behavior: arm at a 0.5% nudge, clear at 3%, Latch exit, a solid red pip
-while recording, a blinking red pip during playback, free-running loops.
-Each fluent call overrides one thing; defaults are shown.
+Everything below is optional. The declaration alone gives: arm at 0.5%,
+clear at 3%, Latch exit, solid red pip while recording, blinking red pip
+during playback, free-running loops. Each call overrides one setting;
+the values shown are the defaults.
 
 ```cpp
 locks.UseClock(clock_)                              /* enables Clocked mode  */
@@ -192,137 +186,132 @@ locks.UseClock(clock_)                              /* enables Clocked mode  */
      .PlayStyle  ({0xFF, 0x00, 0x00}, LockAnim::Blink);
 ```
 
-## The gesture, and why there are two thresholds
+## Arm and clear thresholds
 
-Hold the trigger and move a knob: recording starts the moment the motion
-passes `ArmThreshold`.  The distance to arm is timing error on the loop's
-t = 0, so it is small — 0.5% of travel, roughly 1.5° on a 300° pot,
-still above the filtered pot noise floor (the baseline snapshots at
-button-down, so noise cannot creep toward the threshold during a hold).
-The recording's reference (and a `Return` exit's home) is where the knob
-sat **before** the nudge, so the loop is anchored to the gesture's true
-origin, not origin-plus-threshold.
+Hold the trigger and move a knob. Recording starts when the motion
+exceeds `ArmThreshold`. Travel before that point is lost from the start
+of the loop, so the threshold is kept small: 0.5% of travel, about 1.5°
+on a 300° pot, and about 3× the filtered pot noise floor. The baseline
+is captured at button-down, so noise cannot accumulate toward the
+threshold during a hold. The recording's reference value, and the home
+position for a `Return` exit, is the knob position before the nudge, not
+the position at which the threshold was crossed.
+
+`ClearThreshold` is larger (3%) so that brushing a neighboring pot
+during a hold does not clear a playing lock.
 
 ## Exit modes
 
 What happens to the knob's base value when the button is released:
 
-- **`LockExit::Latch`** (surface default) — the pot stays where the
-  gesture left it, and playback rides on top as an offset.
-- **`LockExit::Return`** — the logical value snaps back to the recorded
-  origin and pot-catch re-arms, exactly as if you had switched pages: the
-  pot is dead until it passes back through the stored value.  Playback
-  reproduces what you recorded, verbatim.  Requires the paged form —
-  there has to be a Pager to write the value into — and applies to every
-  slot the hold armed, buffer-full auto-arms included.
+- **`LockExit::Latch`** (surface default): the pot stays where the
+  gesture left it, and playback is added to it as an offset.
+- **`LockExit::Return`**: the logical value returns to the recorded
+  origin and pot-catch re-arms, as on a page change. The pot has no
+  effect until it crosses the stored value. Playback reproduces the
+  recording exactly. Requires the paged form, since the value is written
+  into a Pager. Applies to every slot the hold armed, including
+  buffer-full auto-arms.
 
-Like Free/Clocked, the policy is a user decision, so `UseLocks` also
-exposes it as a persisted Settings selector (see below) — where the
-menu is in play, **Return is the default**.
+`UseLocks` also exposes the exit policy as a persisted Settings selector
+(see *The settings selectors*). The two defaults differ: the surface
+default is Latch, the selector default is Return.
 
 ## Clocked mode
 
-`UseClock(clock_)` hands the surface a `MusicalClock` (internally timed
-or steered by a `ClockFollower` — the lock does not care).  With the mode
-set to **Clocked**, a finished recording snaps its *loop boundary* to the
-nearest musical duration: play roughly a bar of motion and the loop
-restarts on exactly the bar.  Three properties are worth being precise
-about:
+`UseClock(clock_)` supplies a `MusicalClock`. Whether it is internally
+timed or driven by a `ClockFollower` makes no difference to the lock. In
+**Clocked** mode a finished recording snaps its *loop boundary* to the
+nearest musical duration: record roughly one bar of motion and the loop
+restarts on exactly one bar. Three properties:
 
-- **The motion is sacred.**  Playback always runs at exactly the speed
-  you performed. A take
-  slightly longer than the grid gets its tail trimmed (those samples are
-  simply never reached); a slightly shorter one holds its final value
-  until the restart.  At a stable tempo both corrections are the few
-  milliseconds you missed the grid by.
-- **Only the boundary snaps, and only the boundary follows tempo.**  The
-  loop's start is wherever your gesture ended — deliberately not
-  quantized to the bar.  Restarts are derived from the clock's absolute
-  position (nothing accumulates, nothing drifts), so tempo changes and
-  follower drift move the restart, never the motion speed.  Slow the
-  clock way down and the motion plays out, holds, and restarts on the
-  later grid; speed it way up and each pass replays the front of the
-  take.
-- **A stopped transport holds clocked loops in place** (free loops keep
-  running); signal-loss behavior is whatever your `ClockFollower` loss
-  policy says.
+- **Motion is never resampled.** Playback runs at the recorded speed. A
+  take longer than the snapped length is truncated: samples past the
+  boundary are never reached. A shorter take holds its final value until
+  the restart. At stable tempo either correction is the few milliseconds
+  by which the take missed the grid.
+- **Only the boundary snaps and follows tempo.** The loop starts where
+  the gesture ended; the start is not quantized to the bar. Restart
+  times are computed from the clock's absolute position rather than
+  accumulated, so tempo changes and follower drift move the restart and
+  never the motion speed. If the clock slows, the motion plays out,
+  holds its final value, and restarts on the later grid. If the clock
+  speeds up, each pass replays only the front of the take.
+- **A stopped transport freezes clocked loops.** Free loops keep
+  running. On signal loss, behavior follows the `ClockFollower` loss
+  policy.
 
-The take's duration is measured against the clock itself — a tick stamp
-at arm, a tick delta at release — never derived from the sample count.
-The clock runs on real timestamps, so the snap is immune to control-loop
-frame-timing error and correctly integrates a tempo change made while
-you were still recording.
+The take's duration is measured in clock ticks (a stamp at arm, a delta
+at release), not from the sample count. The clock uses real timestamps,
+so the snap is unaffected by control-loop frame jitter and accounts for
+a tempo change made during recording.
 
-The snap grid is ratio-nearest (log-domain) across the enabled note-value
-families — straight and triplet by default, dotted opt-in via
-`SnapGrid()` — from a 16th note up to a whole note, plus **integer bar
-counts** above one bar regardless of the mask, so a sloppy 5½-bar take
-lands on 5 or 6 bars instead of stretching to 4 or 8.
+The snap grid is nearest-by-ratio (log domain) across the enabled
+note-value families: straight and triplet by default, dotted via
+`SnapGrid()`. It spans a 16th note to a whole note, plus **integer bar
+counts** above one bar regardless of the mask, so a 5½-bar take snaps to
+5 or 6 bars rather than 4 or 8.
 
-The mode is consulted at record time only.  Every slot stores which
+The mode is consulted at record time only. Every slot stores which
 timing it was captured under (`musical_ticks` in the saved header), so
-flipping the setting never re-times an existing lock, and a preset can
-mix free and clocked slots.  Two more consequences of storing musical
+changing the setting never re-times an existing lock, and a preset can
+mix free and clocked slots. Two more consequences of storing musical
 ticks rather than milliseconds:
 
-- **Presets stay on the grid at any tempo.**  A lock saved as 2 bars
-  restarts every 2 bars at any later tempo — the motion inside plays as
+- **Presets stay on the grid at any tempo.** A lock saved as 2 bars
+  restarts every 2 bars at any later tempo; the motion plays as
   recorded.
-- **Restored locks come back aligned.**  Slots loaded from a preset
-  anchor at the clock's origin, so equal musical lengths are mutually
-  phase-locked.
+- **Restored locks are phase-aligned.** Slots loaded from a preset
+  anchor at the clock's origin, so slots of equal musical length restart
+  together.
 
 If Clocked is selected but the clock is not running when a recording
-ends — or no clock was ever wired — that slot falls back to free and
-replays at its recorded length.  Nothing refuses to record.
+ends, or no clock was ever wired, that slot falls back to free and
+replays at its recorded length. Recording is never refused.
 
 ## The settings selectors
 
-The Free/Clocked choice and the exit policy are user decisions, so they
-live in the Settings menu:
+The Free/Clocked choice and the exit policy are exposed in the Settings
+menu:
 
 ```cpp
-settings.UseBrightness();          /* P1 (as before)                   */
-settings.UsePresets(presets);      /* P3–P4 (as before)                */
+settings.UseBrightness();          /* P1                               */
+settings.UsePresets(presets);      /* P3–P4                            */
 settings.UseLocks(locks);          /* P5: Free/Clocked, P6: exit       */
 ```
 
-`UseLocks` installs two ordinary persisted selectors — one byte each in
-the Settings blob, saved and loaded with presets exactly like
-brightness, editable from hosts as normal enum fields — that push their
-values into the lock whenever they change or load.  P5 selects Free or
-Clocked for new recordings.  P6 selects the exit policy: **Return**
-(zone 0, the default — after recording the knob snaps back to the
-original position and pot catch re-arms) or **Latch** (zone 1 — the
-knob stays at its current offset position).  P2 is left free for the
-module, completing the default stack: P1 brightness, P2 free, P3–P4
-presets, P5–P6 locks.
+`UseLocks` installs two persisted selectors. Each is one byte in the
+Settings blob, saved and loaded with presets like brightness, and
+editable from hosts as an enum field. Each pushes its value into the
+lock on change and on load. P5 selects Free or Clocked for new
+recordings. P6 selects the exit policy: **Return** (zone 0, default) or
+**Latch** (zone 1); see *Exit modes*. P2 is unassigned. Default
+assignment: P1 brightness, P2 free, P3–P4 presets, P5–P6 locks.
 
 Relocate the pair with `.At(page, pot)` / `.ExitAt(page, pot)`, restyle
 the sync zones with `.Colors(...)`, and set boot defaults with
 `.Default(LockSync::Clocked)` / `.DefaultExit(LockExit::Latch)`.
 
-Call it after `UseClock` — offering "Clocked" on a module with no clock
-wired is a debug-build assert, not a silent lie — and only on the paged
-form, since offering "Return" needs a Pager to write into.
+Call `UseLocks` after `UseClock`: offering Clocked with no clock wired
+is a debug-build assert. `UseLocks` requires the paged form, because
+Return needs a Pager to write into.
 
 ## LED styles
 
-The stock overlay is a pip at 6 o'clock on any ring whose slot is busy.
+The stock overlay is a pip at 6 o'clock on any ring whose slot is active.
 `RecordStyle` / `PlayStyle` set its color and animation:
 
 | `LockAnim` | Reads as |
 |---|---|
 | `Solid` | lock exists |
-| `Blink` | 2 Hz square — the playback default |
-| `Breathe` | slow ~2 s breath |
-| `LoopPulse` | a flash at every loop restart, decaying over the loop's first fifth — loop length at a glance (solid while recording) |
-| `Sweep` | the pip orbits the ring with the play head; while recording it crawls with the write head, i.e. buffer use |
+| `Blink` | 2 Hz square wave; playback default |
+| `Breathe` | 2 s triangle brightness ramp |
+| `LoopPulse` | flash at each loop restart, decaying over the first 20% of the loop; solid while recording |
+| `Sweep` | pip position follows the play head around the ring; while recording it follows the write head, showing buffer fill |
 
-There are no tuning knobs on the animations on purpose.  When the
-curated set isn't enough, skip the stock `Render()` and compose your own
-ring from `IsActive()` / `IsRecording()` / `PlayPhase()` — that has been
-the escape hatch all along.
+The animations have no tuning parameters. For anything else, skip the
+stock `Render()` and draw the ring yourself from `IsActive()` /
+`IsRecording()` / `PlayPhase()`.
 
 ## Utilities
 
@@ -334,6 +323,6 @@ locks.Freeze(false);                 /* … resume where they held        */
 locks.PlayPhase(pot);                /* 0..1 loop phase, for custom UIs */
 ```
 
-`Freeze` holds playback only — recording is unaffected — and clocked
-loops resume from where they froze rather than jumping to wherever the
-clock got to.  Wire it to a button for the build-and-drop trick.
+`Freeze` affects playback only; recording continues. Clocked loops
+resume from the frozen phase, not from the clock's current position.
+Typically wired to a performance button.

--- a/docs/param-locks.md
+++ b/docs/param-locks.md
@@ -207,14 +207,18 @@ origin, not origin-plus-threshold.
 
 What happens to the knob's base value when the button is released:
 
-- **`LockExit::Latch`** (default) — the pot stays where the gesture left
-  it, and playback rides on top as an offset.
+- **`LockExit::Latch`** (surface default) — the pot stays where the
+  gesture left it, and playback rides on top as an offset.
 - **`LockExit::Return`** — the logical value snaps back to the recorded
   origin and pot-catch re-arms, exactly as if you had switched pages: the
   pot is dead until it passes back through the stored value.  Playback
   reproduces what you recorded, verbatim.  Requires the paged form —
   there has to be a Pager to write the value into — and applies to every
   slot the hold armed, buffer-full auto-arms included.
+
+Like Free/Clocked, the policy is a user decision, so `UseLocks` also
+exposes it as a persisted Settings selector (see below) — where the
+menu is in play, **Return is the default**.
 
 ## Clocked mode
 
@@ -272,26 +276,35 @@ If Clocked is selected but the clock is not running when a recording
 ends — or no clock was ever wired — that slot falls back to free and
 replays at its recorded length.  Nothing refuses to record.
 
-## The settings selector
+## The settings selectors
 
-The Free/Clocked choice is a user decision, so it lives in the Settings
-menu:
+The Free/Clocked choice and the exit policy are user decisions, so they
+live in the Settings menu:
 
 ```cpp
 settings.UseBrightness();          /* P1 (as before)                   */
-settings.UseLocks(locks);          /* P2: Free / Clocked selector      */
 settings.UsePresets(presets);      /* P3–P4 (as before)                */
+settings.UseLocks(locks);          /* P5: Free/Clocked, P6: exit       */
 ```
 
-`UseLocks` is an ordinary persisted selector — one byte in the Settings
-blob, saved and loaded with presets exactly like brightness, editable
-from hosts as a normal enum field — that pushes its value into the lock
-whenever it changes or loads.  It defaults to page 0, pot 1; relocate it
-with `.At(page, pot)`, restyle with `.Colors(...)`, and set the boot
-default with `.Default(LockSync::Clocked)`.
+`UseLocks` installs two ordinary persisted selectors — one byte each in
+the Settings blob, saved and loaded with presets exactly like
+brightness, editable from hosts as normal enum fields — that push their
+values into the lock whenever they change or load.  P5 selects Free or
+Clocked for new recordings.  P6 selects the exit policy: **Return**
+(zone 0, the default — after recording the knob snaps back to the
+original position and pot catch re-arms) or **Latch** (zone 1 — the
+knob stays at its current offset position).  P2 is left free for the
+module, completing the default stack: P1 brightness, P2 free, P3–P4
+presets, P5–P6 locks.
+
+Relocate the pair with `.At(page, pot)` / `.ExitAt(page, pot)`, restyle
+the sync zones with `.Colors(...)`, and set boot defaults with
+`.Default(LockSync::Clocked)` / `.DefaultExit(LockExit::Latch)`.
 
 Call it after `UseClock` — offering "Clocked" on a module with no clock
-wired is a debug-build assert, not a silent lie.
+wired is a debug-build assert, not a silent lie — and only on the paged
+form, since offering "Return" needs a Pager to write into.
 
 ## LED styles
 

--- a/docs/param-locks.md
+++ b/docs/param-locks.md
@@ -1,8 +1,13 @@
-# Parameter locks: length, rate, and what they cost
+# Parameter locks: length, rate, behavior, and what they cost
 
-A parameter lock records a knob gesture and loops it. How long a gesture
-can be is your application's decision, declared once at the ParamLock
-declaration:
+A parameter lock records a knob gesture and loops it. Recording arms the
+moment the knob moves (a 0.5% nudge), a firmer ~3% nudge on a knob that
+is already looping clears it, and an optional **Clocked** mode restarts
+every new loop on the musical grid. Capacity is a compile-time
+declaration.
+
+How long a gesture can be is your application's decision, declared once
+at the ParamLock declaration:
 
 ```cpp
 alchemy::ParamLock<6>                       locks(hw.buttons[0]);  // 16 s (default)
@@ -21,8 +26,11 @@ The second template argument is a capacity policy:
 samples per slot = seconds × rate_hz
 
 RAM          = slots × samples × 2 B
-preset bytes = slots × (5 + samples × 2 B)
+preset bytes = slots × (7 + samples × 2 B)
 ```
+
+(The 7 is the per-slot header: active flag, length, record base, and the
+Clocked loop length in clock ticks.)
 
 Both are compile-time constants you can read back, print at boot, or
 assert against:
@@ -34,9 +42,9 @@ Locks::kMaxSeconds       // 20
 Locks::kSampleRateHz     // 30
 Locks::kFramesPerSlot    // 600
 Locks::kArenaBytes       // 7'200   — motion storage
-Locks::RamBytes()        // 7'440   — arena + the object itself
-Locks::kPresetBytes      // 7'230   — taken from every preset slot
-Locks::kPresetBytesFree  // 13'218  — left for your other components
+Locks::RamBytes()        // 7'560   — arena + the object itself
+Locks::kPresetBytes      // 7'242   — taken from every preset slot
+Locks::kPresetBytesFree  // 13'206  — left for your other components
 ```
 
 ## The two budgets
@@ -78,7 +86,7 @@ preset names):
 
 | Configuration | 6 slots | 12 slots | 16 slots |
 |---|---|---|---|
-| 16 s @ 30 Hz (default) | 5.8 KB ✅ | 11.6 KB ✅ | 15.4 KB ✅ |
+| 16 s @ 30 Hz (default) | 5.8 KB ✅ | 11.6 KB ✅ | 15.5 KB ✅ |
 | 20 s @ 30 Hz | 7.2 KB ✅ | 14.5 KB ✅ | 19.3 KB ✅ |
 | 30 s @ 30 Hz | 10.8 KB ✅ | 21.7 KB ❌ | ❌ |
 | 30 s @ 20 Hz | 7.2 KB ✅ | 14.5 KB ✅ | 19.3 KB ✅ |
@@ -154,9 +162,165 @@ rate, and the storage policy. Changing any of them makes existing preset
 slots **invisible** — they are treated as empty rather than replayed at
 the wrong speed or restored into a differently-shaped buffer.
 
+The v0.11 slot header grew from 5 to 7 bytes (`'PLK1'` → `'PLK2'`, adding
+the Clocked loop length), so locks saved by earlier firmware are invisible
+to v0.11 builds in the same deliberate way.
+
 ## Sample representation
 
 Samples are stored as `uint16` normalized 0..1. Pot positions arrive
 from a 16-bit ADC, so a 1/65535 grid is finer than the signal and three
 times finer than `kCatchTolerance`; storing `float` would double both
 budgets to represent noise.
+
+---
+
+# Behavior
+
+Everything below is optional.  The declaration alone gives you the stock
+behavior: arm at a 0.5% nudge, clear at 3%, Latch exit, a solid red pip
+while recording, a blinking red pip during playback, free-running loops.
+Each fluent call overrides one thing; defaults are shown.
+
+```cpp
+locks.UseClock(clock_)                              /* enables Clocked mode  */
+     .SnapGrid(LockGrid::Straight | LockGrid::Triplet)  /* | LockGrid::Dotted */
+     .ArmThreshold(0.005f)
+     .ClearThreshold(0.03f)
+     .ExitMode(LockExit::Latch)                     /* or LockExit::Return   */
+     .RecordStyle({0xFF, 0x00, 0x00}, LockAnim::Solid)
+     .PlayStyle  ({0xFF, 0x00, 0x00}, LockAnim::Blink);
+```
+
+## The gesture, and why there are two thresholds
+
+Hold the trigger and move a knob: recording starts the moment the motion
+passes `ArmThreshold`.  The distance to arm is timing error on the loop's
+t = 0, so it is small — 0.5% of travel, roughly 1.5° on a 300° pot,
+still above the filtered pot noise floor (the baseline snapshots at
+button-down, so noise cannot creep toward the threshold during a hold).
+The recording's reference (and a `Return` exit's home) is where the knob
+sat **before** the nudge, so the loop is anchored to the gesture's true
+origin, not origin-plus-threshold.
+
+## Exit modes
+
+What happens to the knob's base value when the button is released:
+
+- **`LockExit::Latch`** (default) — the pot stays where the gesture left
+  it, and playback rides on top as an offset.
+- **`LockExit::Return`** — the logical value snaps back to the recorded
+  origin and pot-catch re-arms, exactly as if you had switched pages: the
+  pot is dead until it passes back through the stored value.  Playback
+  reproduces what you recorded, verbatim.  Requires the paged form —
+  there has to be a Pager to write the value into — and applies to every
+  slot the hold armed, buffer-full auto-arms included.
+
+## Clocked mode
+
+`UseClock(clock_)` hands the surface a `MusicalClock` (internally timed
+or steered by a `ClockFollower` — the lock does not care).  With the mode
+set to **Clocked**, a finished recording snaps its *loop boundary* to the
+nearest musical duration: play roughly a bar of motion and the loop
+restarts on exactly the bar.  Three properties are worth being precise
+about:
+
+- **The motion is sacred.**  Playback always runs at exactly the speed
+  you performed. A take
+  slightly longer than the grid gets its tail trimmed (those samples are
+  simply never reached); a slightly shorter one holds its final value
+  until the restart.  At a stable tempo both corrections are the few
+  milliseconds you missed the grid by.
+- **Only the boundary snaps, and only the boundary follows tempo.**  The
+  loop's start is wherever your gesture ended — deliberately not
+  quantized to the bar.  Restarts are derived from the clock's absolute
+  position (nothing accumulates, nothing drifts), so tempo changes and
+  follower drift move the restart, never the motion speed.  Slow the
+  clock way down and the motion plays out, holds, and restarts on the
+  later grid; speed it way up and each pass replays the front of the
+  take.
+- **A stopped transport holds clocked loops in place** (free loops keep
+  running); signal-loss behavior is whatever your `ClockFollower` loss
+  policy says.
+
+The take's duration is measured against the clock itself — a tick stamp
+at arm, a tick delta at release — never derived from the sample count.
+The clock runs on real timestamps, so the snap is immune to control-loop
+frame-timing error and correctly integrates a tempo change made while
+you were still recording.
+
+The snap grid is ratio-nearest (log-domain) across the enabled note-value
+families — straight and triplet by default, dotted opt-in via
+`SnapGrid()` — from a 16th note up to a whole note, plus **integer bar
+counts** above one bar regardless of the mask, so a sloppy 5½-bar take
+lands on 5 or 6 bars instead of stretching to 4 or 8.
+
+The mode is consulted at record time only.  Every slot stores which
+timing it was captured under (`musical_ticks` in the saved header), so
+flipping the setting never re-times an existing lock, and a preset can
+mix free and clocked slots.  Two more consequences of storing musical
+ticks rather than milliseconds:
+
+- **Presets stay on the grid at any tempo.**  A lock saved as 2 bars
+  restarts every 2 bars at any later tempo — the motion inside plays as
+  recorded.
+- **Restored locks come back aligned.**  Slots loaded from a preset
+  anchor at the clock's origin, so equal musical lengths are mutually
+  phase-locked.
+
+If Clocked is selected but the clock is not running when a recording
+ends — or no clock was ever wired — that slot falls back to free and
+replays at its recorded length.  Nothing refuses to record.
+
+## The settings selector
+
+The Free/Clocked choice is a user decision, so it lives in the Settings
+menu:
+
+```cpp
+settings.UseBrightness();          /* P1 (as before)                   */
+settings.UseLocks(locks);          /* P2: Free / Clocked selector      */
+settings.UsePresets(presets);      /* P3–P4 (as before)                */
+```
+
+`UseLocks` is an ordinary persisted selector — one byte in the Settings
+blob, saved and loaded with presets exactly like brightness, editable
+from hosts as a normal enum field — that pushes its value into the lock
+whenever it changes or loads.  It defaults to page 0, pot 1; relocate it
+with `.At(page, pot)`, restyle with `.Colors(...)`, and set the boot
+default with `.Default(LockSync::Clocked)`.
+
+Call it after `UseClock` — offering "Clocked" on a module with no clock
+wired is a debug-build assert, not a silent lie.
+
+## LED styles
+
+The stock overlay is a pip at 6 o'clock on any ring whose slot is busy.
+`RecordStyle` / `PlayStyle` set its color and animation:
+
+| `LockAnim` | Reads as |
+|---|---|
+| `Solid` | lock exists |
+| `Blink` | 2 Hz square — the playback default |
+| `Breathe` | slow ~2 s breath |
+| `LoopPulse` | a flash at every loop restart, decaying over the loop's first fifth — loop length at a glance (solid while recording) |
+| `Sweep` | the pip orbits the ring with the play head; while recording it crawls with the write head, i.e. buffer use |
+
+There are no tuning knobs on the animations on purpose.  When the
+curated set isn't enough, skip the stock `Render()` and compose your own
+ring from `IsActive()` / `IsRecording()` / `PlayPhase()` — that has been
+the escape hatch all along.
+
+## Utilities
+
+```cpp
+locks.ClearSlot(pot);                /* visible page                    */
+locks.ClearSlotAtPage(page, pot);    /* explicit slot                   */
+locks.Freeze(true);                  /* hold every play head …         */
+locks.Freeze(false);                 /* … resume where they held        */
+locks.PlayPhase(pot);                /* 0..1 loop phase, for custom UIs */
+```
+
+`Freeze` holds playback only — recording is unaffected — and clocked
+loops resume from where they froze rather than jumping to wherever the
+clock got to.  Wire it to a button for the build-and-drop trick.

--- a/framework/include/alchemy/control/lock_snap.h
+++ b/framework/include/alchemy/control/lock_snap.h
@@ -1,0 +1,110 @@
+/**
+ * @file alchemy/control/lock_snap.h
+ * @brief Pure snap math for Clocked parameter locks.
+ *
+ * Given a recorded duration in musical-clock ticks, pick the grid length
+ * it "meant": the candidate minimizing the ratio distance max(T/c, c/T).
+ * Ratio distance (equivalently, nearest in the log domain) is the right
+ * metric because the correction is the trimmed tail or held gap at the
+ * loop seam, and it is its size *relative to the loop* that you hear —
+ * being 20 ms long matters a lot at a 16th and not at all at 4 bars.
+ *
+ * Candidates are the enabled note-value families up to a whole note, plus
+ * integer bar counts (always enabled) from 1 bar up to just past the
+ * recording.  Integer bars keep the worst-case correction small above one
+ * bar, where the pure note-value grid goes sparse (a 5½-bar take snaps to
+ * 5 or 6 bars, not 4 or 8).
+ *
+ * Stateless and host-testable; consumed by ParamLockManager at slot
+ * activation.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include "alchemy/control/lock_types.h"
+
+namespace alchemy {
+
+/** Largest representable snapped length (u16 ticks in the saved form). */
+constexpr uint32_t kLockSnapMaxTicks = 65535u;
+
+/**
+ * Snap a recorded duration to the musical grid.
+ *
+ * @param rec_ticks      Recorded duration in clock ticks (> 0).
+ * @param ppqn           Clock resolution (multiple of 24; see MusicalClock).
+ * @param beats_per_bar  Time-signature numerator.
+ * @param grid_mask      LockGrid family bitmask (bars are always included).
+ * @return               Snapped length in ticks, in
+ *                       [smallest enabled candidate, kLockSnapMaxTicks];
+ *                       0 — the caller treats the slot as free — if the
+ *                       configuration is degenerate or the take is too
+ *                       long to represent (better free than trimmed).
+ */
+inline uint32_t LockSnapTicks(double  rec_ticks,
+                              uint32_t ppqn,
+                              uint8_t  beats_per_bar,
+                              uint8_t  grid_mask)
+{
+    if (!(rec_ticks > 0.0) || ppqn == 0u || beats_per_bar == 0u
+        || rec_ticks > static_cast<double>(kLockSnapMaxTicks))
+        return 0u;
+
+    uint32_t best   = 0u;
+    double   best_r = 0.0;
+
+    const auto consider = [&](uint32_t num, uint32_t den)
+    {
+        if (den == 0u || num % den != 0u) return;   /* inexact at this ppqn */
+        const uint32_t c = num / den;
+        if (c == 0u || c > kLockSnapMaxTicks) return;
+        const double cd = static_cast<double>(c);
+        const double r  = (rec_ticks > cd) ? rec_ticks / cd : cd / rec_ticks;
+        if (best == 0u || r < best_r)
+        {
+            best   = c;
+            best_r = r;
+        }
+    };
+
+    if (grid_mask & LockGrid::Straight)
+    {
+        consider(ppqn, 4u);        /* 16th    */
+        consider(ppqn, 2u);        /* 8th     */
+        consider(ppqn, 1u);        /* quarter */
+        consider(ppqn * 2u, 1u);   /* half    */
+        consider(ppqn * 4u, 1u);   /* whole   */
+    }
+    if (grid_mask & LockGrid::Triplet)
+    {
+        consider(ppqn, 6u);        /* 16th-t    */
+        consider(ppqn, 3u);        /* 8th-t     */
+        consider(ppqn * 2u, 3u);   /* quarter-t */
+        consider(ppqn * 4u, 3u);   /* half-t    */
+        consider(ppqn * 8u, 3u);   /* whole-t   */
+    }
+    if (grid_mask & LockGrid::Dotted)
+    {
+        consider(ppqn * 3u, 8u);   /* dotted 16th    */
+        consider(ppqn * 3u, 4u);   /* dotted 8th     */
+        consider(ppqn * 3u, 2u);   /* dotted quarter */
+        consider(ppqn * 3u, 1u);   /* dotted half    */
+        consider(ppqn * 6u, 1u);   /* dotted whole   */
+    }
+
+    /* Integer bars, always: 1 bar up to the first count past the
+     * recording (so both neighbours of T are candidates), within u16. */
+    const uint32_t bar = ppqn * static_cast<uint32_t>(beats_per_bar);
+    for (uint32_t k = 1u; ; k++)
+    {
+        const uint64_t c = static_cast<uint64_t>(bar) * k;
+        if (c > kLockSnapMaxTicks) break;
+        consider(static_cast<uint32_t>(c), 1u);
+        if (static_cast<double>(c) >= rec_ticks) break;
+    }
+
+    return best;
+}
+
+} // namespace alchemy

--- a/framework/include/alchemy/control/lock_types.h
+++ b/framework/include/alchemy/control/lock_types.h
@@ -1,0 +1,158 @@
+/**
+ * @file alchemy/control/lock_types.h
+ * @brief Behavior vocabulary for parameter locks: sync mode, exit policy,
+ *        snap-grid families, LED style animations.
+ *
+ * Capacity policy (how much motion fits) lives in lock_length.h; this
+ * header is how a lock *behaves*.  Everything here is a small closed set
+ * consumed by the ParamLock surface's fluent configuration calls — see
+ * docs/param-locks.md.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace alchemy {
+
+/* ── Gesture thresholds ───────────────────────────────────────────────── */
+
+/** Physical nudge (0..1) that arms recording on an empty slot.  Small on
+ *  purpose — the distance to arm is timing error on the loop's t=0.
+ *  Hardware-verified to sit ~3× above the filtered pot noise floor (the
+ *  baseline snapshots at button-down, so noise cannot creep toward it). */
+constexpr float kParamLockArmThreshold   = 0.005f;
+
+/** Physical nudge (0..1) that clears an active slot.  Deliberately larger
+ *  than the arm threshold: brushing a neighboring pot mid-hold must not
+ *  destroy a playing lock. */
+constexpr float kParamLockClearThreshold = 0.03f;
+
+/* ── Sync mode ────────────────────────────────────────────────────────── */
+
+/**
+ * Whether new recordings snap their loop length to the musical clock.
+ *
+ * Applies at record time only: each slot keeps the truth it was recorded
+ * with (and serializes it), so flipping the mode never re-times an
+ * existing lock.
+ */
+enum class LockSync : uint8_t
+{
+    Free    = 0,   ///< loop replays at the wall-clock length it was recorded
+    Clocked = 1,   ///< loop length snaps to the nearest musical division
+};
+
+/* ── Exit policy ──────────────────────────────────────────────────────── */
+
+/**
+ * What happens to the knob's base value when recording ends.
+ *
+ *   Latch  — the pot stays where the gesture left it; playback rides on
+ *            top as an offset the user can keep performing.
+ *   Return — the logical value snaps back to where the gesture started
+ *            (record_base) and pot-catch re-arms, so playback reproduces
+ *            exactly what was recorded until the pot is caught again.
+ *            Requires the paged ParamLock form (a Pager to write into).
+ */
+enum class LockExit : uint8_t
+{
+    Latch  = 0,
+    Return = 1,
+};
+
+/* ── Snap grid ────────────────────────────────────────────────────────── */
+
+/**
+ * Bitmask of note-value families a Clocked recording may snap to.
+ * Integer bar counts above one bar are always candidates regardless of
+ * the mask — without them a 5½-bar take would stretch to 4 or 8 bars.
+ */
+namespace LockGrid {
+
+constexpr uint8_t Straight = 1u << 0;  ///< 16th, 8th, quarter, half, whole
+constexpr uint8_t Triplet  = 1u << 1;  ///< triplet variants of the above
+constexpr uint8_t Dotted   = 1u << 2;  ///< dotted 16th … dotted whole
+
+constexpr uint8_t Default  = Straight | Triplet;
+
+} // namespace LockGrid
+
+/* ── LED styles ───────────────────────────────────────────────────────── */
+
+/**
+ * Pip animation for the recording / playback overlay.  A small curated
+ * set with no tuning knobs; full control remains the existing escape
+ * hatch (skip the stock Render() and compose your own ring from
+ * IsActive / IsRecording / PlayPhase).
+ */
+enum class LockAnim : uint8_t
+{
+    Solid,      ///< steady pip
+    Blink,      ///< 2 Hz square blink
+    Breathe,    ///< slow sinusoidal breath (~2 s)
+    LoopPulse,  ///< flash at each loop restart, decaying over its first
+                ///< fifth.  Solid while recording (no loop exists yet).
+    Sweep,      ///< pip orbits the ring with the play head; while
+                ///< recording it crawls with the write head (buffer use)
+};
+
+/**
+ * One evaluated animation frame: a brightness factor for the pip and,
+ * for Sweep, where on the ring to draw it.
+ *
+ * Pure function of its inputs (stateless, frame-rate independent —
+ * docs/ring-animations.md rule 3).
+ *
+ * @param anim       Style to evaluate.
+ * @param t_ms       Absolute milliseconds (drives Blink / Breathe).
+ * @param phase      Loop phase 0..1: play head for playback, write
+ *                   position / capacity while recording.
+ * @param recording  True while the slot is recording.
+ */
+struct LockAnimFrame
+{
+    float level;      ///< brightness multiplier 0..1
+    bool  sweep;      ///< true → draw at sweep_pos01 instead of the home pip
+    float sweep_pos01;///< ring position 0..1 (0 = home / 6 o'clock)
+};
+
+inline LockAnimFrame LockAnimEval(LockAnim anim, uint32_t t_ms,
+                                  float phase, bool recording)
+{
+    if (phase < 0.0f) phase = 0.0f;
+    if (phase > 1.0f) phase = 1.0f;
+
+    switch (anim)
+    {
+        case LockAnim::Blink:
+            return {(t_ms % 500u) < 250u ? 1.0f : 0.0f, false, 0.0f};
+
+        case LockAnim::Breathe:
+        {
+            /* 2 s triangle — a cosine reads identically on a single pip. */
+            const uint32_t t   = t_ms % 2000u;
+            const float    lin = (t < 1000u)
+                                   ? static_cast<float>(t) / 1000.0f
+                                   : static_cast<float>(2000u - t) / 1000.0f;
+            return {0.25f + 0.75f * lin, false, 0.0f};
+        }
+
+        case LockAnim::LoopPulse:
+        {
+            if (recording) return {1.0f, false, 0.0f};
+            const float decay = 1.0f - phase * 5.0f;
+            const float k     = decay > 0.0f ? decay : 0.0f;
+            return {0.2f + 0.8f * k, false, 0.0f};
+        }
+
+        case LockAnim::Sweep:
+            return {1.0f, true, phase};
+
+        case LockAnim::Solid:
+        default:
+            return {1.0f, false, 0.0f};
+    }
+}
+
+} // namespace alchemy

--- a/framework/include/alchemy/control/param_lock_manager.h
+++ b/framework/include/alchemy/control/param_lock_manager.h
@@ -17,6 +17,15 @@
  *   on button up:                   bool consumed = mgr.OnButtonUp();
  *   every frame:                    mgr.Advance();         (advances all heads)
  *   when reading slot N:            float mod = mgr.Read(N);
+ *
+ * Clocked mode (optional): give the manager a MusicalClock and set
+ * LockSync::Clocked, and every slot that finishes recording snaps its
+ * loop BOUNDARY to the nearest musical division (control/lock_snap.h).
+ * The motion always replays at the speed it was performed; only the
+ * restart is clock-derived, from absolute clock position, so tempo
+ * changes move the boundary and nothing drifts.  Each slot records its
+ * own timing (ParamLockSlot::musical_ticks), so the mode setting only
+ * affects *new* recordings.
  */
 
 #pragma once
@@ -24,26 +33,32 @@
 #include <cstddef>
 #include <cstdint>
 #include "alchemy/control/lock_length.h"
+#include "alchemy/control/lock_types.h"
 #include "alchemy/control/pot_catch.h"
 
 namespace alchemy {
+
+class MusicalClock;
 
 /** Maximum pots-per-page supported by the gesture engine. */
 constexpr uint8_t kParamLockMaxGestureWidth = 8u;
 
 /**
  * Per-slot header of the serialized form, followed by `stride` little-
- * endian uint16 samples.
+ * endian uint16 samples.  `musical_ticks` is the Clocked loop length in
+ * clock ticks (0 = free-running), so a clocked lock keeps its musical
+ * length under any later tempo.
  */
 struct ParamLockSavedHeader
 {
     uint8_t  active;
     uint16_t length;
     uint16_t record_base;
+    uint16_t musical_ticks;
 } __attribute__((packed));
 
-static_assert(sizeof(ParamLockSavedHeader) == 5u,
-              "ParamLockSavedHeader must pack to 5 bytes");
+static_assert(sizeof(ParamLockSavedHeader) == 7u,
+              "ParamLockSavedHeader must pack to 7 bytes");
 
 /** Configuration handed to ParamLockManager::Init. */
 struct LockConfig
@@ -55,7 +70,8 @@ struct LockConfig
     uint8_t        gesture_width = 0u;     ///< pots per gesture frame
     uint16_t       rate_hz     = 30u;      ///< stored motion sample rate
     uint32_t       frame_ms    = 16u;      ///< control-frame interval
-    float          gesture_threshold = kParamLockGestureThreshold;
+    float          arm_threshold   = kParamLockArmThreshold;
+    float          clear_threshold = kParamLockClearThreshold;
 };
 
 class ParamLockManager
@@ -75,6 +91,24 @@ class ParamLockManager
     /** True once Init() has been given a usable configuration. */
     bool IsReady() const { return slots_ != nullptr && arena_ != nullptr; }
 
+    /* ── Behavior configuration (all optional; see lock_types.h) ─────── */
+
+    /** Musical clock consulted by Clocked mode.  May be null; Clocked
+     *  recordings then fall back to free. */
+    void SetClock(const MusicalClock* clk) { clock_ = clk; }
+    bool HasClock() const                  { return clock_ != nullptr; }
+
+    void     SetSyncMode(LockSync m) { sync_mode_ = m; }
+    LockSync SyncMode() const        { return sync_mode_; }
+
+    void    SetSnapGrid(uint8_t mask) { grid_mask_ = mask; }
+    uint8_t SnapGrid() const          { return grid_mask_; }
+
+    void SetArmThreshold  (float t) { arm_threshold_   = t; }
+    void SetClearThreshold(float t) { clear_threshold_ = t; }
+
+    /* ── Gesture ─────────────────────────────────────────────────────── */
+
     /** Called when the trigger button goes down.  Snapshots baselines. */
     void OnButtonDown(const float phys[]);
 
@@ -88,9 +122,29 @@ class ParamLockManager
      */
     void ProcessGestures(uint8_t offset, const float phys[]);
 
+    /** True if gesture lane @p i (0..gesture_width-1) armed or cleared a
+     *  slot during the current / most recent hold; valid until the next
+     *  OnButtonDown.  Lets the surface exit-policy exactly this hold's
+     *  slots. */
+    bool ActionTaken(uint8_t i) const
+    {
+        return i < kParamLockMaxGestureWidth && action_taken_[i];
+    }
+
+    /* ── Playback ────────────────────────────────────────────────────── */
+
     void Advance();
 
+    /** Hold every play head in place (recording is unaffected).  Clocked
+     *  slots re-anchor on resume so they continue from where they froze
+     *  instead of jumping to where the clock got to. */
+    void SetFrozen(bool on);
+    bool Frozen() const { return frozen_; }
+
     float Read(uint8_t index) const;
+
+    /** Loop phase 0..1 of an active slot's play head (0 for inactive). */
+    float Phase(uint8_t index) const;
 
     bool IsActive   (uint8_t index) const;
     bool IsRecording(uint8_t index) const;
@@ -118,14 +172,21 @@ class ParamLockManager
 
     void Clear();
 
+    /** Reset one slot to its default (inactive) state.  Safe against a
+     *  concurrent audio-ISR Read(): `active` is dropped first, in its own
+     *  store, before the rest of the slot is touched. */
+    void ClearSlot(uint8_t index);
+
     /** Zero the motion arena.  Separate from Clear() because an arena in
      *  a NOLOAD section needs one explicit pass after the memory is up. */
     void ClearArena();
 
   private:
-    void  Finalise();
-    void  EmitSample(ParamLockSlot& lk, uint16_t* buf);
-    float SampleAt(const ParamLockSlot& lk, const uint16_t* buf) const;
+    void   Finalise();
+    void   ActivateSlot(ParamLockSlot& lk);
+    void   EmitSample(ParamLockSlot& lk, uint16_t* buf);
+    float  SampleAt(const ParamLockSlot& lk, const uint16_t* buf) const;
+    double NowTicks() const;
 
     uint16_t*      Buf(uint8_t index)
     {
@@ -144,7 +205,13 @@ class ParamLockManager
     uint16_t       rate_hz_          = 30;
     uint32_t       step_q16_         = 0;
     uint32_t       rec_phase_q16_    = 0;
-    float          gesture_threshold_= kParamLockGestureThreshold;
+    float          arm_threshold_    = kParamLockArmThreshold;
+    float          clear_threshold_  = kParamLockClearThreshold;
+    const MusicalClock* clock_       = nullptr;
+    LockSync       sync_mode_        = LockSync::Free;
+    uint8_t        grid_mask_        = LockGrid::Default;
+    bool           frozen_           = false;
+    double         freeze_tick_      = 0.0;
     float          baseline_   [kParamLockMaxGestureWidth] = {};
     bool           action_taken_[kParamLockMaxGestureWidth] = {};
     bool           button_held_ = false;

--- a/framework/include/alchemy/control/pot_catch.h
+++ b/framework/include/alchemy/control/pot_catch.h
@@ -25,7 +25,9 @@ namespace alchemy {
 /** Proximity window: pot is caught immediately if within this distance. */
 constexpr float    kCatchTolerance             = 0.005f;
 
-/** Minimum physical nudge (0..1) required to start / stop param-lock. */
+/** Legacy single param-lock nudge threshold.  The gesture now uses the
+ *  arm / clear pair in control/lock_types.h (this value became the clear
+ *  default); kept for source compatibility. */
 constexpr float    kParamLockGestureThreshold  = 0.03f;
 
 /** Motion gate: travel off a sleeping stored value required to wake. */
@@ -64,13 +66,17 @@ struct PotState
 
 struct ParamLockSlot
 {
-    bool     active      = false;
-    bool     recording   = false;
-    uint16_t length      = 0;      ///< samples recorded (≤ stride)
-    uint32_t play_pos    = 0;      ///< Q16.16 play position (see above)
-    uint16_t record_base = 0;      ///< quantized pot position at arm time
-    float    rec_accum   = 0.0f;   ///< box-average accumulator (record)
-    uint16_t rec_count   = 0;      ///< frames accumulated toward next sample
+    bool     active        = false;
+    bool     recording     = false;
+    uint16_t length        = 0;    ///< samples recorded (≤ stride)
+    uint32_t play_pos      = 0;    ///< Q16.16 play position (see above)
+    uint16_t record_base   = 0;    ///< quantized pot position at arm time
+    uint16_t musical_ticks = 0;    ///< Clocked loop length in clock ticks;
+                                   ///< 0 = free-running (wall-clock length)
+    float    rec_accum     = 0.0f; ///< box-average accumulator (record)
+    uint16_t rec_count     = 0;    ///< frames accumulated toward next sample
+    double   anchor_tick   = 0.0;  ///< clock position at playback start
+                                   ///< (runtime only; 0 = master origin)
 };
 
 /* The atomicity argument above requires natural alignment. */

--- a/framework/include/alchemy/surface/lock_source.h
+++ b/framework/include/alchemy/surface/lock_source.h
@@ -26,6 +26,21 @@ class LockSource
     /** Modulation delta for one (page, pot) slot. ISR-safe; cheap. */
     virtual float DeltaAtPage(uint8_t page, uint8_t pot) const = 0;
 
+    /* ── Sync-mode binding (Settings::UseLocks) ──────────────────────
+     * Free/Clocked as a raw byte so Settings can push a selector index
+     * without knowing the concrete lock type.  Defaults are no-ops so
+     * custom automation sources are unaffected. */
+
+    /** Set the sync mode (0 = free, 1 = clocked; see alchemy::LockSync). */
+    virtual void    SetSyncMode(uint8_t /*mode*/) {}
+
+    /** Current sync mode as a selector index. */
+    virtual uint8_t SyncMode() const { return 0u; }
+
+    /** True when a musical clock is wired (Clocked mode is meaningful).
+     *  Default true so custom sources aren't nagged by UseLocks' guard. */
+    virtual bool    HasClock() const { return true; }
+
     /** True if the (page, pot) slot is recording. */
     virtual bool  IsRecordingAtPage(uint8_t page, uint8_t pot) const = 0;
 

--- a/framework/include/alchemy/surface/lock_source.h
+++ b/framework/include/alchemy/surface/lock_source.h
@@ -26,8 +26,8 @@ class LockSource
     /** Modulation delta for one (page, pot) slot. ISR-safe; cheap. */
     virtual float DeltaAtPage(uint8_t page, uint8_t pot) const = 0;
 
-    /* ── Sync-mode binding (Settings::UseLocks) ──────────────────────
-     * Free/Clocked as a raw byte so Settings can push a selector index
+    /* ── Sync/exit binding (Settings::UseLocks) ──────────────────────
+     * Behavior modes as raw bytes so Settings can push a selection
      * without knowing the concrete lock type.  Defaults are no-ops so
      * custom automation sources are unaffected. */
 
@@ -40,6 +40,16 @@ class LockSource
     /** True when a musical clock is wired (Clocked mode is meaningful).
      *  Default true so custom sources aren't nagged by UseLocks' guard. */
     virtual bool    HasClock() const { return true; }
+
+    /** Set the exit policy (0 = latch, 1 = return; see alchemy::LockExit). */
+    virtual void    SetExitMode(uint8_t /*mode*/) {}
+
+    /** Current exit policy as a LockExit value. */
+    virtual uint8_t ExitMode() const { return 0u; }
+
+    /** True when a Return exit can take effect (ParamLock: paged form).
+     *  Default true so custom sources aren't nagged by UseLocks' guard. */
+    virtual bool    CanReturn() const { return true; }
 
     /** True if the (page, pot) slot is recording. */
     virtual bool  IsRecordingAtPage(uint8_t page, uint8_t pot) const = 0;

--- a/framework/include/alchemy/surface/manual.h
+++ b/framework/include/alchemy/surface/manual.h
@@ -46,6 +46,13 @@ inline constexpr const char* kLockMode =
     "on the nearest musical division of the clock, staying in time "
     "through tempo changes.";
 
+inline constexpr const char* kLockExit =
+    "What the knob does when a lock finishes recording. **Return** snaps "
+    "the value back to where the gesture started and re-arms pot catch, "
+    "so playback reproduces the recorded motion exactly. **Latch** keeps "
+    "the knob where the gesture left it, with playback riding on top as "
+    "an offset.";
+
 inline constexpr const char* kStorage =
     "The SD card holds files the firmware reads and writes. Browse and "
     "manage them from the web programmer's file panel. Avoid removing the "

--- a/framework/include/alchemy/surface/manual.h
+++ b/framework/include/alchemy/surface/manual.h
@@ -34,7 +34,17 @@ inline constexpr const char* kPresets =
 inline constexpr const char* kLocks =
     "Parameter locks are short automation loops recorded from the panel: "
     "hold the lock gesture and move a knob to capture the motion, and the "
-    "module replays it as part of the patch.";
+    "module replays it as part of the patch. Recording starts the moment "
+    "the knob moves; another nudge on a knob that is already looping "
+    "clears its lock. In **Clocked** mode (where the module offers it) a "
+    "new loop restarts on the nearest musical division and stays in time "
+    "with the clock.";
+
+inline constexpr const char* kLockMode =
+    "How new parameter-lock recordings are timed. **Free** replays a loop "
+    "at exactly the length it was recorded. **Clocked** restarts the loop "
+    "on the nearest musical division of the clock, staying in time "
+    "through tempo changes.";
 
 inline constexpr const char* kStorage =
     "The SD card holds files the firmware reads and writes. Browse and "

--- a/framework/include/alchemy/surface/param_lock.h
+++ b/framework/include/alchemy/surface/param_lock.h
@@ -38,17 +38,36 @@
  *
  * Saving into a preset is just presets.Manage(locks).  Save()/Restore()
  * expose the raw bytes by hand — the only route for LockStore::RamOnly.
+ *
+ * Behavior is configured with optional fluent calls (defaults shown):
+ *
+ *   locks.UseClock(clock_)                 // enables Clocked mode
+ *        .SnapGrid(LockGrid::Default)      // Straight | Triplet
+ *        .ArmThreshold(0.005f)
+ *        .ClearThreshold(0.03f)
+ *        .ExitMode(LockExit::Latch)        // Return needs the paged form
+ *        .RecordStyle({0xFF,0,0}, LockAnim::Solid)
+ *        .PlayStyle  ({0xFF,0,0}, LockAnim::Blink);
+ *
+ * The Free/Clocked choice and the exit policy are Settings options
+ * (Settings::UseLocks), pushed in via LockSource::SetSyncMode() /
+ * SetExitMode().  Each slot serializes the sync mode it was captured
+ * under, so flipping the setting never re-times an existing lock.  See
+ * docs/param-locks.md.
  */
 
 #pragma once
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include "alchemy/control/lock_length.h"
+#include "alchemy/control/lock_types.h"
 #include "alchemy/control/param_lock_manager.h"
 #include "alchemy/control/pot_catch.h"
 #include "alchemy/control/preset_capacity.h"
 #include "alchemy/hw/i_button.h"
+#include "alchemy/led/panel.h"
 #include "alchemy/surface/lock_source.h"
 #include "alchemy/surface/pager.h"
 #include "alchemy/surface/serializable.h"
@@ -72,11 +91,19 @@
 
 namespace alchemy {
 
-class LedPanel;
+class MusicalClock;
 
 /* Schema tag for ParamLock — bump if the saved layout changes shape.
- * 'PLK1': uint16 motion samples at a configurable rate, variable length. */
-inline constexpr uint32_t kParamLockSchemaTag = 0x504C4B31u; /* 'PLK1' */
+ * 'PLK2': 7-byte slot header (adds musical_ticks for Clocked loops) +
+ * uint16 motion samples at a configurable rate, variable length. */
+inline constexpr uint32_t kParamLockSchemaTag = 0x504C4B32u; /* 'PLK2' */
+
+/** One LED style: a color plus a LockAnim (see control/lock_types.h). */
+struct LockStyle
+{
+    LedPanel::Rgb color;
+    LockAnim      anim;
+};
 
 namespace detail {
 
@@ -108,6 +135,71 @@ class ParamLock : public Serializable, public LockSource
     /** Locks help override (default: stock_help::kLocks). */
     ParamLock& Help(const char* md) { help_ = md; return *this; }
     const char* ManualHelp() const { return help_; }
+
+    /* ── Behavior configuration (fluent, optional; defaults shown) ────
+     * See lock_types.h for the vocabulary and docs/param-locks.md for
+     * the full story.  Call from main(), before the loop starts.      */
+
+    /** Wire the musical clock Clocked mode snaps to and follows.  Without
+     *  it, Clocked recordings fall back to free per slot. */
+    ParamLock& UseClock(const MusicalClock& clk)
+    {
+        mgr_.SetClock(&clk);
+        return *this;
+    }
+
+    /** Note-value families Clocked recordings may snap to.  Integer bar
+     *  counts above one bar are always candidates.
+     *  Default: LockGrid::Straight | LockGrid::Triplet. */
+    ParamLock& SnapGrid(uint8_t mask) { mgr_.SetSnapGrid(mask); return *this; }
+
+    /** Nudge (0..1) that arms recording.  Default 0.005. */
+    ParamLock& ArmThreshold(float t) { mgr_.SetArmThreshold(t); return *this; }
+
+    /** Nudge (0..1) that clears an active lock.  Default 0.03. */
+    ParamLock& ClearThreshold(float t)
+    {
+        mgr_.SetClearThreshold(t);
+        return *this;
+    }
+
+    /** What happens to the knob's base value when recording ends.
+     *  LockExit::Return needs the paged form (a Pager to write into).
+     *  Default: LockExit::Latch. */
+    ParamLock& ExitMode(LockExit m)
+    {
+        assert(m != LockExit::Return || pager_ != nullptr);
+        exit_mode_ = m;
+        return *this;
+    }
+
+    /** Ring overlay while recording.  Default: solid red. */
+    ParamLock& RecordStyle(LedPanel::Rgb c, LockAnim a = LockAnim::Solid)
+    {
+        record_style_ = {c, a};
+        return *this;
+    }
+
+    /** Recording animation only — the color keeps its default (red). */
+    ParamLock& RecordStyle(LockAnim a)
+    {
+        record_style_.anim = a;
+        return *this;
+    }
+
+    /** Ring overlay while playing back.  Default: blinking red. */
+    ParamLock& PlayStyle(LedPanel::Rgb c, LockAnim a = LockAnim::Blink)
+    {
+        play_style_ = {c, a};
+        return *this;
+    }
+
+    /** Playback animation only — the color keeps its default (red). */
+    ParamLock& PlayStyle(LockAnim a)
+    {
+        play_style_.anim = a;
+        return *this;
+    }
 
     /* ── Configuration ───────────────────────────────────────────────
      * Compile-time constants — print at boot or static_assert against. */
@@ -286,9 +378,54 @@ class ParamLock : public Serializable, public LockSource
     /** True if any slot on the visible page is active. */
     bool AnyActive() const;
 
+    /** Loop phase 0..1 of pot @p pot on the visible page: the play head
+     *  while active, the write position while recording (buffer use).
+     *  0 when the slot is idle.  For custom ring renders. */
+    float PlayPhase(uint8_t pot) const;
+
+    /** PlayPhase for an arbitrary (page, pot) slot. */
+    float PlayPhaseAtPage(uint8_t page, uint8_t pot) const;
+
+    /** Reset one slot on the visible page (see ClearSlotAtPage). */
+    void ClearSlot(uint8_t pot);
+
+    /** Reset one (page, pot) slot to inactive.  For app plumbing —
+     *  buttons, host commands. */
+    void ClearSlotAtPage(uint8_t page, uint8_t pot);
+
+    /** Hold every play head in place; false resumes where they held.
+     *  Recording is unaffected. */
+    void Freeze(bool on) { mgr_.SetFrozen(on); }
+    bool Frozen() const  { return mgr_.Frozen(); }
+
+    /* ── Sync/exit modes (LockSource; pushed by Settings::UseLocks) ─── */
+
+    void    SetSyncMode(uint8_t mode) override
+    {
+        mgr_.SetSyncMode(mode ? LockSync::Clocked : LockSync::Free);
+    }
+    uint8_t SyncMode() const override
+    {
+        return static_cast<uint8_t>(mgr_.SyncMode());
+    }
+    bool    HasClock() const override { return mgr_.HasClock(); }
+
+    void    SetExitMode(uint8_t mode) override
+    {
+        assert(!mode || pager_ != nullptr);
+        exit_mode_ = mode ? LockExit::Return : LockExit::Latch;
+    }
+    uint8_t ExitMode() const override
+    {
+        return static_cast<uint8_t>(exit_mode_);
+    }
+    bool    CanReturn() const override { return pager_ != nullptr; }
+
     /**
-     * Optional default overlay: marks rings whose lock is active/recording with
-     * a colored pip at 6 o'clock.  Recording = red, active = green.
+     * Optional default overlay: marks rings whose lock is recording or
+     * playing with a pip at 6 o'clock, styled by RecordStyle()/PlayStyle()
+     * (default: solid red recording, blinking red playback).  Sweep-style
+     * pips orbit the ring with the play head instead.
      */
     void Render(LedPanel& panel, uint32_t t_ms) const override;
 
@@ -366,6 +503,9 @@ class ParamLock : public Serializable, public LockSource
     bool             prev_pressed_    = false;
     bool             rising_pending_  = false;
     bool             falling_pending_ = false;
+    LockExit         exit_mode_       = LockExit::Latch;
+    LockStyle        record_style_    = {{0xFF, 0x00, 0x00}, LockAnim::Solid};
+    LockStyle        play_style_      = {{0xFF, 0x00, 0x00}, LockAnim::Blink};
     /* Slot bank latched at the trigger's press edge. */
     uint8_t          held_offset_     = 0;
     ParamLockSlot    slots_[kSlots] = {};

--- a/framework/include/alchemy/surface/param_lock.h
+++ b/framework/include/alchemy/surface/param_lock.h
@@ -398,6 +398,19 @@ class ParamLock : public Serializable, public LockSource
     void Freeze(bool on) { mgr_.SetFrozen(on); }
     bool Frozen() const  { return mgr_.Frozen(); }
 
+    /** One-shot: true exactly once per clean trigger release — one whose
+     *  hold armed or cleared nothing and wasn't poisoned by a gate.  The
+     *  tap-derivation hook (e.g. a mode cycle on the lock button); poll
+     *  it from OnFrame, after Update() has classified the release. */
+    bool TakeCleanRelease()
+    {
+        if (!release_pending_) return false;
+        release_pending_ = false;
+        const bool clean = !release_consumed_;
+        release_consumed_ = false;
+        return clean;
+    }
+
     /* ── Sync/exit modes (LockSource; pushed by Settings::UseLocks) ─── */
 
     void    SetSyncMode(uint8_t mode) override
@@ -503,6 +516,9 @@ class ParamLock : public Serializable, public LockSource
     bool             prev_pressed_    = false;
     bool             rising_pending_  = false;
     bool             falling_pending_ = false;
+    bool             release_poisoned_ = false;
+    bool             release_pending_  = false;
+    bool             release_consumed_ = false;
     LockExit         exit_mode_       = LockExit::Latch;
     LockStyle        record_style_    = {{0xFF, 0x00, 0x00}, LockAnim::Solid};
     LockStyle        play_style_      = {{0xFF, 0x00, 0x00}, LockAnim::Blink};

--- a/framework/include/alchemy/surface/param_lock_impl.h
+++ b/framework/include/alchemy/surface/param_lock_impl.h
@@ -45,7 +45,14 @@ void ParamLock<kSlots, Len>::PollButtons(uint32_t /*t_ms*/, bool gated)
     const bool falling = !pressed && prev_pressed_;
     prev_pressed_ = pressed;
     if (rising && !gated) rising_pending_ = true;
-    if (falling) falling_pending_ = true;
+    if (falling)
+    {
+        /* A release is never dropped — the manager must see OnButtonUp
+         * so a gated release can't dangle the hold — but one landing
+         * under the gate is poisoned: no tap derives from it. */
+        falling_pending_ = true;
+        if (gated) release_poisoned_ = true;
+    }
 }
 
 template<uint8_t kSlots, class Len>
@@ -68,10 +75,20 @@ void ParamLock<kSlots, Len>::Update(const float* phys, uint32_t /*t_ms*/)
     if (falling_pending_)
     {
         falling_pending_ = false;
+        const bool was_held = mgr_.IsButtonHeld();
         const bool consumed = mgr_.OnButtonUp();
         if (pager_) pager_->ReleasePage();
         if (consumed && pager_ && pager_->ConsumesRelease(trigger_))
             pager_->ConsumeButton();
+
+        /* Classify for TakeCleanRelease: a tap candidate is a release
+         * the manager saw as a hold, unpoisoned, with no gesture. */
+        if (was_held && !release_poisoned_)
+        {
+            release_pending_  = true;
+            release_consumed_ = consumed;
+        }
+        release_poisoned_ = false;
 
         /* Return exit: every slot THIS hold armed snaps its base back to
          * the gesture origin and re-arms pot catch.  Cleared slots ended

--- a/framework/include/alchemy/surface/param_lock_impl.h
+++ b/framework/include/alchemy/surface/param_lock_impl.h
@@ -18,7 +18,7 @@ void ParamLock<kSlots, Len>::Save(uint8_t* out) const
     /* An inert surface (external arena refused) still owes the caller a
      * full, well-formed image: SerializedSize() promised kSavedBytes, and
      * the manager — which has no stride to work from — would write only
-     * the 5-byte headers, leaving the caller's buffer uninitialised in
+     * the 7-byte headers, leaving the caller's buffer uninitialised in
      * the gaps and putting stack residue into a preset slot. */
     if (!mgr_.IsReady())
     {
@@ -73,6 +73,27 @@ void ParamLock<kSlots, Len>::Update(const float* phys, uint32_t /*t_ms*/)
         if (pager_) pager_->ReleasePage();
         if (consumed && pager_ && pager_->ConsumesRelease(trigger_))
             pager_->ConsumeButton();
+
+        /* Return exit: every slot THIS hold armed snaps its base back to
+         * the gesture origin and re-arms pot catch.  Cleared slots ended
+         * inactive, so ActionTaken ∧ IsActive excludes them.  Resolves
+         * against the press-edge bank, so a mid-hold page change cannot
+         * retarget the snap. */
+        if (consumed && exit_mode_ == LockExit::Return && pager_)
+        {
+            const uint8_t off = held_offset_;
+            const uint8_t w   = Width();
+            const uint8_t pg  = static_cast<uint8_t>(off / w);
+            for (uint8_t i = 0; i < w; i++)
+            {
+                const uint8_t idx = static_cast<uint8_t>(off + i);
+                if (idx >= kSlots) break;
+                if (mgr_.ActionTaken(i) && mgr_.IsActive(idx))
+                    pager_->SetStored(pg, i,
+                                      LockDequant(slots_[idx].record_base),
+                                      phys);
+            }
+        }
     }
 
     if (mgr_.IsButtonHeld())
@@ -142,19 +163,56 @@ bool ParamLock<kSlots, Len>::AnyActive() const
 }
 
 template<uint8_t kSlots, class Len>
-void ParamLock<kSlots, Len>::Render(LedPanel& panel, uint32_t /*t_ms*/) const
+float ParamLock<kSlots, Len>::PlayPhaseAtPage(uint8_t page, uint8_t pot) const
+{
+    const uint8_t idx = static_cast<uint8_t>(page * Width() + pot);
+    if (idx >= kSlots) return 0.0f;
+    if (mgr_.IsRecording(idx))
+        return static_cast<float>(slots_[idx].length)
+             / static_cast<float>(kFramesPerSlot);
+    return mgr_.Phase(idx);
+}
+
+template<uint8_t kSlots, class Len>
+float ParamLock<kSlots, Len>::PlayPhase(uint8_t pot) const
+{
+    return PlayPhaseAtPage(pager_ ? pager_->Page() : 0u, pot);
+}
+
+template<uint8_t kSlots, class Len>
+void ParamLock<kSlots, Len>::ClearSlot(uint8_t pot)
+{
+    mgr_.ClearSlot(static_cast<uint8_t>(Offset() + pot));
+}
+
+template<uint8_t kSlots, class Len>
+void ParamLock<kSlots, Len>::ClearSlotAtPage(uint8_t page, uint8_t pot)
+{
+    mgr_.ClearSlot(static_cast<uint8_t>(page * Width() + pot));
+}
+
+template<uint8_t kSlots, class Len>
+void ParamLock<kSlots, Len>::Render(LedPanel& panel, uint32_t t_ms) const
 {
     const uint8_t off = Offset();
     const uint8_t w   = Width();
     for (uint8_t i = 0; i < w; i++)
     {
-        const uint8_t idx = static_cast<uint8_t>(off + i);
-        const LedPanel::Rgb red   = {0xFF, 0x00, 0x00};
-        const LedPanel::Rgb green = {0x00, 0xFF, 0x40};
-        if (mgr_.IsRecording(idx))
-            panel.SetRingByHour(i, 6.0f, red);
-        else if (mgr_.IsActive(idx))
-            panel.SetRingByHour(i, 6.0f, green);
+        const uint8_t idx       = static_cast<uint8_t>(off + i);
+        const bool    recording = mgr_.IsRecording(idx);
+        if (!recording && !mgr_.IsActive(idx))
+            continue;
+
+        const LockStyle&    st = recording ? record_style_ : play_style_;
+        const LockAnimFrame f  =
+            LockAnimEval(st.anim, t_ms, PlayPhase(i), recording);
+        if (f.level <= 0.0f)
+            continue;
+
+        /* Sweep orbits clockwise from the 6-o'clock home pip. */
+        float hour = f.sweep ? 6.0f + f.sweep_pos01 * 12.0f : 6.0f;
+        if (hour >= 12.0f) hour -= 12.0f;
+        panel.SetRingByHour(i, hour, LedPanel::Scale(st.color, f.level));
     }
 }
 

--- a/framework/include/alchemy/surface/param_lock_impl.h
+++ b/framework/include/alchemy/surface/param_lock_impl.h
@@ -44,8 +44,7 @@ void ParamLock<kSlots, Len>::PollButtons(uint32_t /*t_ms*/, bool gated)
     const bool rising  = pressed && !prev_pressed_;
     const bool falling = !pressed && prev_pressed_;
     prev_pressed_ = pressed;
-    if (gated) return;
-    if (rising)  rising_pending_  = true;
+    if (rising && !gated) rising_pending_ = true;
     if (falling) falling_pending_ = true;
 }
 

--- a/framework/include/alchemy/surface/settings.h
+++ b/framework/include/alchemy/surface/settings.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <cstdint>
-#include "alchemy/control/lock_types.h"      /* LockSync */
+#include "alchemy/control/lock_types.h"      /* LockSync, LockExit */
 #include "alchemy/control/pot_catch.h"
 #include "alchemy/hw/alchemy_lab_layout.h"   /* kNumPots */
 #include "alchemy/hw/i_button.h"
@@ -88,51 +88,55 @@ class Settings : public Serializable
      */
     PresetGestureUi& UsePresets(Presets& store);
 
-    /** Handle returned by UseLocks — a two-zone selector bound to a
-     *  LockSource's sync mode.  `.At(page, pot)` relocates it. */
+    /** Handle returned by UseLocks — two two-zone selectors bound to a
+     *  LockSource: sync mode and exit policy.  `.At(page, pot)` /
+     *  `.ExitAt(page, pot)` relocate them. */
     class LocksHandle
     {
       public:
         LocksHandle() = default;
-        LocksHandle(Settings* owner, uint8_t page, uint8_t pot)
-            : owner_(owner), page_(page), pot_(pot) {}
+        LocksHandle(Settings* owner, uint8_t page, uint8_t pot,
+                    uint8_t exit_page, uint8_t exit_pot)
+            : owner_(owner), page_(page), pot_(pot),
+              exit_page_(exit_page), exit_pot_(exit_pot) {}
 
-        /** Move the control to another (page, pot). */
+        /** Move the sync-mode control to another (page, pot). */
         LocksHandle& At(uint8_t page, uint8_t pot);
 
-        /** Boot-time mode before any preset loads (default Free). */
+        /** Boot-time sync mode before any preset loads (default Free). */
         LocksHandle& Default(LockSync m);
 
-        /** Zone palette override: 2 colors, {Free, Clocked}. */
+        /** Sync-zone palette override: 2 colors, {Free, Clocked}. */
         LocksHandle& Colors(const LedPanel::Rgb* palette);
 
-        /* Identity + prose (see SettingsSlot). */
+        /* Identity + prose for the sync control (see SettingsSlot). */
         LocksHandle& Ident(const char* id);
         LocksHandle& Name (const char* n);
         LocksHandle& Help (const char* md);
 
-        /** Currently selected mode. */
+        /** Currently selected sync mode. */
         LockSync Value() const;
+
+        /** Move the exit-policy control to another (page, pot). */
+        LocksHandle& ExitAt(uint8_t page, uint8_t pot);
+
+        /** Boot-time exit policy before any preset loads (default Return). */
+        LocksHandle& DefaultExit(LockExit m);
+
+        /** Currently selected exit policy. */
+        LockExit ExitValue() const;
 
       private:
         SettingsSlot* Slot() const;
+        SettingsSlot* ExitSlot() const;
 
-        Settings* owner_ = nullptr;
-        uint8_t   page_  = 0;
-        uint8_t   pot_   = 0;
+        Settings* owner_     = nullptr;
+        uint8_t   page_      = 0;
+        uint8_t   pot_       = 0;
+        uint8_t   exit_page_ = 0;
+        uint8_t   exit_pot_  = 0;
     };
 
-    /**
-     * Param-lock mode control: a persisted Free / Clocked selector bound
-     * to @p locks (any LockSource — normally a ParamLock).  Defaults to
-     * (page=0, pot=1): P1 brightness, P2 lock mode, P3–P4 presets.
-     * Persisted like brightness and pushed into the lock via
-     * LockSource::SetSyncMode() whenever it changes or loads; the mode
-     * applies to NEW recordings only.
-     *
-     * Call after locks.UseClock(...): offering "Clocked" on a module
-     * with no clock wired is asserted against in debug builds.
-     */
     LocksHandle UseLocks(LockSource& locks);
 
     /* ── Declarative custom controls ─────────────────────────────── */

--- a/framework/include/alchemy/surface/settings.h
+++ b/framework/include/alchemy/surface/settings.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstdint>
+#include "alchemy/control/lock_types.h"      /* LockSync */
 #include "alchemy/control/pot_catch.h"
 #include "alchemy/hw/alchemy_lab_layout.h"   /* kNumPots */
 #include "alchemy/hw/i_button.h"
@@ -27,6 +28,8 @@
 #include "alchemy/surface/settings_control.h"
 
 namespace alchemy {
+
+class LockSource;
 
 #if defined(ALCHEMY_BOARD_V2)
 class AlchemyLabV2;
@@ -84,6 +87,53 @@ class Settings : public Serializable
      * @p store .Save() / .Load() directly.
      */
     PresetGestureUi& UsePresets(Presets& store);
+
+    /** Handle returned by UseLocks — a two-zone selector bound to a
+     *  LockSource's sync mode.  `.At(page, pot)` relocates it. */
+    class LocksHandle
+    {
+      public:
+        LocksHandle() = default;
+        LocksHandle(Settings* owner, uint8_t page, uint8_t pot)
+            : owner_(owner), page_(page), pot_(pot) {}
+
+        /** Move the control to another (page, pot). */
+        LocksHandle& At(uint8_t page, uint8_t pot);
+
+        /** Boot-time mode before any preset loads (default Free). */
+        LocksHandle& Default(LockSync m);
+
+        /** Zone palette override: 2 colors, {Free, Clocked}. */
+        LocksHandle& Colors(const LedPanel::Rgb* palette);
+
+        /* Identity + prose (see SettingsSlot). */
+        LocksHandle& Ident(const char* id);
+        LocksHandle& Name (const char* n);
+        LocksHandle& Help (const char* md);
+
+        /** Currently selected mode. */
+        LockSync Value() const;
+
+      private:
+        SettingsSlot* Slot() const;
+
+        Settings* owner_ = nullptr;
+        uint8_t   page_  = 0;
+        uint8_t   pot_   = 0;
+    };
+
+    /**
+     * Param-lock mode control: a persisted Free / Clocked selector bound
+     * to @p locks (any LockSource — normally a ParamLock).  Defaults to
+     * (page=0, pot=1): P1 brightness, P2 lock mode, P3–P4 presets.
+     * Persisted like brightness and pushed into the lock via
+     * LockSource::SetSyncMode() whenever it changes or loads; the mode
+     * applies to NEW recordings only.
+     *
+     * Call after locks.UseClock(...): offering "Clocked" on a module
+     * with no clock wired is asserted against in debug builds.
+     */
+    LocksHandle UseLocks(LockSource& locks);
 
     /* ── Declarative custom controls ─────────────────────────────── */
 
@@ -254,6 +304,13 @@ class Settings : public Serializable
 
   private:
     friend class PotBuilder;
+    friend class BrightnessHandle;   /* At() relocation */
+
+    /** Move a slot's whole configuration to another (page, pot),
+     *  clearing the source.  Shared by every handle's At().  Returns the
+     *  destination slot, or nullptr for out-of-range coordinates. */
+    SettingsSlot* RelocateSlot(uint8_t from_page, uint8_t from_pot,
+                               uint8_t to_page,   uint8_t to_pot);
 
     const SettingsSlot* SlotAt(uint8_t page, uint8_t pot) const
     {

--- a/framework/include/alchemy/surface/settings_control.h
+++ b/framework/include/alchemy/surface/settings_control.h
@@ -32,7 +32,9 @@
 
 namespace alchemy {
 
+class LockSource;
 class PresetGestureUi;
+class Settings;
 struct SettingsSlot;
 
 /* ── Per-slot kind enum ────────────────────────────────────────────── */
@@ -91,6 +93,10 @@ struct SettingsSlot
     /* Preset gesture binding — both halves point at the same UI. */
     PresetGestureUi* preset_gesture = nullptr;
 
+    /* Lock-mode binding (Settings::UseLocks): the resolved zone index is
+     * pushed via SetSyncMode() on change and on Deserialize. */
+    LockSource* lock_src = nullptr;
+
     /* Custom. */
     SettingsTickFn   custom_tick   = nullptr;
     SettingsRenderFn custom_render = nullptr;
@@ -123,6 +129,14 @@ class BrightnessHandle
   public:
     BrightnessHandle() = default;
     explicit BrightnessHandle(SettingsSlot* s) : s_(s) {}
+    BrightnessHandle(Settings* owner, SettingsSlot* s,
+                     uint8_t page, uint8_t pot)
+        : s_(s), owner_(owner), page_(page), pot_(pot) {}
+
+    /** Move the control to another (page, pot).  Handles returned by
+     *  Settings know their owner and relocate; a default-constructed or
+     *  slot-only handle no-ops.  Defined in settings.cpp. */
+    BrightnessHandle& At(uint8_t page, uint8_t pot);
 
     BrightnessHandle& Range(float lo, float hi)
     { if (!s_) return *this; s_->range_lo = lo; s_->range_hi = hi; return *this; }
@@ -168,7 +182,10 @@ class BrightnessHandle
         return (t < 0.0f) ? 0.0f : (t > 1.0f ? 1.0f : t);
     }
 
-    SettingsSlot* s_ = nullptr;
+    SettingsSlot* s_     = nullptr;
+    Settings*     owner_ = nullptr;
+    uint8_t       page_  = 0;
+    uint8_t       pot_   = 0;
 };
 
 class KnobHandle

--- a/framework/include/alchemy/surface/settings_control.h
+++ b/framework/include/alchemy/surface/settings_control.h
@@ -93,9 +93,11 @@ struct SettingsSlot
     /* Preset gesture binding — both halves point at the same UI. */
     PresetGestureUi* preset_gesture = nullptr;
 
-    /* Lock-mode binding (Settings::UseLocks): the resolved zone index is
-     * pushed via SetSyncMode() on change and on Deserialize. */
-    LockSource* lock_src = nullptr;
+    /* Lock bindings (Settings::UseLocks): the resolved selection is
+     * pushed on change and on Deserialize — the zone index via
+     * SetSyncMode(), the mapped LockExit via SetExitMode(). */
+    LockSource* lock_src      = nullptr;
+    LockSource* lock_exit_src = nullptr;
 
     /* Custom. */
     SettingsTickFn   custom_tick   = nullptr;

--- a/framework/src/control/param_lock_manager.cpp
+++ b/framework/src/control/param_lock_manager.cpp
@@ -6,6 +6,9 @@
 
 #include <cstring>
 
+#include "alchemy/control/lock_snap.h"
+#include "alchemy/control/musical_clock.h"
+
 namespace alchemy {
 
 /* ── Lifecycle ────────────────────────────────────────────────────────── */
@@ -30,12 +33,13 @@ void ParamLockManager::Init(const LockConfig& cfg)
     gesture_width_ = cfg.gesture_width < kParamLockMaxGestureWidth
                          ? cfg.gesture_width
                          : kParamLockMaxGestureWidth;
-    rate_hz_           = cfg.rate_hz;
-    gesture_threshold_ = cfg.gesture_threshold;
-    step_q16_          = LockStepQ16(cfg.rate_hz, cfg.frame_ms);
-    rec_phase_q16_     = 0u;
-    button_held_       = false;
-    consumed_          = false;
+    rate_hz_          = cfg.rate_hz;
+    arm_threshold_    = cfg.arm_threshold;
+    clear_threshold_  = cfg.clear_threshold;
+    step_q16_         = LockStepQ16(cfg.rate_hz, cfg.frame_ms);
+    rec_phase_q16_    = 0u;
+    button_held_      = false;
+    consumed_         = false;
 
     for (uint8_t i = 0; i < gesture_width_; i++)
     {
@@ -47,6 +51,12 @@ void ParamLockManager::Init(const LockConfig& cfg)
 void ParamLockManager::SetFrameMs(uint32_t frame_ms)
 {
     step_q16_ = LockStepQ16(rate_hz_, frame_ms);
+}
+
+double ParamLockManager::NowTicks() const
+{
+    if (clock_ == nullptr) return 0.0;
+    return static_cast<double>(clock_->MasterTick()) + clock_->FracTick();
 }
 
 /* ── Gesture ──────────────────────────────────────────────────────────── */
@@ -94,24 +104,33 @@ void ParamLockManager::ProcessGestures(uint8_t offset, const float phys[])
         ParamLockSlot& lk    = slots_[idx];
         const float    diff  = phys[i] - baseline_[i];
         const float    delta = diff > 0.0f ? diff : -diff;
-        const bool     nudged = (delta >= gesture_threshold_);
+
+        const bool nudged = lk.active ? (delta >= clear_threshold_)
+                                      : (delta >= arm_threshold_);
 
         if (nudged && !lk.recording && !action_taken_[i])
         {
             action_taken_[i] = true;
             consumed_        = true;
-            baseline_[i]     = phys[i];
 
             if (lk.active)
             {
-                lk = ParamLockSlot{};
+                ClearSlot(idx);
             }
             else
             {
                 lk = ParamLockSlot{};
                 lk.recording   = true;
-                lk.record_base = LockQuant(phys[i]);
+                /* Pre-nudge baseline, not the trip point: the loop's
+                 * reference and a Return exit land on the gesture's
+                 * true origin. */
+                lk.record_base = LockQuant(baseline_[i]);
+                /* The take's duration is measured against the clock —
+                 * never sample count ÷ rate; the control loop's frame_ms
+                 * is nominal, not real. */
+                lk.anchor_tick = NowTicks();
             }
+            baseline_[i] = phys[i];
         }
 
         if (!lk.recording)
@@ -147,12 +166,33 @@ void ParamLockManager::EmitSample(ParamLockSlot& lk, uint16_t* buf)
 
     if (lk.length >= stride_)
     {
-        /* Buffer full: loop what was captured rather than drop the tail.
-         * `active` publishes last — the ISR-side Read() gates on it. */
-        lk.recording = false;
-        lk.play_pos  = 0u;
-        lk.active    = true;
+        /* Buffer full: loop what was captured rather than drop the tail. */
+        ActivateSlot(lk);
     }
+}
+
+void ParamLockManager::ActivateSlot(ParamLockSlot& lk)
+{
+    lk.recording = false;
+    lk.play_pos  = 0u;
+    lk.rec_accum = 0.0f;
+    lk.rec_count = 0u;
+
+    lk.musical_ticks = 0u;
+    if (sync_mode_ == LockSync::Clocked && clock_ != nullptr
+        && clock_->Running() && lk.length > 0u)
+    {
+        const double now       = NowTicks();
+        const double rec_ticks = now - lk.anchor_tick;
+        const uint32_t snapped = LockSnapTicks(rec_ticks,
+                                               clock_->Ppqn(),
+                                               clock_->BeatsPerBar(),
+                                               grid_mask_);
+        lk.musical_ticks = static_cast<uint16_t>(snapped);
+        lk.anchor_tick = now;
+    }
+
+    lk.active = (lk.length > 0u);
 }
 
 void ParamLockManager::Finalise()
@@ -169,38 +209,106 @@ void ParamLockManager::Finalise()
         /* Flush the partial sample in flight.  Without this a gesture
          * shorter than one sample period (40 ms at 20 Hz) records
          * nothing and leaves a slot that is neither recording nor
-         * active. */
+         * active.  EmitSample may itself activate on a full buffer. */
         if (lk.rec_count && lk.length < stride_)
             EmitSample(lk, Buf(i));
 
-        /* `active` last, same reasoning as EmitSample. */
-        lk.recording = false;
-        lk.play_pos  = 0u;
-        lk.rec_accum = 0.0f;
-        lk.rec_count = 0u;
-        lk.active    = (lk.length > 0);
+        if (lk.recording)
+            ActivateSlot(lk);
     }
 }
 
 /* ── Playback ─────────────────────────────────────────────────────────── */
 
+void ParamLockManager::SetFrozen(bool on)
+{
+    if (on == frozen_)
+        return;
+
+    if (on)
+    {
+        freeze_tick_ = NowTicks();
+        frozen_      = true;
+        return;
+    }
+
+    /* Resume: slide every clocked anchor forward by the frozen span so
+     * playback continues from where it held, instead of jumping to where
+     * the clock got to meanwhile. */
+    const double now = NowTicks();
+    const double gap = now - freeze_tick_;
+    if (IsReady() && gap > 0.0)
+    {
+        for (uint8_t i = 0; i < total_slots_; i++)
+        {
+            ParamLockSlot& lk = slots_[i];
+            if (!lk.active || lk.musical_ticks == 0u)
+                continue;
+            lk.anchor_tick += gap;
+            if (lk.anchor_tick > now)
+                lk.anchor_tick = now;   /* slot activated mid-freeze */
+        }
+    }
+    frozen_ = false;
+}
+
 void ParamLockManager::Advance()
 {
-    if (!IsReady()) return;
+    if (!IsReady() || frozen_) return;
+
+    const double now     = NowTicks();
+    const bool   clk_run = (clock_ != nullptr) && clock_->Running();
 
     for (uint8_t i = 0; i < total_slots_; i++)
     {
         ParamLockSlot& lk = slots_[i];
         if (!lk.active || lk.length == 0) continue;
 
-        /* Compute the whole new position, then publish it as ONE aligned
-         * 32-bit store.  The audio ISR reads play_pos between any two of
-         * these statements. */
-        uint32_t pos  = lk.play_pos + step_q16_;
-        uint32_t head = pos >> 16;
-        if (head >= lk.length)
-            head %= lk.length;
-        lk.play_pos = (head << 16) | (pos & 0xFFFFu);
+        uint32_t pos;
+        if (lk.musical_ticks > 0u && clock_ != nullptr)
+        {
+            /* Clocked: the head still advances by the wall-clock step —
+             * the motion is never resampled.  The clock supplies only
+             * the restart, by exact span multiples of the anchor, so
+             * nothing drifts: a take longer than the span trims at the
+             * seam, a shorter one holds its final sample. */
+            if (!clk_run)
+                continue;                     /* transport stopped: hold */
+            if (now < lk.anchor_tick)
+                lk.anchor_tick = now;         /* clock Reset() guard */
+
+            const double span    = static_cast<double>(lk.musical_ticks);
+            const double elapsed = now - lk.anchor_tick;
+            if (elapsed >= span)
+            {
+                lk.anchor_tick += span
+                    * static_cast<double>(
+                        static_cast<uint64_t>(elapsed / span));
+                pos = 0u;                     /* restart on the grid */
+            }
+            else
+            {
+                const uint32_t cap =
+                    static_cast<uint32_t>(lk.length - 1u) << 16;
+                pos = lk.play_pos + step_q16_;
+                if (pos > cap || pos < lk.play_pos)
+                    pos = cap;                /* hold the final sample */
+            }
+        }
+        else
+        {
+            /* Free-running — and the fallback for a clocked slot
+             * restored into a build with no clock wired. */
+            pos = lk.play_pos + step_q16_;
+            uint32_t head = pos >> 16;
+            if (head >= lk.length)
+                head %= lk.length;
+            pos = (head << 16) | (pos & 0xFFFFu);
+        }
+
+        /* Publish as ONE aligned 32-bit store.  The audio ISR reads
+         * play_pos between any two of these statements. */
+        lk.play_pos = pos;
     }
 }
 
@@ -234,6 +342,29 @@ float ParamLockManager::Read(uint8_t index) const
     return SampleAt(lk, Buf(index)) - LockDequant(lk.record_base);
 }
 
+float ParamLockManager::Phase(uint8_t index) const
+{
+    if (!IsReady() || index >= total_slots_) return 0.0f;
+
+    const ParamLockSlot& lk = slots_[index];
+    if (!lk.active || lk.length == 0) return 0.0f;
+
+    if (lk.musical_ticks > 0u && clock_ != nullptr)
+    {
+        const double span = static_cast<double>(lk.musical_ticks);
+        const double ref  = frozen_ ? freeze_tick_ : NowTicks();
+        double e = ref - lk.anchor_tick;
+        if (e < 0.0) e = 0.0;
+        double ph = e / span;
+        ph -= static_cast<double>(static_cast<uint64_t>(ph));
+        return static_cast<float>(ph);
+    }
+
+    const uint32_t pos = lk.play_pos;
+    return static_cast<float>(pos)
+         / static_cast<float>(static_cast<uint32_t>(lk.length) << 16);
+}
+
 bool ParamLockManager::IsActive(uint8_t index) const
 {
     return IsReady() && index < total_slots_ && slots_[index].active;
@@ -256,7 +387,7 @@ void ParamLockManager::CaptureSlot(uint8_t index, uint8_t* out) const
                     && slots_[index].active
                     && slots_[index].length > 0;
 
-    ParamLockSavedHeader h = {0u, 0u, 0u};
+    ParamLockSavedHeader h = {0u, 0u, 0u, 0u};
 
     if (!valid)
     {
@@ -266,9 +397,10 @@ void ParamLockManager::CaptureSlot(uint8_t index, uint8_t* out) const
     }
 
     const ParamLockSlot& lk = slots_[index];
-    h.active      = 1u;
-    h.length      = lk.length;
-    h.record_base = lk.record_base;
+    h.active        = 1u;
+    h.length        = lk.length;
+    h.record_base   = lk.record_base;
+    h.musical_ticks = lk.musical_ticks;
     std::memcpy(out, &h, sizeof h);
 
     const size_t used = static_cast<size_t>(lk.length) * sizeof(uint16_t);
@@ -282,7 +414,7 @@ void ParamLockManager::RestoreSlot(uint8_t index, const uint8_t* in)
         return;
 
     ParamLockSlot& lk = slots_[index];
-    lk = ParamLockSlot{};   /* active=false while we rebuild below */
+    ClearSlot(index);       /* active drops first; rebuild below */
 
     ParamLockSavedHeader h;
     std::memcpy(&h, in, sizeof h);
@@ -293,9 +425,12 @@ void ParamLockManager::RestoreSlot(uint8_t index, const uint8_t* in)
     std::memcpy(Buf(index), in + sizeof h,
                 static_cast<size_t>(h.length) * sizeof(uint16_t));
 
-    lk.length      = h.length;
-    lk.record_base = h.record_base;
-    lk.active      = true;
+    lk.length        = h.length;
+    lk.record_base   = h.record_base;
+    lk.musical_ticks = h.musical_ticks;
+    /* anchor_tick stays 0: restored clocked slots all measure phase from
+     * the master origin, so same-length loops come back mutually aligned. */
+    lk.active        = true;
 }
 
 void ParamLockManager::Clear()
@@ -303,7 +438,25 @@ void ParamLockManager::Clear()
     if (!IsReady())
         return;
     for (uint8_t i = 0; i < total_slots_; i++)
-        slots_[i] = ParamLockSlot{};
+        ClearSlot(i);
+}
+
+void ParamLockManager::ClearSlot(uint8_t index)
+{
+    if (!IsReady() || index >= total_slots_)
+        return;
+    /* Member-by-member, `active` first: Read() in the audio ISR gates on
+     * it, and a whole-struct assignment gives no ordering to point at. */
+    ParamLockSlot& lk = slots_[index];
+    lk.active        = false;
+    lk.recording     = false;
+    lk.length        = 0u;
+    lk.play_pos      = 0u;
+    lk.record_base   = 0u;
+    lk.musical_ticks = 0u;
+    lk.rec_accum     = 0.0f;
+    lk.rec_count     = 0u;
+    lk.anchor_tick   = 0.0;
 }
 
 void ParamLockManager::ClearArena()

--- a/framework/src/surface/settings.cpp
+++ b/framework/src/surface/settings.cpp
@@ -85,36 +85,52 @@ BrightnessHandle& BrightnessHandle::At(uint8_t page, uint8_t pot)
     return *this;
 }
 
-/* UseLocks defaults: P2, grey Free / orange Clocked, hostlink identity. */
+/* UseLocks defaults: P5 sync / P6 exit, grey/amber zones, hostlink
+ * identity. */
 namespace {
 
-constexpr uint8_t kLockModeDefaultPot = 1u;
+constexpr uint8_t kLockModeDefaultPot = 4u;
+constexpr uint8_t kLockExitDefaultPot = 5u;
 
-const LedPanel::Rgb kLockModeZoneColors[2] = {
-    {0x60, 0x60, 0x60},   /* Free    — neutral grey   */
-    {0xFF, 0x50, 0x00},   /* Clocked — settings amber */
+const LedPanel::Rgb kLockZoneColors[2] = {
+    {0x60, 0x60, 0x60},   /* zone 0 (default) — neutral grey   */
+    {0xFF, 0x50, 0x00},   /* zone 1           — settings amber */
 };
 
 const char* const kLockModeLabels[2] = {"Free", "Clocked"};
+const char* const kLockExitLabels[2] = {"Return", "Latch"};
+
+/* Exit zones render Return-first; LockExit is Latch = 0. */
+uint8_t ExitModeFromZone(uint8_t zone)
+{
+    return static_cast<uint8_t>(zone == 0u ? LockExit::Return
+                                           : LockExit::Latch);
+}
+
+uint8_t ZoneFromExitMode(LockExit m)
+{
+    return (m == LockExit::Return) ? 0u : 1u;
+}
 
 }  // namespace
 
 Settings::LocksHandle Settings::UseLocks(LockSource& locks)
 {
-    /* A Clocked option on a module with no clock wired would be a lie —
-     * call locks.UseClock(...) first. */
+    /* Options the module cannot honor would be lies: call
+     * locks.UseClock(...) first, and Return needs the paged form. */
     assert(locks.HasClock());
+    assert(locks.CanReturn());
 
     EnsurePage(0u);
     SettingsSlot& s = slots_[0][kLockModeDefaultPot];
-    assert(s.kind == SettingsKind::None);   /* P2 already taken */
+    assert(s.kind == SettingsKind::None);   /* P5 already taken */
     s              = SettingsSlot{};
     s.kind         = SettingsKind::Selector;
     s.num_zones    = 2u;
     s.value_idx    = locks.SyncMode() ? 1u : 0u;
     s.pot.stored   = (static_cast<float>(s.value_idx) + 0.5f) / 2.0f;
     s.pot.caught   = true;
-    s.zone_colors  = kLockModeZoneColors;
+    s.zone_colors  = kLockZoneColors;
     s.labels       = kLockModeLabels;
     s.num_labels   = 2u;
     s.ident        = "lock_mode";
@@ -122,7 +138,26 @@ Settings::LocksHandle Settings::UseLocks(LockSource& locks)
     s.help         = stock_help::kLockMode;
     s.lock_src     = &locks;
     locks.SetSyncMode(s.value_idx);
-    return LocksHandle(this, 0u, kLockModeDefaultPot);
+
+    SettingsSlot& e = slots_[0][kLockExitDefaultPot];
+    assert(e.kind == SettingsKind::None);   /* P6 already taken */
+    e               = SettingsSlot{};
+    e.kind          = SettingsKind::Selector;
+    e.num_zones     = 2u;
+    e.value_idx     = ZoneFromExitMode(LockExit::Return);
+    e.pot.stored    = (static_cast<float>(e.value_idx) + 0.5f) / 2.0f;
+    e.pot.caught    = true;
+    e.zone_colors   = kLockZoneColors;
+    e.labels        = kLockExitLabels;
+    e.num_labels    = 2u;
+    e.ident         = "lock_exit";
+    e.display_name  = "Lock Exit";
+    e.help          = stock_help::kLockExit;
+    e.lock_exit_src = &locks;
+    locks.SetExitMode(ExitModeFromZone(e.value_idx));
+
+    return LocksHandle(this, 0u, kLockModeDefaultPot,
+                       0u, kLockExitDefaultPot);
 }
 
 /* ── LocksHandle ──────────────────────────────────────────────────── */
@@ -184,6 +219,42 @@ LockSync Settings::LocksHandle::Value() const
 {
     const SettingsSlot* s = Slot();
     return (s && s->value_idx) ? LockSync::Clocked : LockSync::Free;
+}
+
+SettingsSlot* Settings::LocksHandle::ExitSlot() const
+{
+    if (!owner_ || exit_page_ >= kSettingsMaxPages || exit_pot_ >= kNumPots)
+        return nullptr;
+    SettingsSlot& s = owner_->slots_[exit_page_][exit_pot_];
+    return (s.lock_exit_src != nullptr) ? &s : nullptr;
+}
+
+Settings::LocksHandle& Settings::LocksHandle::ExitAt(uint8_t page, uint8_t pot)
+{
+    if (!ExitSlot()) return *this;
+    if (owner_->RelocateSlot(exit_page_, exit_pot_, page, pot))
+    {
+        exit_page_ = page;
+        exit_pot_  = pot;
+    }
+    return *this;
+}
+
+Settings::LocksHandle& Settings::LocksHandle::DefaultExit(LockExit m)
+{
+    SettingsSlot* s = ExitSlot();
+    if (!s) return *this;
+    s->value_idx  = ZoneFromExitMode(m);
+    s->pot.stored = (static_cast<float>(s->value_idx) + 0.5f) / 2.0f;
+    s->lock_exit_src->SetExitMode(static_cast<uint8_t>(m));
+    return *this;
+}
+
+LockExit Settings::LocksHandle::ExitValue() const
+{
+    const SettingsSlot* s = ExitSlot();
+    return s ? static_cast<LockExit>(ExitModeFromZone(s->value_idx))
+             : LockExit::Latch;
 }
 
 PresetGestureUi& Settings::UsePresets(Presets& store)
@@ -461,6 +532,8 @@ void Settings::Update(const float* phys, uint32_t t_ms)
                 if (idx >= static_cast<int>(s.num_zones)) idx = s.num_zones - 1;
                 s.value_idx = static_cast<uint8_t>(idx);
                 if (s.lock_src) s.lock_src->SetSyncMode(s.value_idx);
+                if (s.lock_exit_src)
+                    s.lock_exit_src->SetExitMode(ExitModeFromZone(s.value_idx));
                 break;
             }
 
@@ -717,6 +790,9 @@ bool Settings::Deserialize(const uint8_t* in)
                         s.pot.stored = (static_cast<float>(idx) + 0.5f)
                                      / static_cast<float>(s.num_zones);
                     if (s.lock_src) s.lock_src->SetSyncMode(s.value_idx);
+                    if (s.lock_exit_src)
+                        s.lock_exit_src->SetExitMode(
+                            ExitModeFromZone(s.value_idx));
                     break;
                 }
                 default:

--- a/framework/src/surface/settings.cpp
+++ b/framework/src/surface/settings.cpp
@@ -5,10 +5,13 @@
 
 #include "alchemy/surface/settings.h"
 
+#include <cassert>
 #include <cstring>
 
 #include "alchemy/hw/alchemy_lab.h"
 #include "alchemy/led/anims/catch_pip.h"
+#include "alchemy/surface/lock_source.h"
+#include "alchemy/surface/manual.h"
 #include "alchemy/surface/pager.h"
 #include "alchemy/surface/presets.h"
 
@@ -48,7 +51,139 @@ BrightnessHandle Settings::UseBrightness()
     s.pot.caught = true;
     s.color    = {0xFF, 0xC0, 0x40};
     if (hw_) ApplyBrightnessSlot(s);
-    return BrightnessHandle(&s);
+    return BrightnessHandle(this, &s, 0u, 0u);
+}
+
+/* ── Slot relocation (handles' At()) ─────────────────────────────────── */
+
+SettingsSlot* Settings::RelocateSlot(uint8_t from_page, uint8_t from_pot,
+                                     uint8_t to_page,   uint8_t to_pot)
+{
+    if (from_page >= kSettingsMaxPages || from_pot >= kNumPots
+     || to_page   >= kSettingsMaxPages || to_pot   >= kNumPots)
+        return nullptr;
+    if (from_page == to_page && from_pot == to_pot)
+        return &slots_[from_page][from_pot];
+
+    /* Relocating onto a configured slot would silently destroy it. */
+    assert(slots_[to_page][to_pot].kind == SettingsKind::None);
+
+    EnsurePage(to_page);
+    slots_[to_page][to_pot]     = slots_[from_page][from_pot];
+    slots_[from_page][from_pot] = SettingsSlot{};
+    return &slots_[to_page][to_pot];
+}
+
+BrightnessHandle& BrightnessHandle::At(uint8_t page, uint8_t pot)
+{
+    if (!owner_ || !s_) return *this;
+    SettingsSlot* moved = owner_->RelocateSlot(page_, pot_, page, pot);
+    if (!moved) return *this;
+    s_    = moved;
+    page_ = page;
+    pot_  = pot;
+    return *this;
+}
+
+/* UseLocks defaults: P2, grey Free / orange Clocked, hostlink identity. */
+namespace {
+
+constexpr uint8_t kLockModeDefaultPot = 1u;
+
+const LedPanel::Rgb kLockModeZoneColors[2] = {
+    {0x60, 0x60, 0x60},   /* Free    — neutral grey   */
+    {0xFF, 0x50, 0x00},   /* Clocked — settings amber */
+};
+
+const char* const kLockModeLabels[2] = {"Free", "Clocked"};
+
+}  // namespace
+
+Settings::LocksHandle Settings::UseLocks(LockSource& locks)
+{
+    /* A Clocked option on a module with no clock wired would be a lie —
+     * call locks.UseClock(...) first. */
+    assert(locks.HasClock());
+
+    EnsurePage(0u);
+    SettingsSlot& s = slots_[0][kLockModeDefaultPot];
+    assert(s.kind == SettingsKind::None);   /* P2 already taken */
+    s              = SettingsSlot{};
+    s.kind         = SettingsKind::Selector;
+    s.num_zones    = 2u;
+    s.value_idx    = locks.SyncMode() ? 1u : 0u;
+    s.pot.stored   = (static_cast<float>(s.value_idx) + 0.5f) / 2.0f;
+    s.pot.caught   = true;
+    s.zone_colors  = kLockModeZoneColors;
+    s.labels       = kLockModeLabels;
+    s.num_labels   = 2u;
+    s.ident        = "lock_mode";
+    s.display_name = "Lock Mode";
+    s.help         = stock_help::kLockMode;
+    s.lock_src     = &locks;
+    locks.SetSyncMode(s.value_idx);
+    return LocksHandle(this, 0u, kLockModeDefaultPot);
+}
+
+/* ── LocksHandle ──────────────────────────────────────────────────── */
+
+SettingsSlot* Settings::LocksHandle::Slot() const
+{
+    if (!owner_ || page_ >= kSettingsMaxPages || pot_ >= kNumPots)
+        return nullptr;
+    SettingsSlot& s = owner_->slots_[page_][pot_];
+    return (s.lock_src != nullptr) ? &s : nullptr;
+}
+
+Settings::LocksHandle& Settings::LocksHandle::At(uint8_t page, uint8_t pot)
+{
+    if (!Slot()) return *this;
+    if (owner_->RelocateSlot(page_, pot_, page, pot))
+    {
+        page_ = page;
+        pot_  = pot;
+    }
+    return *this;
+}
+
+Settings::LocksHandle& Settings::LocksHandle::Default(LockSync m)
+{
+    SettingsSlot* s = Slot();
+    if (!s) return *this;
+    s->value_idx  = (m == LockSync::Clocked) ? 1u : 0u;
+    s->pot.stored = (static_cast<float>(s->value_idx) + 0.5f) / 2.0f;
+    s->lock_src->SetSyncMode(s->value_idx);
+    return *this;
+}
+
+Settings::LocksHandle& Settings::LocksHandle::Colors(const LedPanel::Rgb* palette)
+{
+    if (SettingsSlot* s = Slot()) s->zone_colors = palette;
+    return *this;
+}
+
+Settings::LocksHandle& Settings::LocksHandle::Ident(const char* id)
+{
+    if (SettingsSlot* s = Slot()) s->ident = id;
+    return *this;
+}
+
+Settings::LocksHandle& Settings::LocksHandle::Name(const char* n)
+{
+    if (SettingsSlot* s = Slot()) s->display_name = n;
+    return *this;
+}
+
+Settings::LocksHandle& Settings::LocksHandle::Help(const char* md)
+{
+    if (SettingsSlot* s = Slot()) s->help = md;
+    return *this;
+}
+
+LockSync Settings::LocksHandle::Value() const
+{
+    const SettingsSlot* s = Slot();
+    return (s && s->value_idx) ? LockSync::Clocked : LockSync::Free;
 }
 
 PresetGestureUi& Settings::UsePresets(Presets& store)
@@ -91,7 +226,7 @@ BrightnessHandle Settings::PotBuilder::Brightness()
     s.pot.stored = (s.value - s.range_lo) / (s.range_hi - s.range_lo);
     s.pot.caught = true;
     if (s_.hw_) s_.ApplyBrightnessSlot(s);
-    return BrightnessHandle(&s);
+    return BrightnessHandle(&s_, &s, page_, pot_);
 }
 
 KnobHandle Settings::PotBuilder::Knob()
@@ -325,6 +460,7 @@ void Settings::Update(const float* phys, uint32_t t_ms)
                 int idx = static_cast<int>(v * static_cast<float>(s.num_zones));
                 if (idx >= static_cast<int>(s.num_zones)) idx = s.num_zones - 1;
                 s.value_idx = static_cast<uint8_t>(idx);
+                if (s.lock_src) s.lock_src->SetSyncMode(s.value_idx);
                 break;
             }
 
@@ -580,6 +716,7 @@ bool Settings::Deserialize(const uint8_t* in)
                     if (s.num_zones > 0u)
                         s.pot.stored = (static_cast<float>(idx) + 0.5f)
                                      / static_cast<float>(s.num_zones);
+                    if (s.lock_src) s.lock_src->SetSyncMode(s.value_idx);
                     break;
                 }
                 default:

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -34,6 +34,7 @@ add_executable(hostlink_tests
     "${SDK_ROOT}/framework/src/surface/preset_gesture_ui.cpp"
     "${SDK_ROOT}/framework/src/surface/virtual_knob.cpp"
     "${SDK_ROOT}/framework/src/control/param_lock_manager.cpp"
+    "${SDK_ROOT}/framework/src/control/musical_clock.cpp"
     "${SDK_ROOT}/hardware/alchemy-lab/v1/src/ws2812.cpp"
     "${SDK_ROOT}/hardware/alchemy-lab/v1/src/alchemy_lab_v1.cpp"
     "${SDK_ROOT}/hardware/alchemy-lab/v1/src/alchemy_lab_v1_layout.cpp"

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -985,6 +985,52 @@ static void TestSettingsGesturesEmission()
     (void)mode; (void)gain;
 }
 
+/* Settings::UseLocks is a plain persisted Selector, so it must surface
+ * to hosts as an ordinary editable enum field — one byte in the blob,
+ * two zones, the SDK's Free/Clocked labels. */
+static void TestSettingsUseLocksDescriptor()
+{
+    struct StubLock : LockSource
+    {
+        uint8_t mode = 0u;
+        float DeltaAtPage(uint8_t, uint8_t) const override { return 0.0f; }
+        bool  IsRecordingAtPage(uint8_t, uint8_t) const override { return false; }
+        bool  IsActiveAtPage(uint8_t, uint8_t) const override { return false; }
+        void  Update(const float*, uint32_t) override {}
+        void    SetSyncMode(uint8_t m) override { mode = m; }
+        uint8_t SyncMode() const override { return mode; }
+    };
+
+    RamFlash   flash;
+    AlchemyLab hw;
+    Settings   settings{hw};
+    Presets    presets{g_dummy_qspi};
+    StubLock   lock;
+
+    settings.UseBrightness();
+    settings.UseLocks(lock).Default(LockSync::Clocked);
+    presets.Manage(settings);
+    presets.Init(flash.Ops(), flash.Base());
+
+    static char buf[8192];
+    DescriptorBuilder db(buf, sizeof buf, presets);
+    bool ok = db.Begin({"lockmod", "Locks", "0.0.1", "gitl", "0.1.0", "v1"});
+    ok &= db.BeginSettings("settings", settings);
+    ok &= db.SettingsField(0, 0, "s.bright", "Brightness", nullptr);
+    ok &= db.SettingsField(0, 1, "s.lock_mode", "Lock Mode", nullptr);
+    ok &= db.EndSettings();
+    const uint32_t len = db.Finish();
+    CHECK(ok);
+    CHECK(len > 0u);
+    const std::string json(buf, len);
+
+    /* An enum field with the stock labels and the pushed default. */
+    CHECK(json.find("\"id\":\"s.lock_mode\"") != std::string::npos);
+    CHECK(json.find("\"labels\":[\"Free\",\"Clocked\"]") != std::string::npos);
+    CHECK(json.find("\"zones\":2") != std::string::npos);
+    CHECK_EQ(lock.mode, 1u);
+}
+
 /* ── Descriptor auto-derivation (describe.h) ───────────────────────── */
 
 static const DescriptorBuilder::ModuleInfo kAutoInfo =
@@ -2075,6 +2121,7 @@ int main(int argc, char** argv)
     TestTornWrite();
     TestDescriptorBuilder();
     TestSettingsGesturesEmission();
+    TestSettingsUseLocksDescriptor();
     TestAutoDescribe();
     TestAutoDescribeGenericAndOverrides();
     TestManualEmission();

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -985,20 +985,23 @@ static void TestSettingsGesturesEmission()
     (void)mode; (void)gain;
 }
 
-/* Settings::UseLocks is a plain persisted Selector, so it must surface
- * to hosts as an ordinary editable enum field — one byte in the blob,
- * two zones, the SDK's Free/Clocked labels. */
+/* Settings::UseLocks installs two plain persisted Selectors, so they
+ * must surface to hosts as ordinary editable enum fields — one byte
+ * each, two zones, the SDK's Free/Clocked and Return/Latch labels. */
 static void TestSettingsUseLocksDescriptor()
 {
     struct StubLock : LockSource
     {
         uint8_t mode = 0u;
+        uint8_t exit = 0u;
         float DeltaAtPage(uint8_t, uint8_t) const override { return 0.0f; }
         bool  IsRecordingAtPage(uint8_t, uint8_t) const override { return false; }
         bool  IsActiveAtPage(uint8_t, uint8_t) const override { return false; }
         void  Update(const float*, uint32_t) override {}
         void    SetSyncMode(uint8_t m) override { mode = m; }
         uint8_t SyncMode() const override { return mode; }
+        void    SetExitMode(uint8_t m) override { exit = m; }
+        uint8_t ExitMode() const override { return exit; }
     };
 
     RamFlash   flash;
@@ -1017,18 +1020,22 @@ static void TestSettingsUseLocksDescriptor()
     bool ok = db.Begin({"lockmod", "Locks", "0.0.1", "gitl", "0.1.0", "v1"});
     ok &= db.BeginSettings("settings", settings);
     ok &= db.SettingsField(0, 0, "s.bright", "Brightness", nullptr);
-    ok &= db.SettingsField(0, 1, "s.lock_mode", "Lock Mode", nullptr);
+    ok &= db.SettingsField(0, 4, "s.lock_mode", "Lock Mode", nullptr);
+    ok &= db.SettingsField(0, 5, "s.lock_exit", "Lock Exit", nullptr);
     ok &= db.EndSettings();
     const uint32_t len = db.Finish();
     CHECK(ok);
     CHECK(len > 0u);
     const std::string json(buf, len);
 
-    /* An enum field with the stock labels and the pushed default. */
+    /* Enum fields with the stock labels and the pushed defaults. */
     CHECK(json.find("\"id\":\"s.lock_mode\"") != std::string::npos);
     CHECK(json.find("\"labels\":[\"Free\",\"Clocked\"]") != std::string::npos);
+    CHECK(json.find("\"id\":\"s.lock_exit\"") != std::string::npos);
+    CHECK(json.find("\"labels\":[\"Return\",\"Latch\"]") != std::string::npos);
     CHECK(json.find("\"zones\":2") != std::string::npos);
     CHECK_EQ(lock.mode, 1u);
+    CHECK_EQ(lock.exit, static_cast<uint8_t>(LockExit::Return));
 }
 
 /* ── Descriptor auto-derivation (describe.h) ───────────────────────── */

--- a/tests/host/param_lock_tests.cpp
+++ b/tests/host/param_lock_tests.cpp
@@ -1320,6 +1320,115 @@ void TestRestoredClockedLocksShareAlignment()
 
 /* ── 11. Freeze / ClearSlot / PlayPhase ────────────────────────────── */
 
+/* ── Paged + clocked + steered tempo (the bassvox wiring) ────────────
+ * The clock ticks at poll cadence (16 sub-ticks per frame), the tempo
+ * is re-pushed every frame with estimator jitter, and the surface is
+ * the PAGED form.  A ~1-bar take must still snap to the bar. */
+
+void TestClockedSteeredPagedIntegration()
+{
+    FakeButton trigger;
+    FakeButton nav;
+    Pager      pager(nav, 3, 4);
+    using BvLocks = ParamLock<12, LockLength<4, 50>>;
+    BvLocks locks(trigger, pager);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+    locks.UseClock(clk);
+    static_cast<LockSource&>(locks).SetSyncMode(1u);
+
+    int  jit   = 0;
+    auto frame = [&](const float* phys) {
+        for (int i = 0; i < 16; i++) { t_us += 1000u; clk.Tick(t_us); }
+        clk.SetBpm(120.0f + ((jit++ & 1) ? 0.25f : -0.25f));
+        locks.SetFrameMs(16u);
+        locks.PollButtons(0u, false);
+        pager.PollButtons(0u, false);
+        locks.Advance();
+        locks.Update(phys, 0u);
+        pager.Update(phys, 0u);
+    };
+
+    float phys[4];
+    for (uint8_t i = 0; i < 4; i++) phys[i] = kRest;
+
+    /* ~1 bar of motion at 120 BPM: 125 × 16 ms = 2.0 s. */
+    trigger.pressed = true;
+    frame(phys);                                     /* baseline */
+    for (int i = 1; i <= 125; i++)
+    {
+        phys[2] = kRest + 0.003f * static_cast<float>(i);
+        frame(phys);
+    }
+    trigger.pressed = false;
+    frame(phys);
+    PCHECK(locks.IsActive(2));
+
+    /* Restart period: crossing-to-crossing on a mid-ramp level must be
+     * the snapped bar — 125 frames at the (jittering ~120) tempo. */
+    const float level = 0.003f * 60.0f;              /* mid-take delta */
+    float    prev  = locks.Delta(2);
+    bool     armed = false;
+    uint32_t n     = 0u, period = 0u;
+    for (uint32_t i = 0; i < 4000u && period == 0u; i++)
+    {
+        frame(phys);
+        n++;
+        const float now = locks.Delta(2);
+        const bool crossed = (prev < level && now >= level);
+        prev = now;
+        if (!crossed) continue;
+        if (!armed) { armed = true; n = 0u; }
+        else        period = n;
+    }
+    PCHECK(period >= 123u && period <= 127u);
+}
+
+/* ── TakeCleanRelease: the tap-derivation hook ──────────────────────── */
+
+void TestTakeCleanRelease()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    float phys[4];
+    for (uint8_t i = 0; i < 4; i++) phys[i] = kRest;
+
+    /* A plain tap is clean — reported exactly once. */
+    button.pressed = true;
+    Frame(locks, phys, kExactFrameMs);
+    button.pressed = false;
+    Frame(locks, phys, kExactFrameMs);
+    PCHECK(locks.TakeCleanRelease());
+    PCHECK(!locks.TakeCleanRelease());
+
+    /* A hold that recorded a lock is not. */
+    RecordGesture<ExactLocks, 4>(locks, button, 0, {0.6f, 0.7f, 0.8f},
+                                 kExactFrameMs);
+    PCHECK(locks.IsActive(0));
+    PCHECK(!locks.TakeCleanRelease());
+
+    /* A release landing under the gate is poisoned — but still reaches
+     * the manager, so the hold cannot dangle. */
+    button.pressed = true;
+    Frame(locks, phys, kExactFrameMs);
+    button.pressed = false;
+    locks.PollButtons(0u, /*gated=*/true);
+    Frame(locks, phys, kExactFrameMs);
+    PCHECK(!locks.TakeCleanRelease());
+    button.pressed = true;                       /* manager saw the up: */
+    Frame(locks, phys, kExactFrameMs);           /* a new hold works    */
+    button.pressed = false;
+    Frame(locks, phys, kExactFrameMs);
+    PCHECK(locks.TakeCleanRelease());
+}
+
 void TestFreezeHoldsPlayheads()
 {
     FakeButton button;
@@ -1828,6 +1937,8 @@ int RunParamLockTests(int& checks, int& failures)
     TestRestoredClockedLocksShareAlignment();
 
     TestFreezeHoldsPlayheads();
+    TestClockedSteeredPagedIntegration();
+    TestTakeCleanRelease();
     TestRecordingFinishedWhileFrozen();
     TestClearSlotIsIsolated();
     TestPlayPhaseReportsHeadAndWriteFill();

--- a/tests/host/param_lock_tests.cpp
+++ b/tests/host/param_lock_tests.cpp
@@ -1544,6 +1544,40 @@ void TestReturnExitRestoresOriginAndRearmsCatch()
     PCHECK(pager.State(0, 1).caught);
 }
 
+void TestExitModeLockSourceBinding()
+{
+    using Locks = ParamLock<4, LockLength<4, 50>>;
+
+    /* Unpaged: Return has no Pager to write into. */
+    FakeButton btn;
+    Locks unpaged(btn);
+    unpaged.Init();
+    LockSource& u = unpaged;
+    PCHECK(!u.CanReturn());
+    PCHECK_EQ(u.ExitMode(), static_cast<uint8_t>(LockExit::Latch));
+
+    /* Paged: the settings push lands on the surface's exit policy and
+     * behaves exactly like the fluent ExitMode(Return). */
+    FakeButton lock_btn, page_btn;
+    Pager pager(page_btn, 1, 4);
+    Locks locks(lock_btn, pager);
+    locks.Init();
+    LockSource& p = locks;
+    PCHECK(p.CanReturn());
+    p.SetExitMode(static_cast<uint8_t>(LockExit::Return));
+    PCHECK_EQ(p.ExitMode(), static_cast<uint8_t>(LockExit::Return));
+
+    float phys[4] = {kRest, kRest, kRest, kRest};
+    pager.Update(phys, 0u);
+    RecordGesture<Locks, 4>(locks, lock_btn, 1, {0.6f, 0.7f, 0.8f},
+                            kExactFrameMs);
+    PCHECK_NEAR(pager.Stored(0, 1), kRest, 1e-4f);
+    PCHECK(!pager.State(0, 1).caught);
+
+    p.SetExitMode(static_cast<uint8_t>(LockExit::Latch));
+    PCHECK_EQ(p.ExitMode(), static_cast<uint8_t>(LockExit::Latch));
+}
+
 /* ── 13. Pure math: snap table and anim eval ───────────────────────── */
 
 void TestLockSnapTicksTable()
@@ -1638,6 +1672,7 @@ void TestLockAnimEval()
 struct FakeLockSource : LockSource
 {
     uint8_t mode      = 0u;
+    uint8_t exit      = 0u;
     bool    has_clock = true;
 
     float DeltaAtPage(uint8_t, uint8_t) const override { return 0.0f; }
@@ -1648,6 +1683,9 @@ struct FakeLockSource : LockSource
     void    SetSyncMode(uint8_t m) override { mode = m; }
     uint8_t SyncMode() const override { return mode; }
     bool    HasClock() const override { return has_clock; }
+
+    void    SetExitMode(uint8_t m) override { exit = m; }
+    uint8_t ExitMode() const override { return exit; }
 };
 
 void TestSettingsUseLocksBinding()
@@ -1658,44 +1696,67 @@ void TestSettingsUseLocksBinding()
 
     auto h = settings.UseLocks(lock);
 
-    /* A plain persisted Selector at P2 — one byte, exactly like any
-     * selector, so it rides presets the way brightness does. */
-    PCHECK(settings.KindAt(0, 1) == SettingsKind::Selector);
-    PCHECK_EQ(settings.ZonesAt(0, 1), 2u);
-    PCHECK_EQ(settings.SerializedSize(), 1u);
+    /* Two plain persisted Selectors at P5 (sync) and P6 (exit) — one
+     * byte each, exactly like any selector, so they ride presets the
+     * way brightness does.  P2 stays free for the module. */
+    PCHECK(settings.KindAt(0, 1) == SettingsKind::None);
+    PCHECK(settings.KindAt(0, 4) == SettingsKind::Selector);
+    PCHECK(settings.KindAt(0, 5) == SettingsKind::Selector);
+    PCHECK_EQ(settings.ZonesAt(0, 4), 2u);
+    PCHECK_EQ(settings.ZonesAt(0, 5), 2u);
+    PCHECK_EQ(settings.SerializedSize(), 2u);
     PCHECK_EQ(lock.mode, 0u);
     PCHECK(h.Value() == LockSync::Free);
 
-    /* Default() pushes immediately. */
+    /* The exit selector defaults to Return (zone 0) and pushes it. */
+    PCHECK_EQ(lock.exit, static_cast<uint8_t>(LockExit::Return));
+    PCHECK(h.ExitValue() == LockExit::Return);
+    PCHECK_EQ(settings.SelectorIdxAt(0, 5), 0u);
+
+    /* Default() / DefaultExit() push immediately. */
     h.Default(LockSync::Clocked);
     PCHECK_EQ(lock.mode, 1u);
     PCHECK(h.Value() == LockSync::Clocked);
+    h.DefaultExit(LockExit::Latch);
+    PCHECK_EQ(lock.exit, static_cast<uint8_t>(LockExit::Latch));
+    PCHECK(h.ExitValue() == LockExit::Latch);
+    PCHECK_EQ(settings.SelectorIdxAt(0, 5), 1u);
 
-    /* Serialize carries the byte; Deserialize pushes into the lock, so
-     * a preset load re-times future recordings with no menu visit. */
-    uint8_t img = 0xFFu;
-    settings.Serialize(&img);
-    PCHECK_EQ(img, 1u);
+    /* Serialize carries the zone bytes; Deserialize pushes into the
+     * lock, so a preset load restores behavior with no menu visit. */
+    uint8_t img[2] = {0xFFu, 0xFFu};
+    settings.Serialize(img);
+    PCHECK_EQ(img[0], 1u);
+    PCHECK_EQ(img[1], 1u);
 
     lock.mode = 0u;
-    img       = 1u;
-    PCHECK(settings.Deserialize(&img));
+    img[0]    = 1u;   /* Clocked      */
+    img[1]    = 0u;   /* zone 0 = Return */
+    PCHECK(settings.Deserialize(img));
     PCHECK_EQ(lock.mode, 1u);
-    PCHECK_EQ(settings.SelectorIdxAt(0, 1), 1u);
+    PCHECK_EQ(lock.exit, static_cast<uint8_t>(LockExit::Return));
+    PCHECK_EQ(settings.SelectorIdxAt(0, 4), 1u);
+    PCHECK_EQ(settings.SelectorIdxAt(0, 5), 0u);
 
     /* An out-of-range byte clamps instead of poisoning the zone math. */
-    img = 9u;
-    PCHECK(settings.Deserialize(&img));
-    PCHECK_EQ(settings.SelectorIdxAt(0, 1), 1u);
+    img[0] = 9u;
+    img[1] = 9u;
+    PCHECK(settings.Deserialize(img));
+    PCHECK_EQ(settings.SelectorIdxAt(0, 4), 1u);
+    PCHECK_EQ(settings.SelectorIdxAt(0, 5), 1u);
+    PCHECK_EQ(lock.exit, static_cast<uint8_t>(LockExit::Latch));
 
-    /* At() relocates the slot; the handle follows. */
-    h.At(0, 4);
-    PCHECK(settings.KindAt(0, 1) == SettingsKind::None);
-    PCHECK(settings.KindAt(0, 4) == SettingsKind::Selector);
-    PCHECK_EQ(settings.ZonesAt(0, 4), 2u);
-    PCHECK_EQ(settings.SerializedSize(), 1u);
+    /* At() / ExitAt() relocate the slots; the handle follows. */
+    h.At(0, 1).ExitAt(0, 2);
+    PCHECK(settings.KindAt(0, 4) == SettingsKind::None);
+    PCHECK(settings.KindAt(0, 5) == SettingsKind::None);
+    PCHECK(settings.KindAt(0, 1) == SettingsKind::Selector);
+    PCHECK(settings.KindAt(0, 2) == SettingsKind::Selector);
+    PCHECK_EQ(settings.SerializedSize(), 2u);
     h.Default(LockSync::Free);
     PCHECK_EQ(lock.mode, 0u);
+    h.DefaultExit(LockExit::Return);
+    PCHECK_EQ(lock.exit, static_cast<uint8_t>(LockExit::Return));
 }
 
 void TestBrightnessHandleAt()
@@ -1773,6 +1834,7 @@ int RunParamLockTests(int& checks, int& failures)
 
     TestLatchExitLeavesBaseAlone();
     TestReturnExitRestoresOriginAndRearmsCatch();
+    TestExitModeLockSourceBinding();
 
     TestLockSnapTicksTable();
     TestLockAnimEval();

--- a/tests/host/param_lock_tests.cpp
+++ b/tests/host/param_lock_tests.cpp
@@ -17,9 +17,12 @@
 #include <cstring>
 #include <vector>
 
+#include "alchemy/control/lock_snap.h"
+#include "alchemy/control/musical_clock.h"
 #include "alchemy/surface/pager.h"
 #include "alchemy/surface/param_lock.h"
 #include "alchemy/surface/presets.h"
+#include "alchemy/surface/settings.h"
 
 using namespace alchemy;
 
@@ -96,8 +99,10 @@ constexpr float kRest = 0.5f;
  *
  * The first frame stays at kRest because OnButtonDown snapshots the
  * baseline there — a gesture already displaced on the press frame arms
- * nothing.  So the lock arms on values[0]: record_base == values[0], and
- * the recorded samples are `values`.
+ * nothing.  The lock arms on values[0], and record_base is the PRE-nudge
+ * baseline (kRest): the loop's reference — and a Return exit's home — is
+ * where the hand started, not where the arm threshold tripped.  The
+ * recorded samples are `values`.
  */
 template<class Locks, uint8_t kPots>
 void RecordGesture(Locks& locks, FakeButton& button, uint8_t pot,
@@ -155,14 +160,16 @@ uint32_t FramesPerLoop(Locks& locks, uint8_t pot, uint32_t frame_ms,
 /** Build a raw saved image for one slot (header + samples, zero tail). */
 template<class Locks>
 void PokeSlot(std::vector<uint8_t>& image, uint8_t slot, bool active,
-              float record_base, const std::vector<float>& samples)
+              float record_base, const std::vector<float>& samples,
+              uint16_t musical_ticks = 0u)
 {
     uint8_t* p = image.data() + static_cast<size_t>(slot) * Locks::kBytesPerSavedSlot;
 
     ParamLockSavedHeader h;
-    h.active      = active ? 1u : 0u;
-    h.length      = static_cast<uint16_t>(samples.size());
-    h.record_base = LockQuant(record_base);
+    h.active        = active ? 1u : 0u;
+    h.length        = static_cast<uint16_t>(samples.size());
+    h.record_base   = LockQuant(record_base);
+    h.musical_ticks = musical_ticks;
     std::memcpy(p, &h, sizeof h);
 
     for (size_t i = 0; i < samples.size(); i++)
@@ -218,9 +225,9 @@ void TestConfigConstants()
     PCHECK_EQ(Long::kFramesPerSlot, 600u);
     PCHECK_EQ(Paged::kFramesPerSlot, 600u);
 
-    /* 5-byte header + 2 B per sample, per slot. */
-    PCHECK_EQ(Long::kBytesPerSavedSlot, 5u + 600u * 2u);
-    PCHECK_EQ(Long::kSavedBytes, 6u * (5u + 1200u));
+    /* 7-byte header (PLK2: + musical_ticks) + 2 B per sample, per slot. */
+    PCHECK_EQ(Long::kBytesPerSavedSlot, 7u + 600u * 2u);
+    PCHECK_EQ(Long::kSavedBytes, 6u * (7u + 1200u));
     PCHECK_EQ(Long::kPresetBytes, Long::kSavedBytes);
 
     /* Arena is 2 B per sample and nothing else. */
@@ -230,7 +237,7 @@ void TestConfigConstants()
     /* The headline configurations fit a preset slot. */
     PCHECK(Long::kPresetBytes  <= kPresetBlobCapacity);
     PCHECK(Paged::kPresetBytes <= kPresetBlobCapacity);
-    PCHECK(Paged::kPresetBytes  == 12u * (5u + 1200u));
+    PCHECK(Paged::kPresetBytes  == 12u * (7u + 1200u));
 
     /* RamOnly contributes nothing to a preset but keeps its byte form. */
     using RamOnly = ParamLock<6, LockLength<20, 30, LockStore::RamOnly>>;
@@ -261,7 +268,8 @@ void TestRecordPlaybackRoundTrip()
     ExactLocks locks(button);
     locks.Init();
 
-    /* First swept value arms the lock, so it becomes record_base. */
+    /* The first swept value arms the lock; deltas reference the
+     * PRE-nudge baseline (kRest), the gesture's true origin. */
     const std::vector<float> sweep = {0.6f, 0.7f, 0.8f, 0.9f};
     RecordGesture<ExactLocks, 4>(locks, button, 1, sweep, kExactFrameMs);
 
@@ -275,7 +283,7 @@ void TestRecordPlaybackRoundTrip()
     {
         for (float v : sweep)
         {
-            PCHECK_NEAR(locks.Delta(1), v - sweep.front(), 1e-3f);
+            PCHECK_NEAR(locks.Delta(1), v - kRest, 1e-3f);
             Frame(locks, phys, kExactFrameMs);
         }
     }
@@ -330,8 +338,8 @@ void TestBufferFullAutoArms()
     PCHECK(locks.IsActive(0));
 
     /* kFramesPerSlot samples, one frame each at this cadence. */
-    /* Recorded deltas span 0 .. 0.398; 0.2 is an interior level. */
-    PCHECK_EQ(FramesPerLoop(locks, 0, kExactFrameMs, 0.2f),
+    /* Deltas reference kRest: they span -0.2 .. 0.198; 0.1 is interior. */
+    PCHECK_EQ(FramesPerLoop(locks, 0, kExactFrameMs, 0.1f),
               uint32_t{ExactLocks::kFramesPerSlot});
 }
 
@@ -434,11 +442,12 @@ void TestRecordingBoxAverages()
     PCHECK(locks.IsActive(0));
 
     /* The first stored sample averages the 0.9 arm frame with the 0.5
-     * frames sharing its period, landing inside the raw -0.4 excursion. */
+     * frames sharing its period.  Relative to record_base (kRest, the
+     * pre-nudge baseline) that lands inside the raw +0.4 excursion. */
     const float first = locks.Delta(0);
-    PCHECK(first > -0.4f);
-    PCHECK(first < 0.0f);
-    PCHECK_NEAR(first, (0.9f + 4.0f * 0.5f) / 5.0f - 0.9f, 3e-2f);
+    PCHECK(first < 0.4f);
+    PCHECK(first > 0.0f);
+    PCHECK_NEAR(first, (0.9f + 4.0f * 0.5f) / 5.0f - kRest, 3e-2f);
 }
 
 void TestSlowFrameHoldsLastSample()
@@ -461,7 +470,7 @@ void TestSlowFrameHoldsLastSample()
 
     ParamLockSavedHeader h;
     std::memcpy(&h, out.data(), sizeof h);
-    PCHECK_EQ(h.record_base, LockQuant(0.6f));
+    PCHECK_EQ(h.record_base, LockQuant(kRest));   /* pre-nudge baseline */
     PCHECK(h.length >= 12u);                 /* ~3 frames x 6 samples */
 
     /* Every sample from the second frame on is 0.9, averages and holds
@@ -758,6 +767,964 @@ void TestPresetBudget()
     PCHECK(decltype(locks)::kPresetBytesFree > 5000u);
 }
 
+/* ── 9. Gesture thresholds ─────────────────────────────────────────── */
+
+void TestArmAndClearThresholds()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    /* Below the arm threshold (default 0.005): nothing arms. */
+    RecordGesture<ExactLocks, 4>(locks, button, 0, {0.502f, 0.502f},
+                                 kExactFrameMs);
+    PCHECK(!locks.IsActive(0));
+    PCHECK(!locks.IsRecording(0));
+
+    /* A 0.02 nudge arms — under the OLD single threshold (0.03) this
+     * gesture was silently ignored, which is the timing complaint the
+     * arm/clear split exists to fix. */
+    RecordGesture<ExactLocks, 4>(locks, button, 0, {0.52f, 0.53f},
+                                 kExactFrameMs);
+    PCHECK(locks.IsActive(0));
+
+    /* The same 0.02 nudge on the now-active slot does NOT clear it:
+     * clearing needs the larger clear threshold (default 0.03), so a
+     * brush against a playing pot mid-hold is survivable. */
+    RecordGesture<ExactLocks, 4>(locks, button, 0, {0.52f}, kExactFrameMs);
+    PCHECK(locks.IsActive(0));
+
+    /* A firmer 0.04 nudge clears. */
+    RecordGesture<ExactLocks, 4>(locks, button, 0, {0.54f}, kExactFrameMs);
+    PCHECK(!locks.IsActive(0));
+
+    /* Both thresholds are configurable. */
+    locks.ArmThreshold(0.10f);
+    RecordGesture<ExactLocks, 4>(locks, button, 1, {0.55f}, kExactFrameMs);
+    PCHECK(!locks.IsActive(1));                    /* 0.05 < 0.10 */
+    RecordGesture<ExactLocks, 4>(locks, button, 1, {0.65f, 0.7f},
+                                 kExactFrameMs);
+    PCHECK(locks.IsActive(1));                     /* 0.15 ≥ 0.10 */
+}
+
+/* ── 10. Clocked mode ──────────────────────────────────────────────── */
+
+/* 120 BPM at 96 PPQN: 192 ticks/s — a half note is 192 ticks = 1000 ms.
+ * Rate 50 Hz at 20 ms frames keeps 1 sample per frame. */
+constexpr uint32_t kTestPpqn = 96u;
+
+/** One control frame with the clock ticking, in ControlLoop's order. */
+template<class Locks>
+void ClockedFrame(Locks& locks, MusicalClock& clk, uint32_t& t_us,
+                  const float* phys, uint32_t frame_ms)
+{
+    t_us += frame_ms * 1000u;
+    clk.Tick(t_us);
+    locks.SetFrameMs(frame_ms);
+    locks.PollButtons(0u, false);
+    locks.Advance();
+    locks.Update(phys, 0u);
+}
+
+template<class Locks, uint8_t kPots>
+void ClockedRecordGesture(Locks& locks, MusicalClock& clk, uint32_t& t_us,
+                          FakeButton& button, uint8_t pot,
+                          const std::vector<float>& values, uint32_t frame_ms)
+{
+    float phys[kPots];
+    for (uint8_t i = 0; i < kPots; i++) phys[i] = kRest;
+
+    button.pressed = true;
+    ClockedFrame(locks, clk, t_us, phys, frame_ms);   /* baseline */
+    for (float v : values)
+    {
+        phys[pot] = v;
+        ClockedFrame(locks, clk, t_us, phys, frame_ms);
+    }
+    button.pressed = false;
+    ClockedFrame(locks, clk, t_us, phys, frame_ms);
+}
+
+/** FramesPerLoop with the clock running — crossing-to-crossing. */
+template<class Locks>
+uint32_t ClockedFramesPerLoop(Locks& locks, MusicalClock& clk, uint32_t& t_us,
+                              uint8_t pot, uint32_t frame_ms, float level,
+                              uint32_t limit = 100000u)
+{
+    const float phys[8] = {};
+    float    prev  = locks.Delta(pot);
+    bool     armed = false;
+    uint32_t n     = 0u;
+
+    for (uint32_t i = 0; i < limit; i++)
+    {
+        ClockedFrame(locks, clk, t_us, phys, frame_ms);
+        n++;
+        const float now = locks.Delta(pot);
+        const bool crossed = (prev < level && now >= level);
+        prev = now;
+        if (!crossed) continue;
+        if (!armed) { armed = true; n = 0u; continue; }
+        return n;
+    }
+    return 0u;
+}
+
+/** A rising n-frame ramp in 0.006 steps: sample k plays back as delta
+ *  0.006·(k+1).  Every step clears the arm threshold, so all n frames
+ *  record.  Default 51 frames = 1020 ms at the 20 ms cadence. */
+std::vector<float> ClockedTestRamp(int n = 51)
+{
+    std::vector<float> ramp;
+    for (int i = 1; i <= n; i++)
+        ramp.push_back(kRest + 0.006f * static_cast<float>(i));
+    return ramp;
+}
+
+/** Drive frames until Delta drops by more than 0.1 (the loop restart),
+ *  then return.  The NEXT ClockedFrame is cycle-frame 1 (sample 1). */
+template<class Locks>
+bool DriveToRestart(Locks& locks, MusicalClock& clk, uint32_t& t_us,
+                    uint8_t pot, uint32_t frame_ms, uint32_t limit = 1000u)
+{
+    const float phys[8] = {};
+    float prev = locks.Delta(pot);
+    for (uint32_t i = 0; i < limit; i++)
+    {
+        ClockedFrame(locks, clk, t_us, phys, frame_ms);
+        const float now = locks.Delta(pot);
+        if (now < prev - 0.1f) return true;
+        prev = now;
+    }
+    return false;
+}
+
+uint16_t SavedTicks(const std::vector<uint8_t>& image, size_t slot,
+                    size_t bytes_per_slot)
+{
+    ParamLockSavedHeader h;
+    std::memcpy(&h, image.data() + slot * bytes_per_slot, sizeof h);
+    return h.musical_ticks;
+}
+
+void TestClockedLengthSnapsToGrid()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+
+    locks.UseClock(clk);
+    static_cast<LockSource&>(locks).SetSyncMode(1u);   /* Clocked */
+
+    /* The motivating case: a 1020 ms take against a 1000 ms half note
+     * loops as exactly the half note — the boundary snaps; the last
+     * ~20 ms of motion is simply never reached. */
+    ClockedRecordGesture<ExactLocks, 4>(locks, clk, t_us, button, 0,
+                                        ClockedTestRamp(), kExactFrameMs);
+    PCHECK(locks.IsActive(0));
+
+    std::vector<uint8_t> image(ExactLocks::kSavedBytes, 0u);
+    locks.Save(image.data());
+    PCHECK_EQ(SavedTicks(image, 0, ExactLocks::kBytesPerSavedSlot), 192u);
+
+    /* 192 ticks at 120 BPM = 1000 ms = 50 frames (51 were recorded). */
+    const uint32_t frames =
+        ClockedFramesPerLoop(locks, clk, t_us, 0, kExactFrameMs, 0.15f);
+    PCHECK(frames >= 49u && frames <= 51u);
+}
+
+void TestClockedTrimsLongTakes()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+
+    locks.UseClock(clk);
+    static_cast<LockSource&>(locks).SetSyncMode(1u);
+
+    /* 55 samples (1100 ms, deltas up to 0.33) snap to the 1000 ms half
+     * note.  The motion must play 1:1 and get RIGHT-TRIMMED: the head
+     * never reaches samples 50..54, so the peak delta is sample 49's
+     * 0.300 — a time-stretch would compress the full 0.33 ramp into the
+     * loop and hit 0.33. */
+    ClockedRecordGesture<ExactLocks, 4>(locks, clk, t_us, button, 0,
+                                        ClockedTestRamp(55), kExactFrameMs);
+
+    const float phys[4] = {};
+    float peak = 0.0f;
+    for (int i = 0; i < 120; i++)
+    {
+        ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);
+        if (locks.Delta(0) > peak) peak = locks.Delta(0);
+    }
+    PCHECK(peak > 0.29f);
+    PCHECK(peak < 0.31f);
+
+    const uint32_t frames =
+        ClockedFramesPerLoop(locks, clk, t_us, 0, kExactFrameMs, 0.15f);
+    PCHECK(frames >= 49u && frames <= 51u);
+}
+
+void TestClockedHoldsShortTakes()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+
+    locks.UseClock(clk);
+    static_cast<LockSource&>(locks).SetSyncMode(1u);
+
+    /* 45 samples (900 ms) snap to the 1000 ms half note: the motion
+     * plays 1:1 for 45 frames, HOLDS its final value (0.27) for ~5
+     * frames, and restarts on the grid. */
+    ClockedRecordGesture<ExactLocks, 4>(locks, clk, t_us, button, 0,
+                                        ClockedTestRamp(45), kExactFrameMs);
+    PCHECK(DriveToRestart(locks, clk, t_us, 0, kExactFrameMs));
+
+    const float phys[4] = {};
+    float at[54];
+    for (int k = 1; k <= 53; k++)
+    {
+        ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);
+        at[k] = locks.Delta(0);
+    }
+
+    /* 1:1 through the motion: cycle-frame k is sample k, NOT the
+     * 0.9×-stretched sample a fit-to-span playback would give. */
+    PCHECK_NEAR(at[20], 0.006f * 21.0f, 5e-3f);
+    PCHECK_NEAR(at[40], 0.006f * 41.0f, 5e-3f);
+
+    /* The hold tail: parked exactly on the final sample. */
+    PCHECK_NEAR(at[46], 0.006f * 45.0f, 2e-3f);
+    PCHECK(at[47] == at[46]);
+    PCHECK(at[48] == at[46]);
+
+    /* And the restart lands on the 50-frame grid (±1 frame of clock
+     * integration rounding). */
+    int restart = -1;
+    for (int k = 49; k <= 52 && restart < 0; k++)
+        if (at[k] < 0.05f) restart = k;
+    PCHECK(restart >= 49 && restart <= 51);
+}
+
+void TestClockedSnapSurvivesFrameTimingLie()
+{
+    /* The hardware repro: a lock at the stock 30 Hz stored rate on a
+     * control loop that DECLARES 16 ms frames but actually runs ~32 ms
+     * (control_loop.cpp's poll loop adds its work to the nominal delay,
+     * so the real frame period always exceeds frame_ms).  Four beats of
+     * motion at 120 BPM must snap to the whole bar and play back in
+     * full.  Deriving the duration from sample count ÷ rate measured
+     * this take at HALF length — snapping to the half note and trimming
+     * two of the four performed beats. */
+    using RigLocks = ParamLock<4>;               /* LockLength<16, 30> */
+    FakeButton button;
+    RigLocks locks(button);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+
+    locks.UseClock(clk);
+    static_cast<LockSource&>(locks).SetSyncMode(1u);
+
+    constexpr uint32_t kDeclaredMs = 16u;
+    constexpr uint32_t kRealMs     = 32u;
+
+    float phys[4] = {kRest, kRest, kRest, kRest};
+    auto lie_frame = [&]()
+    {
+        t_us += kRealMs * 1000u;                 /* reality */
+        clk.Tick(t_us);
+        locks.SetFrameMs(kDeclaredMs);           /* the loop's belief */
+        locks.PollButtons(0u, false);
+        locks.Advance();
+        locks.Update(phys, 0u);
+    };
+
+    /* 63 real frames × 32 ms ≈ 2016 ms ≈ four beats of motion. */
+    button.pressed = true;
+    lie_frame();
+    for (int i = 1; i <= 63; i++)
+    {
+        phys[0] = kRest + 0.006f * static_cast<float>(i);
+        lie_frame();
+    }
+    button.pressed = false;
+    lie_frame();
+    PCHECK(locks.IsActive(0));
+
+    /* Snapped to the whole bar (384 ticks), not the half note. */
+    std::vector<uint8_t> image(RigLocks::kSavedBytes, 0u);
+    locks.Save(image.data());
+    PCHECK_EQ(SavedTicks(image, 0, RigLocks::kBytesPerSavedSlot), 384u);
+
+    /* Restart period spans the full take: 384 ticks = 2000 ms real
+     * = ~62.5 real frames — the whole four beats replay each bar. */
+    float    prev   = locks.Delta(0);
+    bool     armed  = false;
+    uint32_t n      = 0u;
+    uint32_t frames = 0u;
+    for (uint32_t i = 0; i < 4000u && frames == 0u; i++)
+    {
+        lie_frame();
+        n++;
+        const float now_d   = locks.Delta(0);
+        const bool  crossed = (prev < 0.15f && now_d >= 0.15f);
+        prev = now_d;
+        if (!crossed) continue;
+        if (!armed) { armed = true; n = 0u; }
+        else        frames = n;
+    }
+    PCHECK(frames >= 61u && frames <= 64u);
+}
+
+void TestClockedTracksTempoChange()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+
+    locks.UseClock(clk);
+    static_cast<LockSource&>(locks).SetSyncMode(1u);
+
+    /* 45 samples (900 ms), snapped to the 192-tick half note. */
+    ClockedRecordGesture<ExactLocks, 4>(locks, clk, t_us, button, 0,
+                                        ClockedTestRamp(45), kExactFrameMs);
+
+    /* Halve the tempo: the BOUNDARY moves (192 ticks now spans 2000 ms
+     * = 100 frames) but the MOTION does not — it still plays its 45
+     * frames at recorded speed, then holds until the restart. */
+    clk.SetBpm(60.0f);
+    const uint32_t slow =
+        ClockedFramesPerLoop(locks, clk, t_us, 0, kExactFrameMs, 0.15f);
+    PCHECK(slow >= 99u && slow <= 101u);
+
+    PCHECK(DriveToRestart(locks, clk, t_us, 0, kExactFrameMs));
+    const float phys[4] = {};
+    float at20 = 0.f;
+    for (int k = 1; k <= 20; k++)
+    {
+        ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);
+        at20 = locks.Delta(0);
+    }
+    /* Still sample 20 at frame 20 — a stretch-to-span would be at half
+     * that position (~0.063) in the doubled loop. */
+    PCHECK_NEAR(at20, 0.006f * 21.0f, 5e-3f);
+
+    /* Double the tempo past the motion length: 192 ticks = 500 ms = 25
+     * frames — the take is truncated to the first 25 samples each pass. */
+    clk.SetBpm(240.0f);
+    const uint32_t fast =
+        ClockedFramesPerLoop(locks, clk, t_us, 0, kExactFrameMs, 0.10f);
+    PCHECK(fast >= 24u && fast <= 26u);
+}
+
+void TestClockedFollowsTransportStop()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+
+    locks.UseClock(clk);
+    static_cast<LockSource&>(locks).SetSyncMode(1u);
+
+    ClockedRecordGesture<ExactLocks, 4>(locks, clk, t_us, button, 0,
+                                        ClockedTestRamp(), kExactFrameMs);
+
+    const float phys[4] = {};
+    for (int i = 0; i < 10; i++) ClockedFrame(locks, clk, t_us, phys,
+                                              kExactFrameMs);
+
+    /* Transport stop halts MasterTick — the loop freezes in place. */
+    clk.Stop();
+    ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);   /* applies stop */
+    const float held = locks.Delta(0);
+    for (int i = 0; i < 25; i++)
+    {
+        ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);
+        PCHECK(locks.Delta(0) == held);
+    }
+
+    /* Start resumes advancement. */
+    clk.Start();
+    bool moved = false;
+    for (int i = 0; i < 5; i++)
+    {
+        ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);
+        if (locks.Delta(0) != held) moved = true;
+    }
+    PCHECK(moved);
+}
+
+void TestClockResetReAnchors()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+
+    locks.UseClock(clk);
+    static_cast<LockSource&>(locks).SetSyncMode(1u);
+
+    ClockedRecordGesture<ExactLocks, 4>(locks, clk, t_us, button, 0,
+                                        ClockedTestRamp(), kExactFrameMs);
+
+    /* Reset() zeroes MasterTick — the loop must re-anchor, not compute
+     * a negative phase.  Loop length is preserved. */
+    clk.Reset();
+    const uint32_t frames =
+        ClockedFramesPerLoop(locks, clk, t_us, 0, kExactFrameMs, 0.15f);
+    PCHECK(frames >= 49u && frames <= 51u);
+}
+
+void TestClockedFallsBackWithoutRunningClock()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    /* Clocked selected, clock wired but never started: the mature
+     * fallback records the slot free (musical_ticks 0) and it replays
+     * at its recorded wall-clock length. */
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);           /* rate set, but transport never runs */
+    locks.UseClock(clk);
+    static_cast<LockSource&>(locks).SetSyncMode(1u);
+
+    RecordGesture<ExactLocks, 4>(locks, button, 0, ClockedTestRamp(),
+                                 kExactFrameMs);
+    PCHECK(locks.IsActive(0));
+
+    std::vector<uint8_t> image(ExactLocks::kSavedBytes, 0u);
+    locks.Save(image.data());
+    PCHECK_EQ(SavedTicks(image, 0, ExactLocks::kBytesPerSavedSlot), 0u);
+
+    /* All 51 samples replay in 51 frames — wall-clock, no snap. */
+    PCHECK_EQ(FramesPerLoop(locks, 0, kExactFrameMs, 0.15f), 51u);
+}
+
+void TestModeAffectsNewRecordingsOnly()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+    locks.UseClock(clk);
+
+    /* Recorded under Free: stays free forever. */
+    ClockedRecordGesture<ExactLocks, 4>(locks, clk, t_us, button, 0,
+                                        ClockedTestRamp(), kExactFrameMs);
+
+    /* Flip to Clocked (as the Settings selector would); record another. */
+    static_cast<LockSource&>(locks).SetSyncMode(1u);
+    ClockedRecordGesture<ExactLocks, 4>(locks, clk, t_us, button, 1,
+                                        ClockedTestRamp(), kExactFrameMs);
+
+    std::vector<uint8_t> image(ExactLocks::kSavedBytes, 0u);
+    locks.Save(image.data());
+    PCHECK_EQ(SavedTicks(image, 0, ExactLocks::kBytesPerSavedSlot), 0u);
+    PCHECK_EQ(SavedTicks(image, 1, ExactLocks::kBytesPerSavedSlot), 192u);
+
+    /* Clocked mode must not touch SAMPLING in any way: the same gesture
+     * recorded under Free and under Clocked stores identical sample
+     * data (same count, same base, same bytes).  The clock names the
+     * restart interval — musical_ticks above — and nothing else. */
+    ParamLockSavedHeader h_free, h_clk;
+    const uint8_t* s_free = image.data();
+    const uint8_t* s_clk  = image.data() + ExactLocks::kBytesPerSavedSlot;
+    std::memcpy(&h_free, s_free, sizeof h_free);
+    std::memcpy(&h_clk,  s_clk,  sizeof h_clk);
+    PCHECK_EQ(h_free.length, h_clk.length);
+    PCHECK_EQ(h_free.record_base, h_clk.record_base);
+    PCHECK_EQ(std::memcmp(s_free + sizeof h_free, s_clk + sizeof h_clk,
+                          static_cast<size_t>(h_free.length)
+                              * sizeof(uint16_t)),
+              0);
+}
+
+void TestRestoredClockedLocksShareAlignment()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+    locks.UseClock(clk);
+
+    /* Two clocked slots restored from a preset anchor at the master
+     * origin, so equal musical lengths come back mutually phase-locked
+     * even though their sample counts differ. */
+    std::vector<uint8_t> image(ExactLocks::kSavedBytes, 0u);
+    PokeSlot<ExactLocks>(image, 0, true, 0.2f,
+                         {0.2f, 0.4f, 0.6f, 0.8f}, 192u);
+    PokeSlot<ExactLocks>(image, 2, true, 0.1f,
+                         {0.1f, 0.3f, 0.5f, 0.7f, 0.9f, 0.9f, 0.1f, 0.5f},
+                         192u);
+    locks.Restore(image.data());
+
+    const float phys[4] = {};
+    for (int i = 0; i < 37; i++)
+        ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);
+
+    PCHECK_NEAR(locks.PlayPhase(0), locks.PlayPhase(2), 1e-4f);
+    PCHECK(locks.PlayPhase(0) > 0.0f);
+}
+
+/* ── 11. Freeze / ClearSlot / PlayPhase ────────────────────────────── */
+
+void TestFreezeHoldsPlayheads()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+    locks.UseClock(clk);
+
+    /* One free slot, one clocked slot. */
+    ClockedRecordGesture<ExactLocks, 4>(locks, clk, t_us, button, 0,
+                                        {0.6f, 0.7f, 0.8f, 0.9f},
+                                        kExactFrameMs);
+    static_cast<LockSource&>(locks).SetSyncMode(1u);
+    ClockedRecordGesture<ExactLocks, 4>(locks, clk, t_us, button, 1,
+                                        ClockedTestRamp(), kExactFrameMs);
+
+    const float phys[4] = {};
+    for (int i = 0; i < 5; i++)
+        ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);
+
+    PCHECK(!locks.Frozen());
+    locks.Freeze(true);
+    PCHECK(locks.Frozen());
+
+    const float d_free    = locks.Delta(0);
+    const float p_clocked = locks.PlayPhase(1);
+    for (int i = 0; i < 20; i++)
+    {
+        ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);
+        PCHECK(locks.Delta(0) == d_free);
+        PCHECK(locks.PlayPhase(1) == p_clocked);
+    }
+
+    /* Resume continues from the held position — the clocked anchor is
+     * slid by the frozen span, so there is no jump to "where the clock
+     * got to".  One frame at 20 ms is 1/50th of the 1000 ms loop. */
+    locks.Freeze(false);
+    ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);
+    float expect = p_clocked + 0.02f;
+    if (expect >= 1.0f) expect -= 1.0f;
+    PCHECK_NEAR(locks.PlayPhase(1), expect, 5e-3f);
+}
+
+/* Recording is unaffected by Freeze — so a recording can also FINISH
+ * while frozen.  Such a slot must not inherit the whole frozen span on
+ * resume: its boundary starts at the resume point. */
+void TestRecordingFinishedWhileFrozen()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    MusicalClock clk(kTestPpqn, 4u);
+    clk.SetBpm(120.0f);
+    clk.Start();
+    uint32_t t_us = 1000u;
+    clk.Tick(t_us);
+    locks.UseClock(clk);
+    static_cast<LockSource&>(locks).SetSyncMode(1u);   /* Clocked */
+
+    locks.Freeze(true);
+
+    /* The whole take happens under Freeze.  The span still snaps
+     * normally — duration is measured against the clock, which Freeze
+     * does not stop. */
+    ClockedRecordGesture<ExactLocks, 4>(locks, clk, t_us, button, 0,
+                                        ClockedTestRamp(), kExactFrameMs);
+    PCHECK(locks.IsActive(0));
+
+    std::vector<uint8_t> image(ExactLocks::kSavedBytes, 0u);
+    locks.Save(image.data());
+    PCHECK_EQ(SavedTicks(image, 0, ExactLocks::kBytesPerSavedSlot), 192u);
+
+    /* Held at phase 0 while still frozen. */
+    const float phys[4] = {};
+    for (int i = 0; i < 5; i++)
+    {
+        ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);
+        PCHECK_NEAR(locks.PlayPhase(0), 0.0f, 1e-6f);
+    }
+
+    /* Resume: the boundary begins here, so the first restart lands one
+     * full span later — 192 ticks = 1000 ms = 50 frames. */
+    locks.Freeze(false);
+    PCHECK_NEAR(locks.PlayPhase(0), 0.0f, 1e-3f);
+
+    uint32_t frames  = 0u;
+    float    prev_ph = locks.PlayPhase(0);
+    for (uint32_t i = 0; i < 200u; i++)
+    {
+        ClockedFrame(locks, clk, t_us, phys, kExactFrameMs);
+        frames++;
+        const float ph = locks.PlayPhase(0);
+        if (ph < prev_ph) break;   /* wrapped: first restart */
+        prev_ph = ph;
+    }
+    PCHECK(frames >= 49u && frames <= 51u);
+}
+
+void TestClearSlotIsIsolated()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    RecordGesture<ExactLocks, 4>(locks, button, 0, {0.6f, 0.7f},
+                                 kExactFrameMs);
+    RecordGesture<ExactLocks, 4>(locks, button, 2, {0.7f, 0.8f},
+                                 kExactFrameMs);
+    PCHECK(locks.IsActive(0));
+    PCHECK(locks.IsActive(2));
+
+    locks.ClearSlot(2);
+    PCHECK(!locks.IsActive(2));
+    PCHECK(locks.Delta(2) == 0.0f);
+    PCHECK(locks.IsActive(0));          /* untouched */
+}
+
+void TestPlayPhaseReportsHeadAndWriteFill()
+{
+    FakeButton button;
+    ExactLocks locks(button);
+    locks.Init();
+
+    std::vector<uint8_t> image(ExactLocks::kSavedBytes, 0u);
+    PokeSlot<ExactLocks>(image, 0, true, 0.5f, {0.5f, 0.6f, 0.7f, 0.8f});
+    locks.Restore(image.data());
+
+    const float phys[4] = {};
+    PCHECK_NEAR(locks.PlayPhase(0), 0.00f, 1e-4f);
+    Frame(locks, phys, kExactFrameMs);
+    PCHECK_NEAR(locks.PlayPhase(0), 0.25f, 1e-3f);
+    Frame(locks, phys, kExactFrameMs);
+    PCHECK_NEAR(locks.PlayPhase(0), 0.50f, 1e-3f);
+
+    /* While recording, PlayPhase is the write head against capacity. */
+    float rec[4] = {kRest, kRest, kRest, kRest};
+    button.pressed = true;
+    Frame(locks, rec, kExactFrameMs);
+    rec[1] = 0.7f;
+    for (int i = 0; i < 10; i++) Frame(locks, rec, kExactFrameMs);
+    PCHECK(locks.IsRecording(1));
+    PCHECK_NEAR(locks.PlayPhase(1),
+                10.0f / static_cast<float>(ExactLocks::kFramesPerSlot),
+                2.0f / static_cast<float>(ExactLocks::kFramesPerSlot));
+    button.pressed = false;
+    Frame(locks, rec, kExactFrameMs);
+}
+
+/* ── 12. Exit modes ────────────────────────────────────────────────── */
+
+void TestLatchExitLeavesBaseAlone()
+{
+    using Locks = ParamLock<4, LockLength<4, 50>>;   /* 1 page × 4 pots */
+    FakeButton lock_btn, page_btn;
+    Pager pager(page_btn, 1, 4);
+    Locks locks(lock_btn, pager);
+    locks.Init();
+
+    /* Catch the pager at the gesture's end position first. */
+    float phys[4] = {kRest, kRest, kRest, kRest};
+    pager.Update(phys, 0u);
+
+    RecordGesture<Locks, 4>(locks, lock_btn, 1, {0.6f, 0.7f, 0.8f},
+                            kExactFrameMs);
+    phys[1] = 0.8f;
+    pager.Update(phys, 0u);
+
+    /* Latch (default): the pot's stored value is wherever the pager put
+     * it — the lock exit wrote nothing. */
+    PCHECK_NEAR(pager.Stored(0, 1), 0.8f, 1e-4f);
+    PCHECK(pager.State(0, 1).caught);
+}
+
+void TestReturnExitRestoresOriginAndRearmsCatch()
+{
+    using Locks = ParamLock<4, LockLength<4, 50>>;
+    FakeButton lock_btn, page_btn;
+    Pager pager(page_btn, 1, 4);
+    Locks locks(lock_btn, pager);
+    locks.Init();
+    locks.ExitMode(LockExit::Return);
+
+    float phys[4] = {kRest, kRest, kRest, kRest};
+    pager.Update(phys, 0u);
+
+    RecordGesture<Locks, 4>(locks, lock_btn, 1, {0.6f, 0.7f, 0.8f},
+                            kExactFrameMs);
+
+    /* The base snapped back to the gesture origin (kRest) and catch
+     * re-armed: the pot, still physically at 0.8, is dead until it
+     * comes back through the stored value. */
+    PCHECK_NEAR(pager.Stored(0, 1), kRest, 1e-4f);
+    PCHECK(!pager.State(0, 1).caught);
+
+    phys[1] = 0.8f;
+    pager.Update(phys, 0u);
+    PCHECK_NEAR(pager.Stored(0, 1), kRest, 1e-4f);   /* still parked */
+    PCHECK(!pager.State(0, 1).caught);
+
+    /* Crossing the origin catches, exactly like a page switch. */
+    phys[1] = 0.45f;
+    pager.Update(phys, 0u);
+    PCHECK(pager.State(0, 1).caught);
+
+    /* Playback reproduces the recording relative to the restored base:
+     * total = stored + delta = recording, exactly as captured. */
+    PCHECK(locks.IsActive(1));
+
+    /* A cleared slot must NOT return-snap: clear pot 1 (a 0.04 nudge,
+     * past the clear threshold) and check stored stays caught wherever
+     * the pot is — the exit hook only touches slots that ended active. */
+    phys[1] = 0.45f;
+    RecordGesture<Locks, 4>(locks, lock_btn, 1, {0.54f}, kExactFrameMs);
+    PCHECK(!locks.IsActive(1));
+    pager.Update(phys, 0u);
+    PCHECK(pager.State(0, 1).caught);
+}
+
+/* ── 13. Pure math: snap table and anim eval ───────────────────────── */
+
+void TestLockSnapTicksTable()
+{
+    constexpr uint8_t kST  = LockGrid::Straight | LockGrid::Triplet;
+    constexpr uint8_t kAll = kST | LockGrid::Dotted;
+
+    /* 96 PPQN, 4/4: quarter 96, half 192, bar 384. */
+
+    /* The motivating cases: near a half note snaps to the half note. */
+    PCHECK_EQ(LockSnapTicks(195.84, 96, 4, kST), 192u);
+    PCHECK_EQ(LockSnapTicks(188.20, 96, 4, kST), 192u);
+
+    /* Near a triplet lands on the triplet (128 = half-note triplet). */
+    PCHECK_EQ(LockSnapTicks(130.0, 96, 4, kST), 128u);
+
+    /* 140 ticks: triplet 128 wins under the default grid… */
+    PCHECK_EQ(LockSnapTicks(140.0, 96, 4, kST), 128u);
+    /* …the dotted quarter (144) wins when dotted is enabled… */
+    PCHECK_EQ(LockSnapTicks(140.0, 96, 4, kAll), 144u);
+    /* …and straight-only has to reach to the half note (ratio beats
+     * the quarter: 192/140 < 140/96). */
+    PCHECK_EQ(LockSnapTicks(140.0, 96, 4, LockGrid::Straight), 192u);
+
+    /* Above one bar, integer bar counts are always in the grid: a
+     * 5.5-bar take goes to 6 bars, never stretched to 4 or 8. */
+    PCHECK_EQ(LockSnapTicks(5.5 * 384.0, 96, 4, kST), 6u * 384u);
+    PCHECK_EQ(LockSnapTicks(4.9 * 384.0, 96, 4, kST), 5u * 384u);
+
+    /* Tiny blips snap up to the smallest enabled candidate. */
+    PCHECK_EQ(LockSnapTicks(3.0, 96, 4, kST), 16u);          /* 16th-t  */
+    PCHECK_EQ(LockSnapTicks(3.0, 96, 4, LockGrid::Straight), 24u);
+
+    /* Degenerate inputs are refused, not guessed at. */
+    PCHECK_EQ(LockSnapTicks(0.0, 96, 4, kST), 0u);
+    PCHECK_EQ(LockSnapTicks(100.0, 0, 4, kST), 0u);
+    PCHECK_EQ(LockSnapTicks(100.0, 96, 0, kST), 0u);
+
+    /* Too long for the u16 saved form: refused, so the slot falls back
+     * to free rather than trimming the take to a far-shorter grid. */
+    PCHECK_EQ(LockSnapTicks(70000.0, 96, 4, kST), 0u);
+    PCHECK_EQ(LockSnapTicks(65000.0, 96, 4, kST), 169u * 384u);
+
+    /* 3/4 time: the bar is 288 ticks, and bar multiples track it. */
+    PCHECK_EQ(LockSnapTicks(2.1 * 288.0, 96, 3, kST), 2u * 288u);
+
+    /* PPQN-independent: nothing assumes 96 — the same musical take
+     * scales with whatever resolution the clock declares. */
+    PCHECK_EQ(LockSnapTicks(2.0 * 195.84, 192, 4, kST), 384u); /* half @192  */
+    PCHECK_EQ(LockSnapTicks(48.9, 24, 4, kST), 48u);           /* half @24   */
+    PCHECK_EQ(LockSnapTicks(2.1 * 72.0, 24, 3, kST), 2u * 72u);/* 2 bars 3/4 */
+}
+
+void TestLockAnimEval()
+{
+    /* Solid: always full, home pip. */
+    PCHECK_NEAR(LockAnimEval(LockAnim::Solid, 123u, 0.7f, false).level,
+                1.0f, 1e-6f);
+    PCHECK(!LockAnimEval(LockAnim::Solid, 123u, 0.7f, false).sweep);
+
+    /* Blink: 2 Hz square off absolute time. */
+    PCHECK_NEAR(LockAnimEval(LockAnim::Blink, 100u, 0.f, false).level,
+                1.0f, 1e-6f);
+    PCHECK_NEAR(LockAnimEval(LockAnim::Blink, 300u, 0.f, false).level,
+                0.0f, 1e-6f);
+    PCHECK_NEAR(LockAnimEval(LockAnim::Blink, 600u, 0.f, false).level,
+                1.0f, 1e-6f);
+
+    /* Breathe: bounded, dim at the trough, full at the crest. */
+    PCHECK_NEAR(LockAnimEval(LockAnim::Breathe, 0u, 0.f, false).level,
+                0.25f, 1e-4f);
+    PCHECK_NEAR(LockAnimEval(LockAnim::Breathe, 1000u, 0.f, false).level,
+                1.0f, 1e-4f);
+
+    /* LoopPulse: flash at the wrap, floor later; solid while recording. */
+    PCHECK_NEAR(LockAnimEval(LockAnim::LoopPulse, 0u, 0.0f, false).level,
+                1.0f, 1e-4f);
+    PCHECK_NEAR(LockAnimEval(LockAnim::LoopPulse, 0u, 0.5f, false).level,
+                0.2f, 1e-4f);
+    PCHECK_NEAR(LockAnimEval(LockAnim::LoopPulse, 0u, 0.5f, true).level,
+                1.0f, 1e-4f);
+
+    /* Sweep: the pip rides the phase. */
+    const LockAnimFrame s = LockAnimEval(LockAnim::Sweep, 0u, 0.3f, false);
+    PCHECK(s.sweep);
+    PCHECK_NEAR(s.sweep_pos01, 0.3f, 1e-6f);
+    PCHECK_NEAR(s.level, 1.0f, 1e-6f);
+}
+
+/* ── 14. Settings::UseLocks binding ────────────────────────────────── */
+
+struct FakeLockSource : LockSource
+{
+    uint8_t mode      = 0u;
+    bool    has_clock = true;
+
+    float DeltaAtPage(uint8_t, uint8_t) const override { return 0.0f; }
+    bool  IsRecordingAtPage(uint8_t, uint8_t) const override { return false; }
+    bool  IsActiveAtPage(uint8_t, uint8_t) const override { return false; }
+    void  Update(const float*, uint32_t) override {}
+
+    void    SetSyncMode(uint8_t m) override { mode = m; }
+    uint8_t SyncMode() const override { return mode; }
+    bool    HasClock() const override { return has_clock; }
+};
+
+void TestSettingsUseLocksBinding()
+{
+    FakeButton b2, b3;
+    Settings settings(b2, b3);
+    FakeLockSource lock;
+
+    auto h = settings.UseLocks(lock);
+
+    /* A plain persisted Selector at P2 — one byte, exactly like any
+     * selector, so it rides presets the way brightness does. */
+    PCHECK(settings.KindAt(0, 1) == SettingsKind::Selector);
+    PCHECK_EQ(settings.ZonesAt(0, 1), 2u);
+    PCHECK_EQ(settings.SerializedSize(), 1u);
+    PCHECK_EQ(lock.mode, 0u);
+    PCHECK(h.Value() == LockSync::Free);
+
+    /* Default() pushes immediately. */
+    h.Default(LockSync::Clocked);
+    PCHECK_EQ(lock.mode, 1u);
+    PCHECK(h.Value() == LockSync::Clocked);
+
+    /* Serialize carries the byte; Deserialize pushes into the lock, so
+     * a preset load re-times future recordings with no menu visit. */
+    uint8_t img = 0xFFu;
+    settings.Serialize(&img);
+    PCHECK_EQ(img, 1u);
+
+    lock.mode = 0u;
+    img       = 1u;
+    PCHECK(settings.Deserialize(&img));
+    PCHECK_EQ(lock.mode, 1u);
+    PCHECK_EQ(settings.SelectorIdxAt(0, 1), 1u);
+
+    /* An out-of-range byte clamps instead of poisoning the zone math. */
+    img = 9u;
+    PCHECK(settings.Deserialize(&img));
+    PCHECK_EQ(settings.SelectorIdxAt(0, 1), 1u);
+
+    /* At() relocates the slot; the handle follows. */
+    h.At(0, 4);
+    PCHECK(settings.KindAt(0, 1) == SettingsKind::None);
+    PCHECK(settings.KindAt(0, 4) == SettingsKind::Selector);
+    PCHECK_EQ(settings.ZonesAt(0, 4), 2u);
+    PCHECK_EQ(settings.SerializedSize(), 1u);
+    h.Default(LockSync::Free);
+    PCHECK_EQ(lock.mode, 0u);
+}
+
+void TestBrightnessHandleAt()
+{
+    FakeButton b2, b3;
+    Settings settings(b2, b3);
+
+    /* The placement override UseBrightness's doc always promised:
+     * relocate, then keep configuring through the moved handle. */
+    auto h = settings.UseBrightness().At(1, 0).Default(0.5f);
+    PCHECK(settings.KindAt(0, 0) == SettingsKind::None);
+    PCHECK(settings.KindAt(1, 0) == SettingsKind::Brightness);
+    PCHECK_EQ(settings.NumPages(), 2u);
+    PCHECK_NEAR(h.Value(), 0.5f, 1e-5f);
+    PCHECK_NEAR(settings.RangeLoAt(1, 0), 0.05f, 1e-6f);
+    PCHECK_EQ(settings.SerializedSize(), sizeof(float));
+
+    /* Out-of-range targets are refused; the handle stays put. */
+    h.At(9, 0).Default(0.8f);
+    PCHECK(settings.KindAt(1, 0) == SettingsKind::Brightness);
+    PCHECK_NEAR(h.Value(), 0.8f, 1e-5f);
+
+    /* Builder-returned handles know their owner too. */
+    auto k = settings.Page(0).Pot(3).Brightness();
+    k.At(2, 5);
+    PCHECK(settings.KindAt(0, 3) == SettingsKind::None);
+    PCHECK(settings.KindAt(2, 5) == SettingsKind::Brightness);
+}
+
 } // namespace
 
 int RunParamLockTests(int& checks, int& failures)
@@ -785,6 +1752,33 @@ int RunParamLockTests(int& checks, int& failures)
     TestShortArenaIsRefused();
     TestPagedSlotAddressing();
     TestPresetBudget();
+
+    TestArmAndClearThresholds();
+
+    TestClockedLengthSnapsToGrid();
+    TestClockedTrimsLongTakes();
+    TestClockedHoldsShortTakes();
+    TestClockedSnapSurvivesFrameTimingLie();
+    TestClockedTracksTempoChange();
+    TestClockedFollowsTransportStop();
+    TestClockResetReAnchors();
+    TestClockedFallsBackWithoutRunningClock();
+    TestModeAffectsNewRecordingsOnly();
+    TestRestoredClockedLocksShareAlignment();
+
+    TestFreezeHoldsPlayheads();
+    TestRecordingFinishedWhileFrozen();
+    TestClearSlotIsIsolated();
+    TestPlayPhaseReportsHeadAndWriteFill();
+
+    TestLatchExitLeavesBaseAlone();
+    TestReturnExitRestoresOriginAndRearmsCatch();
+
+    TestLockSnapTicksTable();
+    TestLockAnimEval();
+
+    TestSettingsUseLocksBinding();
+    TestBrightnessHandleAt();
 
     checks   += s_checks;
     failures += s_failures;


### PR DESCRIPTION
Parameter locks v2. Full story in `docs/param-locks.md` and the CHANGELOG.

- **Clocked mode**: recordings snap their loop *boundary* to the nearest musical division; the motion is never resampled. Duration is tick-measured, so it's immune to the ControlLoop frame-cadence lie.
- Arm/clear threshold pair, `record_base` = pre-nudge origin, Latch/Return exits, persisted Free/Clocked selector via `Settings::UseLocks`.
- **Styling**: `RecordStyle`/`PlayStyle` set the pip's color and animation (`Solid`/`Blink`/`Breathe`/`LoopPulse`/`Sweep`; defaults solid-red record, blinking-red play, replacing the fixed red/green pips); custom rings still compose from `IsActive`/`IsRecording`/`PlayPhase`.

7,043 host checks pass; ARM build clean. Hardware-tested on the V2 rig except Freeze and preset round-trip.