### PR TITLE
Pager: navigation bindings (Cycle / Shift / Latch layers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,55 @@
+# Alchemy SDK — unreleased
+
+Shift layers are pages: page navigation became declarative button
+bindings on `Pager`, so a hold-layer gets pot-catch, presets, locks, CV,
+rings, and the descriptor for free (#16).
+
+## Pager navigation bindings
+
+- `Pager(num_pages, num_pots)` + fluent `.Cycle(btn, pages...)`,
+  `.Shift(btn, page)`, `.Latch(btn, a, b)`, `.From(pages...)`.  The
+  classic `Pager(b1, n, m)` constructor is unchanged and equivalent to
+  `.Cycle(b1)` over every page; the serialized image and `'PAG0'` schema
+  are untouched.
+- Shift engages on the press edge and re-arms catch both ways; catch
+  only ever runs on the active page, so a hold cannot smear the pages
+  underneath — no app-side snapshot/restore.
+- The clean-release contract: a hold that edited nothing leaves the
+  release for taps; a used hold claims it.  `Pager::HoldUsed()` is the
+  pull-style read.
+- Latch pairs are sub-pages that occupy one cycle slot and remember
+  their member (the issue-#16 VAR/RND UI).
+- Arbitration built in: gate (Settings) poisoning incl. presses spanning
+  the gate, chord-reach abort on nav-button co-press, one layer at a
+  time, `GoToPage` cancels an active layer.
+- `KnobStorage` gains three defaulted queries — `ConsumesRelease()`
+  (the general form of the `PageButton()` identity check),
+  `HoldClaimed()`, and `IndicatorColor()`.
+- `ButtonBank` suppresses a tap whose release a used hold claimed, and
+  resolves its consume handshake through `ConsumesRelease()` — so latch
+  buttons shadow correctly too.  Hold gestures now make their consume
+  claim at the release (same-frame contract) rather than at fire time.
+- `ControlLoop` paints navigation indicators per button via
+  `IndicatorColor()`.  (It previously painted the page tint on button 0
+  regardless of which button the pager was constructed on.  A custom
+  `KnobStorage` that wants an indicator must implement `PageButton()`
+  or override `IndicatorColor()`.)
+- `ParamLock` banks its record gesture at the trigger's press edge —
+  fixes a latent bug where a mid-hold `GoToPage` silently retargeted an
+  in-flight recording — holds the pager's view latch
+  (`RetainPage`/`ReleasePage`) so a recording started on a layer keeps
+  its surface, and consumes only when its trigger actually carries a
+  release-driven binding.
+- Behavior fix: a pager-button press alive under (or spanning) the
+  Settings gate is poisoned until released, and an edge already latched
+  when the gate rises is dropped; previously the release after the gate
+  lifted still advanced the page.  Layers abort the instant the gate
+  rises, so Settings opens over the base surface.  The consume claim is
+  now frame-scoped (and frame-wide within that frame), per its
+  documented same-frame contract.
+- New: `docs/pages-and-layers.md` and a host test battery
+  (`tests/host/pager_nav_tests.cpp`).
+
 # Alchemy SDK v0.10.0 — 2026-08-19
 
 Modules can now ship their own documentation, and the descriptor build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,10 @@ rings, and the descriptor for free (#16).
   when the gate rises is dropped; previously the release after the gate
   lifted still advanced the page.  Layers abort the instant the gate
   rises, so Settings opens over the base surface.  The consume claim is
-  now frame-scoped (and frame-wide within that frame), per its
-  documented same-frame contract.
+  now scoped: it covers this frame's releases and the release of any
+  bound button held when the claim is made (the mid-hold chord idiom),
+  and otherwise evaporates instead of latching onto a later, unrelated
+  release.
 - New: `docs/pages-and-layers.md` and a host test battery
   (`tests/host/pager_nav_tests.cpp`).
 

--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -90,10 +90,15 @@ changed.
   reads; bank callbacks run at the 1 ms poll.
 - **Gestures resolve against the press-time page.**  A page change mid
   hold cannot retarget the gesture.
-- **Pager shadowing is deliberate.**  A gesture fired on the pager's
-  button consumes that release (`KnobStorage::ConsumeButton`), so a
-  button declared on B1 shadows page-advance on pages that declare it —
-  and only there.
+- **Pager shadowing is deliberate.**  A gesture fired on a button that
+  carries a release-driven navigation binding — the cycle button, a
+  latch pair's button (`KnobStorage::ConsumesRelease`) — consumes that
+  release (`KnobStorage::ConsumeButton`), so a button declared on B1
+  shadows page-advance on pages that declare it — and only there.
+- **Shift layers compose with taps.**  A `Pager::Shift` hold that
+  edited a parameter claims its release (`KnobStorage::HoldClaimed`)
+  and the trailing tap stays quiet; a clean hold leaves the tap free.
+  See docs/pages-and-layers.md.
 - **Don't stack holds on the ParamLock button.**  Lock recording is
   hold+knob; the two hold gestures cannot be arbitrated.
 - **Settings gates gestures, not data.**  While Settings is active

--- a/docs/pages-and-layers.md
+++ b/docs/pages-and-layers.md
@@ -1,17 +1,13 @@
 # Pages and layers: Pager navigation bindings
 
-A shift layer touches everything a page touches: pot values and their
-catch state, presets, param-locks, CV routing, ring rendering, and the
-HostLink descriptor.  Hand-rolled as a parallel surface, each of those
-integrations must be rebuilt and kept honest by hand — snapshotting the
-pager's storage around every hold, compensating the DSP reads for catch
-smear, re-implementing `LockSource` to bank locks per layer, writing a
-`Serializable` and a `Describe` for the layer's values.
+A shift layer touches everything a page touches: pot values and catch
+state, presets, param-locks, CV routing, ring rendering, and the
+HostLink descriptor. A layer implemented as a separate surface has to
+reimplement each of those integrations.
 
-The SDK's answer is to not have layers as a second concept.  **A layer
-is a page selected by holding a button.**  `Pager` owns the page pool it
-always owned; what's new is that page *navigation* is declared, per
-button:
+In the SDK a layer is not a separate concept. **A layer is a page
+selected by holding a button.** `Pager` owns the page pool, and page
+*navigation* is declared per button:
 
 ```cpp
 enum : uint8_t { kPageTone, kPageSpace, kPageShift, kNumAppPages };
@@ -31,52 +27,53 @@ static VirtualKnob out_level = VirtualKnob(kPotTopLeft, "Out Level")
 static Page shift_page = Page(kPageShift).Name("Shift").Knobs(out_level, ...);
 ```
 
-`presets.Manage(pager)` persists the layer's values with everything
-else; `ParamLock` banks per page, so the layer records automation; a
-`CvMatrix` routes to `(page, pot)` cells, so the layer takes CV; the
-renderer draws the layer's declared rings while it's held; the web
-editor shows it as a page tab.  None of that is layer-specific code.
+- `presets.Manage(pager)` persists the layer's values with everything
+  else.
+- `ParamLock` banks per page, so the layer records automation.
+- A `CvMatrix` routes to `(page, pot)` cells, so the layer takes CV.
+- The renderer draws the layer's declared rings while it is held.
+- The web editor shows it as a page tab.
 
-The classic constructor `Pager(b1, n_pages, n_pots)` is unchanged and
-means exactly `Pager(n_pages, n_pots).Cycle(b1)` — an empty cycle list
-is "every page, in order".
+None of that is layer-specific code.
 
-## The three bindings
+`Pager(b1, n_pages, n_pots)` is equivalent to
+`Pager(n_pages, n_pots).Cycle(b1)`. An empty cycle list means every page
+in order.
+
+## Bindings
 
 | Declaration | Gesture | Meaning |
 |---|---|---|
 | `.Cycle(btn, pages...)` | clean release | advance to the next entry (all pages when the list is empty) |
 | `.Shift(btn, page)` | hold | that page while held; return on release |
 | `.Latch(btn, a, b)` | clean release | toggle the sub-page pair while one member is showing |
-| `.From(pages...)` | — | scope the binding declared just before it (Shift/Latch) |
+| `.From(pages...)` | n/a | scope the binding declared just before it (Shift/Latch) |
 
 One binding per button, at most four bindings, at most one Shift layer
-active at a time.  Out-of-range pages reject the declaration silently,
+active at a time. Out-of-range pages reject the declaration silently,
 matching `GoToPage`'s out-of-range rule.
 
-**Shift engages on the press edge** — no hold threshold.  The moment the
-button goes down, the layer's page re-arms pot-catch (`LockPage`), so
-every pot detaches and must cross its stored value to take hold; early
-movement can never drag a base parameter.  The release returns to the
-page the press left and re-arms catch again — the pot is wherever the
-layer edit parked it, and the base value waits to be caught.  Because
-catch only ever runs on the active page, the pages underneath a hold are
-untouched *by construction*: there is nothing to snapshot and nothing to
-restore.
+**Shift engages on the press edge**, with no hold threshold. On press,
+the layer's page re-arms pot-catch (`LockPage`): every pot is detached
+until it crosses its stored value, so motion during the press cannot
+move a base-page parameter. On release, the pager returns to the page
+the press left and re-arms catch again, because the pot now sits where
+the layer edit left it. Catch runs only on the active page, so pages
+under a hold are never modified. No snapshot or restore is needed.
 
 **Latch pairs are sub-pages** (the [issue #16](https://github.com/hermetic-modular/alchemy-sdk/issues/16)
-UI).  `Latch(b3, kVar, kRnd)` toggles between the two while either is
-showing and is inert elsewhere — the button stays free for `ButtonBank`
-work on other pages.  A pair occupies **one cycle slot**: with
-`Cycle(b1, kVar, kReverb)`, standing on `kRnd` still advances to
+UI). `Latch(b3, kVar, kRnd)` toggles between the two while either is
+showing and does nothing elsewhere, so the button remains available to
+`ButtonBank` on other pages. A pair occupies **one cycle slot**: with
+`Cycle(b1, kVar, kReverb)`, the cycle advances from `kRnd` to
 `kReverb`, and cycling back lands on whichever member the pair last
-showed.  A page may belong to at most one pair.
+showed. A page may belong to at most one pair.
 
 ## The release contract
 
-**Clean releases compose with taps.**  A Shift hold that edited nothing
-(no pot caught, no caught pot moved past the catch tolerance) does not
-claim its release.  A hold that did edit claims it: `ButtonBank` asks
+**A clean hold does not claim its release.** A Shift hold counts as
+clean when no pot was caught and no caught pot moved past the catch
+tolerance. A hold that did edit claims its release: `ButtonBank` asks
 the storage (`KnobStorage::HoldClaimed`) before firing a tap, so
 
 ```cpp
@@ -84,82 +81,78 @@ static VirtualButton mute_btn = VirtualButton(kButtonB2, "Mute")
     .Ident("out.mute").Toggle().Bind(SetMute);
 ```
 
-on the same button as `.Shift(...)` gives the kick idiom — tap mutes,
-hold-and-turn edits the layer — with no app-side arbitration.  App code
-outside the bank reads `pager.HoldUsed(btn)` instead; it stays valid
-across the release frame.  The release frame itself never absorbs pot
-motion (releases process before that frame's catch), so a
-final-millisecond nudge cannot both edit the layer and pass for a clean
-tap.
+on the same button as `.Shift(...)` gives tap-to-mute plus
+hold-and-turn-to-edit, as in the kick example, with no app-side
+arbitration. App code outside the bank reads `pager.HoldUsed(btn)`
+instead; it stays valid across the release frame. The release frame
+itself never absorbs pot motion (releases process before that frame's
+catch), so a final-millisecond nudge cannot both edit the layer and pass
+for a clean tap.
 
-**Consume is scoped and generalized.**  A surface firing its own
-gesture on a button that carries a release-driven binding (Cycle *or*
-Latch — test with `KnobStorage::ConsumesRelease`) calls
-`ConsumeButton()`, and that release navigates nothing.  The claim covers
-this frame's releases and the release of any bound button held when the
-claim is made, so a chord handler may claim the moment the chord forms.
-A claim with nothing held evaporates at the end of the frame instead of
-latching onto a later, unrelated release.  Consumers still run before
-the pager in the canonical order (`locks.Update` → `pager.Update`).
+**Consuming a release.** A surface firing its own gesture on a button
+that carries a release-driven binding (Cycle *or* Latch; test with
+`KnobStorage::ConsumesRelease`) calls `ConsumeButton()`, and that
+release navigates nothing. The claim covers this frame's releases and
+the release of any bound button held when the claim is made, so a chord
+handler may claim the moment the chord forms. A claim made with nothing
+held expires at the end of the frame, so it cannot attach to a later,
+unrelated release. Consumers run before the pager: `locks.Update` then
+`pager.Update`.
 
 ## Arbitration
 
-These rules exist because every hand-rolled layer implementation ended
-up needing them:
-
-- **Gate (Settings).**  While gated, bindings sync but fire nothing.  A
-  press alive under — or spanning — the gate is poisoned until its
-  release, and the gate rising mid-hold aborts an active layer, so the
-  Settings chord always lands on a clean base surface.
-- **Chord reach.**  Two navigation-bound buttons down at once reads as
-  reaching for a chord: active layers abort and both presses poison for
-  their whole holds.  (A layer on a Settings-chord button whose partner
-  is *not* navigation-bound is briefly active during the reach; the
-  gate abort cleans it up when Settings opens.)
-- **View latch.**  `ParamLock` holds `Pager::RetainPage()` around its
-  trigger hold: a layer showing when the hold began defers its exit —
-  rings, catch, and the recording's bank stay in agreement — until the
-  trigger releases.  Layers engaged *after* the hold began aren't
-  covered.
-- **`GoToPage` outranks everything**: an explicit jump cancels an active
-  layer with no return leg and adopts the target into its latch pair's
-  memory if it has one.
+- **Gate (Settings).** While gated, bindings sync but fire nothing. A
+  press that starts under or spans the gate is poisoned (inert until its
+  release). A gate rising mid-hold aborts an active layer, so Settings
+  always opens on the base page.
+- **Chord reach.** Two navigation-bound buttons down at once is treated
+  as a chord attempt: active layers abort and both presses are poisoned
+  for their whole holds. (A layer on a Settings-chord button whose
+  partner is *not* navigation-bound stays active during the reach; the
+  gate abort clears it when Settings opens.)
+- **View latch.** `ParamLock` calls `Pager::RetainPage()` for the
+  duration of its trigger hold. A layer active when the hold began stays
+  active until the trigger releases, so rings, catch, and the
+  recording's bank remain consistent. Layers engaged *after* the hold
+  began are not retained.
+- **`GoToPage` has priority.** An explicit jump cancels an active layer
+  without returning to the previous page. If the target belongs to a
+  latch pair, it becomes that pair's remembered member.
 
 ## Locks bank at the press edge
 
 `ParamLock`'s record gesture latches its slot bank when the trigger goes
-down — you lock what you were looking at.  A layer released mid-hold, or
-a host-driven `GoToPage`, cannot retarget an in-flight recording.  (This
-also fixes a pre-binding latent bug: the bank used to resolve live, so a
-`GoToPage` during a hold silently switched the recording's target.)
+down: the recording targets the page visible at press time. A layer
+released mid-hold, or a host-driven `GoToPage`, cannot retarget an
+in-flight recording.
 
 ## LEDs
 
 `ControlLoop` queries `KnobStorage::IndicatorColor(btn)` once per button
-per frame: the cycle button wears the active page's color (as before), a
-Shift button wears its layer's color while engaged, a Latch button wears
-the showing member's color while on its pair.  `ButtonBank` zone colors
-still paint afterwards and deliberately win.
+per frame: the cycle button shows the active page's color, a Shift
+button shows its layer's color while engaged, and a Latch button shows
+the visible member's color while on its pair. `ButtonBank` zone colors
+paint afterwards and take precedence.
 
 ## What stays app-side
 
 - **Zone-commit debouncing** for selector knobs that trigger expensive
-  DSP swaps (hysteresis + dwell) — a DSP-commit policy, not a surface
-  concern.
-- **Custom ring art** for layer faces — declare per-knob
+  DSP swaps (hysteresis plus dwell). This is a DSP-commit policy, not a
+  surface concern.
+- **Custom ring art** for layer faces. Declare per-knob
   `.Ring(Custom(...))` / `.Overdraw(...)` as on any page.
 - **Trigger suppression** while a layer is held (e.g. a trigger pad
-  sharing the panel) — read `pager.ActivePage()` or `HoldUsed()`.
+  sharing the panel). Read `pager.ActivePage()` or `HoldUsed()`.
 
-## Deferred by design
+## Not implemented
 
-- **Tap-to-latch / hold-to-momentary hybrids** on one Shift button —
-  recognizing the split forces latency onto every plain interaction;
-  the binding model leaves room when a real module wants it.
-- **Cross-products** (a shift of a shift) — nothing motivates it.
-- **Multiple `KnobStorage`s per loop** — `(page, pot)` is the keying
-  invariant across locks, CV, rendering, presets, and the descriptor;
-  a second storage forks it everywhere.  Layers-as-pages is the answer.
+- **Tap-to-latch / hold-to-momentary hybrids** on one Shift button.
+  Detecting the split adds latency to every plain tap. The binding
+  model can accommodate it later.
+- **Nested shifts** (a shift of a shift). No use case.
+- **Multiple `KnobStorage`s per loop.** `(page, pot)` is the keying
+  invariant across locks, CV, rendering, presets, and the descriptor; a
+  second storage would fork it everywhere.
 - **Descriptor metadata for navigation gestures** ("hold B2 for Shift"
-  in the editor and the interactive manual) — additive, follows the
-  `gestures` precedent from #17.
+  in the editor and the interactive manual). Additive; follows the
+  `gestures` precedent from [issue #17](https://github.com/hermetic-modular/alchemy-sdk/issues/17).

--- a/docs/pages-and-layers.md
+++ b/docs/pages-and-layers.md
@@ -1,0 +1,163 @@
+# Pages and layers: Pager navigation bindings
+
+A shift layer touches everything a page touches: pot values and their
+catch state, presets, param-locks, CV routing, ring rendering, and the
+HostLink descriptor.  Hand-rolled as a parallel surface, each of those
+integrations must be rebuilt and kept honest by hand — snapshotting the
+pager's storage around every hold, compensating the DSP reads for catch
+smear, re-implementing `LockSource` to bank locks per layer, writing a
+`Serializable` and a `Describe` for the layer's values.
+
+The SDK's answer is to not have layers as a second concept.  **A layer
+is a page selected by holding a button.**  `Pager` owns the page pool it
+always owned; what's new is that page *navigation* is declared, per
+button:
+
+```cpp
+enum : uint8_t { kPageTone, kPageSpace, kPageShift, kNumAppPages };
+
+static Pager pager = Pager(kNumAppPages, kNumPots)
+    .Cycle(hw.buttons[kButtonB1], kPageTone, kPageSpace) // release advances
+    .Shift(hw.buttons[kButtonB2], kPageShift);           // page while held
+```
+
+Knobs on the layer are ordinary `VirtualKnob`s on an ordinary `Page`:
+
+```cpp
+static VirtualKnob out_level = VirtualKnob(kPotTopLeft, "Out Level")
+    .Linear(-40.f, 6.f).Unit("dB").Ident("out.level")
+    .Ring(Level(kShiftViolet));
+
+static Page shift_page = Page(kPageShift).Name("Shift").Knobs(out_level, ...);
+```
+
+`presets.Manage(pager)` persists the layer's values with everything
+else; `ParamLock` banks per page, so the layer records automation; a
+`CvMatrix` routes to `(page, pot)` cells, so the layer takes CV; the
+renderer draws the layer's declared rings while it's held; the web
+editor shows it as a page tab.  None of that is layer-specific code.
+
+The classic constructor `Pager(b1, n_pages, n_pots)` is unchanged and
+means exactly `Pager(n_pages, n_pots).Cycle(b1)` — an empty cycle list
+is "every page, in order".
+
+## The three bindings
+
+| Declaration | Gesture | Meaning |
+|---|---|---|
+| `.Cycle(btn, pages...)` | clean release | advance to the next entry (all pages when the list is empty) |
+| `.Shift(btn, page)` | hold | that page while held; return on release |
+| `.Latch(btn, a, b)` | clean release | toggle the sub-page pair while one member is showing |
+| `.From(pages...)` | — | scope the binding declared just before it (Shift/Latch) |
+
+One binding per button, at most four bindings, at most one Shift layer
+active at a time.  Out-of-range pages reject the declaration silently,
+matching `GoToPage`'s out-of-range rule.
+
+**Shift engages on the press edge** — no hold threshold.  The moment the
+button goes down, the layer's page re-arms pot-catch (`LockPage`), so
+every pot detaches and must cross its stored value to take hold; early
+movement can never drag a base parameter.  The release returns to the
+page the press left and re-arms catch again — the pot is wherever the
+layer edit parked it, and the base value waits to be caught.  Because
+catch only ever runs on the active page, the pages underneath a hold are
+untouched *by construction*: there is nothing to snapshot and nothing to
+restore.
+
+**Latch pairs are sub-pages** (the [issue #16](https://github.com/hermetic-modular/alchemy-sdk/issues/16)
+UI).  `Latch(b3, kVar, kRnd)` toggles between the two while either is
+showing and is inert elsewhere — the button stays free for `ButtonBank`
+work on other pages.  A pair occupies **one cycle slot**: with
+`Cycle(b1, kVar, kReverb)`, standing on `kRnd` still advances to
+`kReverb`, and cycling back lands on whichever member the pair last
+showed.  A page may belong to at most one pair.
+
+## The release contract
+
+**Clean releases compose with taps.**  A Shift hold that edited nothing
+(no pot caught, no caught pot moved past the catch tolerance) does not
+claim its release.  A hold that did edit claims it: `ButtonBank` asks
+the storage (`KnobStorage::HoldClaimed`) before firing a tap, so
+
+```cpp
+static VirtualButton mute_btn = VirtualButton(kButtonB2, "Mute")
+    .Ident("out.mute").Toggle().Bind(SetMute);
+```
+
+on the same button as `.Shift(...)` gives the kick idiom — tap mutes,
+hold-and-turn edits the layer — with no app-side arbitration.  App code
+outside the bank reads `pager.HoldUsed(btn)` instead; it stays valid
+across the release frame.  The release frame itself never absorbs pot
+motion (releases process before that frame's catch), so a
+final-millisecond nudge cannot both edit the layer and pass for a clean
+tap.
+
+**Consume is same-frame and generalized.**  A surface firing its own
+gesture on a button that carries a release-driven binding (Cycle *or*
+Latch — test with `KnobStorage::ConsumesRelease`) calls
+`ConsumeButton()` in the same frame, and that release navigates nothing.
+The claim is frame-scoped: unmatched, it evaporates instead of latching
+onto a later, unrelated release.  Consumers still run before the pager
+in the canonical order (`locks.Update` → `pager.Update`).
+
+## Arbitration
+
+These rules exist because every hand-rolled layer implementation ended
+up needing them:
+
+- **Gate (Settings).**  While gated, bindings sync but fire nothing.  A
+  press alive under — or spanning — the gate is poisoned until its
+  release, and the gate rising mid-hold aborts an active layer, so the
+  Settings chord always lands on a clean base surface.
+- **Chord reach.**  Two navigation-bound buttons down at once reads as
+  reaching for a chord: active layers abort and both presses poison for
+  their whole holds.  (A layer on a Settings-chord button whose partner
+  is *not* navigation-bound is briefly active during the reach; the
+  gate abort cleans it up when Settings opens.)
+- **View latch.**  `ParamLock` holds `Pager::RetainPage()` around its
+  trigger hold: a layer showing when the hold began defers its exit —
+  rings, catch, and the recording's bank stay in agreement — until the
+  trigger releases.  Layers engaged *after* the hold began aren't
+  covered.
+- **`GoToPage` outranks everything**: an explicit jump cancels an active
+  layer with no return leg and adopts the target into its latch pair's
+  memory if it has one.
+
+## Locks bank at the press edge
+
+`ParamLock`'s record gesture latches its slot bank when the trigger goes
+down — you lock what you were looking at.  A layer released mid-hold, or
+a host-driven `GoToPage`, cannot retarget an in-flight recording.  (This
+also fixes a pre-binding latent bug: the bank used to resolve live, so a
+`GoToPage` during a hold silently switched the recording's target.)
+
+## LEDs
+
+`ControlLoop` queries `KnobStorage::IndicatorColor(btn)` once per button
+per frame: the cycle button wears the active page's color (as before), a
+Shift button wears its layer's color while engaged, a Latch button wears
+the showing member's color while on its pair.  `ButtonBank` zone colors
+still paint afterwards and deliberately win.
+
+## What stays app-side
+
+- **Zone-commit debouncing** for selector knobs that trigger expensive
+  DSP swaps (hysteresis + dwell) — a DSP-commit policy, not a surface
+  concern.
+- **Custom ring art** for layer faces — declare per-knob
+  `.Ring(Custom(...))` / `.Overdraw(...)` as on any page.
+- **Trigger suppression** while a layer is held (e.g. a trigger pad
+  sharing the panel) — read `pager.ActivePage()` or `HoldUsed()`.
+
+## Deferred by design
+
+- **Tap-to-latch / hold-to-momentary hybrids** on one Shift button —
+  recognizing the split forces latency onto every plain interaction;
+  the binding model leaves room when a real module wants it.
+- **Cross-products** (a shift of a shift) — nothing motivates it.
+- **Multiple `KnobStorage`s per loop** — `(page, pot)` is the keying
+  invariant across locks, CV, rendering, presets, and the descriptor;
+  a second storage forks it everywhere.  Layers-as-pages is the answer.
+- **Descriptor metadata for navigation gestures** ("hold B2 for Shift"
+  in the editor and the interactive manual) — additive, follows the
+  `gestures` precedent from #17.

--- a/docs/pages-and-layers.md
+++ b/docs/pages-and-layers.md
@@ -92,13 +92,15 @@ motion (releases process before that frame's catch), so a
 final-millisecond nudge cannot both edit the layer and pass for a clean
 tap.
 
-**Consume is same-frame and generalized.**  A surface firing its own
+**Consume is scoped and generalized.**  A surface firing its own
 gesture on a button that carries a release-driven binding (Cycle *or*
 Latch — test with `KnobStorage::ConsumesRelease`) calls
-`ConsumeButton()` in the same frame, and that release navigates nothing.
-The claim is frame-scoped: unmatched, it evaporates instead of latching
-onto a later, unrelated release.  Consumers still run before the pager
-in the canonical order (`locks.Update` → `pager.Update`).
+`ConsumeButton()`, and that release navigates nothing.  The claim covers
+this frame's releases and the release of any bound button held when the
+claim is made, so a chord handler may claim the moment the chord forms.
+A claim with nothing held evaporates at the end of the frame instead of
+latching onto a later, unrelated release.  Consumers still run before
+the pager in the canonical order (`locks.Update` → `pager.Update`).
 
 ## Arbitration
 

--- a/framework/include/alchemy/surface/control_loop.h
+++ b/framework/include/alchemy/surface/control_loop.h
@@ -47,8 +47,9 @@
  *        OnPageChange hook
  *        OnFrame user hook
  *   5. Render: clear → (Settings if active, else: PerfRenderer pass →
- *      custom rings → overdraw → page indicator → ButtonBank colors →
- *      clip light) → OnRender hook → LockSource overlay → leds.Show
+ *      custom rings → overdraw → navigation indicators → ButtonBank
+ *      colors → clip light) → OnRender hook → LockSource overlay →
+ *      leds.Show
  */
 
 #pragma once

--- a/framework/include/alchemy/surface/knob_storage.h
+++ b/framework/include/alchemy/surface/knob_storage.h
@@ -86,11 +86,34 @@ class KnobStorage
      * or nullptr when it has none.  Surfaces that claim a gesture on the
      * same button (ParamLock, ButtonBank) compare against this and call
      * ConsumeButton() so the same release doesn't also advance the page.
+     * With navigation bindings (see Pager), prefer ConsumesRelease() —
+     * it also covers latch buttons; this remains the cycle button.
      */
     virtual const IButton* PageButton() const { return nullptr; }
 
     /** Suppress the next page-advance release (no-op by default). */
     virtual void ConsumeButton() {}
+
+    /** True when a release-driven page gesture (cycle, latch) is bound
+     *  to @p b — the general form of the PageButton() identity check. */
+    virtual bool ConsumesRelease(const IButton* b) const
+    {
+        return b != nullptr && b == PageButton();
+    }
+
+    /** True while a hold-layer gesture on @p b has edited a parameter:
+     *  the release is claimed and a same-button tap stays quiet. */
+    virtual bool HoldClaimed(const IButton* /*b*/) const { return false; }
+
+    /** Indicator color for button @p b's LED pair, painted by
+     *  ControlLoop (black = unpainted; ButtonBank colors win).
+     *  Default: the page tint on the page-advance button. */
+    virtual LedPanel::Rgb IndicatorColor(const IButton* b) const
+    {
+        return (b != nullptr && b == PageButton())
+                   ? PageColor(ActivePage())
+                   : LedPanel::Rgb{0, 0, 0};
+    }
 };
 
 } // namespace alchemy

--- a/framework/include/alchemy/surface/pager.h
+++ b/framework/include/alchemy/surface/pager.h
@@ -1,13 +1,20 @@
 /**
  * @file alchemy/surface/pager.h
- * @brief alchemy::Pager — opt-in performance pagination surface.
+ * @brief alchemy::Pager — opt-in pagination + layer surface.
  *
- * A Pager owns a page index and per-page pot-catch state.  It consumes one
- * button (the page-advance gesture) and an external array of physical pot
- * readings; everything else is composition at the user's call site.
+ * Owns the per-(page, pot) pool (pot-catch, presets, VirtualKnob reads)
+ * and the navigation that picks the active page, declared per button:
  *
- * Pages + locks: pass `pager` into a `ParamLock<kSlots>` constructor and the
- * lock surface will resolve `Delta(p)` against `pager.Page()` automatically.
+ *   Pager pager = Pager(kNumAppPages, kNumPots)
+ *       .Cycle(hw.buttons[kButtonB1], kTone, kSpace) // release advances
+ *       .Shift(hw.buttons[kButtonB2], kShiftPage)    // page while held
+ *       .Latch(hw.buttons[kButtonB3], kVar, kRnd);   // release toggles
+ *
+ * A shift layer is a page reached by holding a button: catch, presets,
+ * locks, CV, rings and the descriptor come with it, and since catch
+ * only runs on the active page a hold cannot smear the pages
+ * underneath.  `Pager(b1, n, m)` is unchanged: ≡ `Pager(n, m).Cycle(b1)`.
+ * The full contract lives in docs/pages-and-layers.md.
  */
 
 #pragma once
@@ -24,56 +31,93 @@ namespace alchemy {
 class Pager : public Serializable, public KnobStorage
 {
   public:
-    static constexpr uint8_t kMaxPages = 8u;
-    static constexpr uint8_t kMaxPots  = 8u;
+    static constexpr uint8_t kMaxPages    = 8u;
+    static constexpr uint8_t kMaxPots     = 8u;
+    static constexpr uint8_t kMaxBindings = 4u;
 
     /**
-     * @param b1         B1 (or any button) that drives the page-advance gesture.
+     * Storage-only construction; declare navigation with Cycle() /
+     * Shift() / Latch().
+     *
      * @param num_pages  Number of pages (1..kMaxPages).  Must be ≥ 1.
      * @param num_pots   Pots per page (1..kMaxPots).
      */
+    Pager(uint8_t num_pages, uint8_t num_pots);
+
+    /** Classic form: ≡ `Pager(num_pages, num_pots).Cycle(b1)`. */
     Pager(IButton& b1, uint8_t num_pages, uint8_t num_pots);
 
-    /**
-     * Process one frame: poll the button, advance the page on clean release,
-     * and run pot-catch on the active page.
-     *
-     * If a page advance occurs, the new page is locked (pots stay uncaught
-     * until the user moves through their stored values).
-     *
-     * If any other surface in this frame consumes B1 by
-     * calling `Pager::ConsumeButton()` — `ParamLock`, a freeze/chord
-     * handler, a tap-tempo handler, etc. — those surfaces' `Update()`
-     * methods MUST run **before** `Pager::Update()` so the consume flag
-     * is set in the same frame as the release the pager is about to
-     * process.  Reverse the order and the pager has already advanced
-     * the page this frame; the consume flag then suppresses the *next*,
-     * unrelated B1 release.  The canonical ordering is:
-     *
-     * ```cpp
-     * // any B1 consumers (chord handlers, etc.)
-     * locks.Update(phys, now);   // ← ParamLock first
-     * pager.Update(phys, now);   // ← Pager last
-     * ```
-     *
-     * @param phys   Physical pot readings, length ≥ NumPots().
-     * @param t_ms   Current timestamp (ms); unused today, reserved.
-     */
-    void PollButtons(uint32_t t_ms, bool gated) override;
-    void Update     (const float* phys, uint32_t t_ms) override;
+    /* ── Navigation declaration.  One binding per button; out-of-range
+     *    pages reject a declaration silently (the GoToPage rule). ───── */
 
-    /**
-     * Suppress the next B1-release page advance.
-     *
-     * Called by any surface that "claims" a B1 gesture in the same frame
-     * (e.g. `ParamLock` on a hold-and-nudge, a freeze chord handler on a
-     * B1+B2 combination).  See `Update()` for the required call order:
-     * consumers must run before the pager.
-     */
+    /** Cycle @p b through @p pages on a clean release (empty list =
+     *  every page); a Latch pair counts as one slot. */
+    template <typename... Pages>
+    Pager& Cycle(IButton& b, Pages... pages)
+    {
+        if (NavBinding* n = AddBinding(NavKind::Cycle, b))
+            (AddNavPage(*n, static_cast<uint8_t>(pages)), ...);
+        return *this;
+    }
+
+    /** Momentary layer: @p page while @p b is held.  Engages on the
+     *  press edge, catch re-armed both ways. */
+    Pager& Shift(IButton& b, uint8_t page);
+
+    /** Toggle the @p page_a / @p page_b sub-page pair on a clean
+     *  release; inert while neither member is showing. */
+    Pager& Latch(IButton& b, uint8_t page_a, uint8_t page_b);
+
+    /** Scope the just-declared Shift/Latch to engage only from @p pages. */
+    template <typename... Pages>
+    Pager& From(Pages... pages)
+    {
+        if (last_binding_ >= 0 && sizeof...(pages) > 0)
+        {
+            NavBinding& n = bindings_[static_cast<uint8_t>(last_binding_)];
+            if (n.kind != NavKind::Cycle)
+            {
+                n.from_mask = 0u;
+                ((n.from_mask |= PageBit(static_cast<uint8_t>(pages))), ...);
+            }
+        }
+        return *this;
+    }
+
+    /** True when the current (or just-released) Shift hold on @p b
+     *  edited a parameter — for app-side tap arbitration. */
+    bool HoldUsed(const IButton& b) const;
+
+    /* ── View latch (ParamLock, around its trigger hold): the layer
+     *    showing at RetainPage() defers its exit until ReleasePage(). ── */
+
+    void RetainPage();
+    void ReleasePage();
+
+    /** Edge detection at 1 ms; transitions happen in Update().  When
+     *  @p gated, state syncs but nothing fires. */
+    void PollButtons(uint32_t t_ms, bool gated) override;
+
+    /** Apply pending navigation, then run pot-catch on the active page.
+     *  Surfaces that may ConsumeButton() must run earlier in the frame. */
+    void Update(const float* phys, uint32_t t_ms) override;
+
+    /** Suppress this frame's release-driven navigation (frame-wide). */
     void ConsumeButton() override;
 
-    /** The page-advance button, for consume-handshake identity checks. */
-    const IButton* PageButton() const override { return b1_; }
+    /** The cycle button, for legacy identity checks; nullptr without
+     *  one.  Prefer ConsumesRelease(). */
+    const IButton* PageButton() const override;
+
+    /** True when a Cycle or Latch binding rides @p b. */
+    bool ConsumesRelease(const IButton* b) const override;
+
+    /** True while the Shift hold on @p b has edited a parameter. */
+    bool HoldClaimed(const IButton* b) const override;
+
+    /** Per-binding tint: page color on Cycle, layer color while a Shift
+     *  is engaged, member color on a Latch's own pair. */
+    LedPanel::Rgb IndicatorColor(const IButton* b) const override;
 
     uint8_t Page()        const { return page_; }
     uint8_t NumPages()    const override { return num_pages_; }
@@ -86,10 +130,7 @@ class Pager : public Serializable, public KnobStorage
     /** Catch-aware stored value for an arbitrary (page, pot). */
     float Stored(uint8_t page, uint8_t pot) const override;
 
-    /**
-     * Set a per-page indicator color. ControlLoop reads PageColor(ActivePage())
-     * each frame and paints the page-advance button accordingly.
-     */
+    /** Per-page indicator color, painted via IndicatorColor(). */
     void          SetPageColor(uint8_t page, LedPanel::Rgb c);
     LedPanel::Rgb PageColor(uint8_t page) const override;
 
@@ -99,42 +140,32 @@ class Pager : public Serializable, public KnobStorage
     /** Raw PotState for an arbitrary (page, pot). */
     PotState State(uint8_t page, uint8_t pot) const override;
 
-    /**
-     * Set the stored value for one (page, pot) and re-arm catch — the user
-     * must physically move through the new value before it responds.
-     */
+    /** Set one (page, pot) stored value and re-arm catch — the user
+     *  must move through the new value before it responds. */
     void SetStored(uint8_t page, uint8_t pot, float value, const float* phys);
 
     /** Lock catch on every pot of @p page (e.g. after a preset apply). */
     void LockPage(uint8_t page, const float* phys) override;
 
     /**
-     * Jump straight to @p page, re-arming catch exactly as an advance does.
+     * Jump straight to @p page, re-arming catch exactly as an advance
+     * does — a jump can never make a parameter leap.  Outranks
+     * navigation: an active Shift layer is cancelled outright (no
+     * return leg), and a Latch pair containing @p page adopts it.
      *
-     * The direct-addressing counterpart to the button's cyclic advance, for
-     * callers that must land on a *known* page rather than the next one — a
-     * "home" gesture, a preset that pins a page, a host command.  Catch is
-     * re-armed through `LockPage()`, so every pot on the destination page
-     * stays uncaught until the user moves through its stored value: a jump
-     * can never make a parameter leap.
-     *
-     * Out-of-range @p page is ignored.  Jumping to the page already showing
-     * still re-arms catch, so a caller driven by a *held* gesture MUST
-     * edge-trigger on the gesture forming — re-issuing this every frame of a
-     * hold would keep the pots permanently uncaught.
-     *
-     * Button-gesture state is deliberately untouched: an advance already
-     * latched from a button release this frame still applies on the next
-     * `Update()`.  If the gesture that triggered the jump also involves this
-     * pager's button, call `ConsumeButton()` alongside it.
+     * Out-of-range @p page is ignored.  Jumping to the page already
+     * showing still re-arms catch, so a caller driven by a *held*
+     * gesture MUST edge-trigger on the gesture forming.  Pending
+     * button releases are deliberately untouched; if the triggering
+     * gesture involves a bound button, call ConsumeButton() alongside.
      */
     void GoToPage(uint8_t page, const float* phys);
 
     /* ── Serializable ──────────────────────────────────────────────────
-     * Serialises the per-(page, pot) stored values.  Catch state and
-     * page index are excluded — both are re-derived against fresh phys
-     * on the next Update() (we set a flag in Deserialize that locks
-     * every page so the user must re-catch on load).
+     * Serialises the per-(page, pot) stored values.  Catch state, the
+     * page index, and navigation state are excluded — re-derived
+     * against fresh phys on the next Update() (a layer held through a
+     * load stays engaged and re-arms with the rest).
      */
     size_t   SerializedSize() const override;
     void     Serialize  (uint8_t* out) const override;
@@ -144,15 +175,78 @@ class Pager : public Serializable, public KnobStorage
     DescKind DescribeKind() const override { return DescKind::Pager; }
 
   private:
-    IButton*       b1_;
-    uint8_t        num_pages_;
-    uint8_t        num_pots_;
-    uint8_t        page_ = 0;
+    enum class NavKind : uint8_t { Cycle, Shift, Latch };
 
-    /* Button-poll state (updated by PollButtons at 1 ms cadence). */
-    bool prev_pressed_     = false;
-    bool consume_          = false;
-    bool advance_pending_  = false;
+    /** One button binding: the cycle list / Shift target / Latch pair
+     *  in `pages`, plus poll and gesture state. */
+    struct NavBinding
+    {
+        NavKind  kind             = NavKind::Cycle;
+        IButton* btn              = nullptr;
+        uint8_t  pages[kMaxPages] = {};
+        uint8_t  num_pages        = 0;
+        uint8_t  from_mask        = 0xFFu;
+
+        bool prev_pressed    = false;
+        bool press_pending   = false;
+        bool release_pending = false;
+        bool poisoned        = false;   /* press inert until its release   */
+
+        bool    active      = false;    /* Shift layer engaged             */
+        bool    used        = false;    /* the hold edited a parameter     */
+        bool    lingering   = false;    /* exit deferred by the view latch */
+        uint8_t return_page = 0;
+
+        uint8_t latch_sel = 0;          /* which pair member is remembered */
+    };
+
+    static uint8_t PageBit(uint8_t page)
+    {
+        return (page < kMaxPages) ? static_cast<uint8_t>(1u << page) : 0u;
+    }
+
+    NavBinding* AddBinding(NavKind kind, IButton& b);
+    void        AddNavPage(NavBinding& n, uint8_t page);
+
+    NavBinding*       ActiveOverlay();
+    const NavBinding* ActiveOverlay() const;
+    const NavBinding* FindBinding(const IButton* b) const;
+
+    void TryEngage      (NavBinding& b, const float* phys);
+    void EngageShift    (NavBinding& b, const float* phys);
+    void ExitShift      (NavBinding& b, const float* phys);
+    void SnapshotOverlay();
+    void AbortOverlays  ();
+    void DoCycle        (NavBinding& b, const float* phys);
+    void DoLatch        (NavBinding& b, const float* phys);
+    void Go             (uint8_t page, const float* phys);
+
+    bool    SameSlot    (uint8_t entry, uint8_t cur) const;
+    uint8_t ResolveLatch(uint8_t page) const;
+    void    SyncLatchSel(uint8_t page);
+
+    uint8_t num_pages_;
+    uint8_t num_pots_;
+    uint8_t page_ = 0;
+
+    NavBinding bindings_[kMaxBindings] = {};
+    uint8_t    num_bindings_           = 0;
+    int8_t     last_binding_           = -1;
+
+    bool consume_        = false;
+    bool prev_gated_     = false;
+
+    /* A poll-context abort (no phys[]) owes the visible page a catch
+     * re-arm, delivered by the next Update. */
+    bool relock_pending_ = false;
+
+    /* The one layer the view latch covers (nullptr: none). */
+    NavBinding* retained_ov_ = nullptr;
+
+    /* Engage-time snapshot for used-tracking: a pot caught at engage
+     * counts as used only once it moves. */
+    float   overlay_engage_[kMaxPots] = {};
+    uint8_t overlay_caught_mask_      = 0;
 
     /* Set by Deserialize; cleared by the next Update once we have a
      * phys[] to re-arm against. */

--- a/framework/include/alchemy/surface/pager.h
+++ b/framework/include/alchemy/surface/pager.h
@@ -102,7 +102,9 @@ class Pager : public Serializable, public KnobStorage
      *  Surfaces that may ConsumeButton() must run earlier in the frame. */
     void Update(const float* phys, uint32_t t_ms) override;
 
-    /** Suppress this frame's release-driven navigation (frame-wide). */
+    /** Suppress this frame's release-driven navigation, and that of any
+     *  bound button held right now (a claim with nothing held evaporates
+     *  at the end of the frame). */
     void ConsumeButton() override;
 
     /** The cycle button, for legacy identity checks; nullptr without

--- a/framework/include/alchemy/surface/param_lock.h
+++ b/framework/include/alchemy/surface/param_lock.h
@@ -25,6 +25,11 @@
  * from Update() (gestures) so playback survives modes — like the Settings
  * menu — that suspend gesture handling.
  *
+ * The RECORD gesture banks at the trigger's press edge — you lock what
+ * you were looking at, even if the page changes mid-hold — and the
+ * paged form holds the pager's view latch (Pager::RetainPage) for the
+ * duration, so a layer the recording started on stays showing.
+ *
  * Composition at the user's read site:
  *
  *   float knob(uint8_t p, void*) {
@@ -361,6 +366,8 @@ class ParamLock : public Serializable, public LockSource
     bool             prev_pressed_    = false;
     bool             rising_pending_  = false;
     bool             falling_pending_ = false;
+    /* Slot bank latched at the trigger's press edge. */
+    uint8_t          held_offset_     = 0;
     ParamLockSlot    slots_[kSlots] = {};
     ParamLockManager mgr_;
 

--- a/framework/include/alchemy/surface/param_lock_impl.h
+++ b/framework/include/alchemy/surface/param_lock_impl.h
@@ -60,17 +60,23 @@ void ParamLock<kSlots, Len>::Update(const float* phys, uint32_t /*t_ms*/)
     if (rising_pending_)
     {
         rising_pending_ = false;
+        /* Bank at the press edge; the view latch keeps a layer the
+         * recording started on showing until release. */
+        held_offset_ = Offset();
+        if (pager_) pager_->RetainPage();
         mgr_.OnButtonDown(phys);
     }
     if (falling_pending_)
     {
         falling_pending_ = false;
         const bool consumed = mgr_.OnButtonUp();
-        if (consumed && pager_) pager_->ConsumeButton();
+        if (pager_) pager_->ReleasePage();
+        if (consumed && pager_ && pager_->ConsumesRelease(trigger_))
+            pager_->ConsumeButton();
     }
 
     if (mgr_.IsButtonHeld())
-        mgr_.ProcessGestures(Offset(), phys);
+        mgr_.ProcessGestures(held_offset_, phys);
 }
 
 template<uint8_t kSlots, class Len>

--- a/framework/src/surface/button_bank.cpp
+++ b/framework/src/surface/button_bank.cpp
@@ -148,7 +148,7 @@ void ButtonBank::FireGesture(VirtualButton& b,
 {
     const bool claims =
         storage_ && hw_btns_ && hw < num_hw_
-        && hw_btns_[hw] == storage_->PageButton();
+        && storage_->ConsumesRelease(hw_btns_[hw]);
 
     if (g.fn)
     {
@@ -287,7 +287,20 @@ void ButtonBank::PollButtons(uint32_t t_ms, bool gated, uint8_t active_page)
             hs.hold_fired = 0;
         }
         if (pressed) DispatchHolds(hw, t_ms);
-        if (falling && !hs.hold_any) DispatchTaps(hw);
+        if (falling)
+        {
+            /* A hold fired during this press claims the release now —
+             * the storage's consume contract is same-frame. */
+            if (hs.hold_any && storage_
+                && storage_->ConsumesRelease(hw_btns_[hw]))
+                storage_->ConsumeButton();
+
+            /* A used hold-layer gesture suppresses the trailing tap
+             * exactly as a fired hold does. */
+            if (!hs.hold_any
+                && !(storage_ && storage_->HoldClaimed(hw_btns_[hw])))
+                DispatchTaps(hw);
+        }
     }
 }
 

--- a/framework/src/surface/control_loop.cpp
+++ b/framework/src/surface/control_loop.cpp
@@ -193,11 +193,15 @@ void ControlLoop::Render(uint32_t t_ms)
             }
         }
 
-        /* Page indicator (only meaningful when storage advertises one). */
+        /* Navigation indicators: every binding paints its own button. */
         if (storage_)
         {
-            const LedPanel::Rgb c = storage_->PageColor(active);
-            if (c.r || c.g || c.b) hw_->leds.SetButtonPair(0, c);
+            for (uint8_t i = 0; i < kNumButtons; i++)
+            {
+                const LedPanel::Rgb c =
+                    storage_->IndicatorColor(&hw_->buttons[i]);
+                if (c.r || c.g || c.b) hw_->leds.SetButtonPair(i, c);
+            }
         }
     }
 

--- a/framework/src/surface/pager.cpp
+++ b/framework/src/surface/pager.cpp
@@ -8,13 +8,13 @@
 
 namespace alchemy {
 
-/* Schema tag — bump intentionally if the on-flash layout for Pager changes. */
+/* Schema tag — bump intentionally if the on-flash layout for Pager changes.
+ * Navigation bindings are configuration, not state: 'PAG0' stands. */
 static constexpr uint32_t kPagerSchemaTag = 0x50414730u; /* 'PAG0' */
 
 
-Pager::Pager(IButton& b1, uint8_t num_pages, uint8_t num_pots)
-    : b1_(&b1),
-      num_pages_((num_pages == 0u) ? 1u
+Pager::Pager(uint8_t num_pages, uint8_t num_pots)
+    : num_pages_((num_pages == 0u) ? 1u
                  : (num_pages > kMaxPages ? kMaxPages : num_pages)),
       num_pots_((num_pots == 0u) ? 1u
                 : (num_pots > kMaxPots ? kMaxPots : num_pots))
@@ -24,47 +24,467 @@ Pager::Pager(IButton& b1, uint8_t num_pages, uint8_t num_pots)
             states_[pg][p] = PotState{0.5f, true, 0};
 }
 
+Pager::Pager(IButton& b1, uint8_t num_pages, uint8_t num_pots)
+    : Pager(num_pages, num_pots)
+{
+    Cycle(b1);   /* the classic gesture: one button, every page, in order */
+}
+
+/* ── Navigation declaration ────────────────────────────────────────────── */
+
+Pager::NavBinding* Pager::AddBinding(NavKind kind, IButton& b)
+{
+    last_binding_ = -1;
+    if (num_bindings_ >= kMaxBindings) return nullptr;
+    for (uint8_t i = 0; i < num_bindings_; i++)
+        if (bindings_[i].btn == &b) return nullptr;   /* one binding per button */
+
+    NavBinding& n = bindings_[num_bindings_];
+    n      = NavBinding{};
+    n.kind = kind;
+    n.btn  = &b;
+    last_binding_ = static_cast<int8_t>(num_bindings_);
+    num_bindings_++;
+    return &n;
+}
+
+void Pager::AddNavPage(NavBinding& n, uint8_t page)
+{
+    if (page >= num_pages_ || n.num_pages >= kMaxPages) return;
+    n.pages[n.num_pages++] = page;
+}
+
+Pager& Pager::Shift(IButton& b, uint8_t page)
+{
+    if (page >= num_pages_) { last_binding_ = -1; return *this; }
+    if (NavBinding* n = AddBinding(NavKind::Shift, b))
+    {
+        n->pages[0]  = page;
+        n->num_pages = 1u;
+    }
+    return *this;
+}
+
+Pager& Pager::Latch(IButton& b, uint8_t page_a, uint8_t page_b)
+{
+    if (page_a >= num_pages_ || page_b >= num_pages_ || page_a == page_b)
+    {
+        last_binding_ = -1;
+        return *this;
+    }
+    if (NavBinding* n = AddBinding(NavKind::Latch, b))
+    {
+        n->pages[0]  = page_a;
+        n->pages[1]  = page_b;
+        n->num_pages = 2u;
+        n->from_mask = static_cast<uint8_t>(PageBit(page_a) | PageBit(page_b));
+        n->latch_sel = (page_ == page_b) ? 1u : 0u;
+    }
+    return *this;
+}
+
+/* ── Navigation queries / handshakes ───────────────────────────────────── */
+
 void Pager::ConsumeButton() { consume_ = true; }
+
+const IButton* Pager::PageButton() const
+{
+    for (uint8_t i = 0; i < num_bindings_; i++)
+        if (bindings_[i].kind == NavKind::Cycle) return bindings_[i].btn;
+    return nullptr;
+}
+
+const Pager::NavBinding* Pager::FindBinding(const IButton* b) const
+{
+    if (!b) return nullptr;
+    for (uint8_t i = 0; i < num_bindings_; i++)
+        if (bindings_[i].btn == b) return &bindings_[i];
+    return nullptr;   /* buttons are unique per binding (AddBinding) */
+}
+
+bool Pager::ConsumesRelease(const IButton* b) const
+{
+    const NavBinding* n = FindBinding(b);
+    return n && n->kind != NavKind::Shift;
+}
+
+bool Pager::HoldClaimed(const IButton* b) const
+{
+    const NavBinding* n = FindBinding(b);
+    return n && n->kind == NavKind::Shift && n->active && n->used;
+}
+
+bool Pager::HoldUsed(const IButton& b) const
+{
+    const NavBinding* n = FindBinding(&b);
+    return n && n->kind == NavKind::Shift && n->used;
+}
+
+LedPanel::Rgb Pager::IndicatorColor(const IButton* b) const
+{
+    const NavBinding* n = FindBinding(b);
+    if (!n) return {0, 0, 0};
+    switch (n->kind)
+    {
+        case NavKind::Cycle:
+            return PageColor(page_);
+        case NavKind::Shift:
+            return n->active ? PageColor(n->pages[0]) : LedPanel::Rgb{0, 0, 0};
+        case NavKind::Latch:
+            return (page_ == n->pages[0] || page_ == n->pages[1])
+                       ? PageColor(page_)
+                       : LedPanel::Rgb{0, 0, 0};
+    }
+    return {0, 0, 0};
+}
+
+void Pager::RetainPage()  { retained_ov_ = ActiveOverlay(); }
+void Pager::ReleasePage() { retained_ov_ = nullptr; }
+
+/* ── Poll: edge detection + poison bookkeeping only ────────────────────── */
 
 void Pager::PollButtons(uint32_t /*t_ms*/, bool gated)
 {
-    const bool pressed = b1_->Pressed();
-    const bool falling = !pressed && prev_pressed_;
-    prev_pressed_ = pressed;
-    /* When gated (e.g. Settings active), keep prev synced but don't react. */
-    if (gated) return;
-    if (falling) advance_pending_ = true;
+    if (gated && !prev_gated_)
+    {
+        /* Gate rise: layers abort now, latched edges drop, in-flight
+         * presses poison until their release. */
+        AbortOverlays();
+        for (uint8_t i = 0; i < num_bindings_; i++)
+        {
+            bindings_[i].press_pending   = false;
+            bindings_[i].release_pending = false;
+        }
+    }
+
+    for (uint8_t i = 0; i < num_bindings_; i++)
+    {
+        NavBinding& b = bindings_[i];
+        const bool pressed = b.btn->Pressed();
+        const bool rising  = pressed && !b.prev_pressed;
+        const bool falling = !pressed && b.prev_pressed;
+        b.prev_pressed = pressed;
+
+        if (gated || prev_gated_)
+        {
+            /* Sync only: presses under (or spanning) the gate poison. */
+            if (pressed) b.poisoned = true;
+            if (falling)
+            {
+                b.poisoned        = false;
+                b.press_pending   = false;
+                b.release_pending = false;
+            }
+            continue;
+        }
+
+        if (rising)
+        {
+            bool other_down = false;
+            for (uint8_t j = 0; j < num_bindings_; j++)
+                if (j != i && bindings_[j].btn->Pressed()) other_down = true;
+
+            if (other_down)
+            {
+                /* Two nav buttons down = reaching for a chord:
+                 * navigation stands down. */
+                AbortOverlays();
+                for (uint8_t j = 0; j < num_bindings_; j++)
+                    if (bindings_[j].btn->Pressed())
+                        bindings_[j].poisoned = true;
+                b.poisoned = true;
+            }
+            else
+            {
+                b.poisoned      = false;
+                b.press_pending = true;
+            }
+        }
+        if (falling) b.release_pending = true;
+    }
+
+    prev_gated_ = gated;
 }
+
+/* ── Frame: apply pending navigation, then catch ───────────────────────── */
 
 void Pager::Update(const float* phys, uint32_t /*t_ms*/)
 {
-    /* Lazy re-arm after a Deserialize: we now have a phys[] to lock against. */
+    /* Lazy re-arm after a Deserialize: we now have a phys[] to lock
+     * against.  A held layer stays engaged and reads as clean again. */
     if (pending_rearm_)
     {
         pending_rearm_ = false;
         for (uint8_t pg = 0; pg < num_pages_; pg++) LockPage(pg, phys);
+        if (NavBinding* ov = ActiveOverlay())
+        {
+            SnapshotOverlay();
+            ov->used = false;
+        }
     }
 
-    if (advance_pending_)
+    /* Catch re-arm owed by a poll-context abort. */
+    if (relock_pending_)
     {
-        advance_pending_ = false;
-        if (consume_)
-        {
-            consume_ = false;
-        }
-        else
-        {
-            page_ = static_cast<uint8_t>((page_ + 1u) % num_pages_);
-            /* Lock the new page so the user must catch each pot. */
-            LockPage(page_, phys);
-        }
+        relock_pending_ = false;
+        LockPage(page_, phys);
     }
 
-    /* Run pot-catch on the currently visible page. */
+    for (uint8_t i = 0; i < num_bindings_; i++)
+    {
+        NavBinding& b = bindings_[i];
+        const bool press   = b.press_pending;
+        const bool release = b.release_pending;
+        if (!press && !release) continue;
+        b.press_pending = b.release_pending = false;
+
+        if (b.kind == NavKind::Shift)
+        {
+            if (!b.active)
+            {
+                /* Idle; press+release in one frame is a tap, no layer. */
+                b.used = false;
+                if (press && !release) TryEngage(b, phys);
+            }
+            else if (b.lingering)
+            {
+                /* Button starts UP, so press first: re-press resumes
+                 * the hold, a same-frame release ends it again. */
+                if (press) b.lingering = false;
+                if (press && release)
+                {
+                    if (retained_ov_ == &b) b.lingering = true;
+                    else                    ExitShift(b, phys);
+                }
+            }
+            else
+            {
+                /* Held: release exits (defers under the view latch). */
+                if (release)
+                {
+                    if (retained_ov_ == &b) b.lingering = true;
+                    else                    ExitShift(b, phys);
+                }
+                if (press)
+                {
+                    if (b.active) b.lingering = false;
+                    else          TryEngage(b, phys);
+                }
+            }
+            if (release) b.poisoned = false;
+            continue;
+        }
+
+        /* Cycle / Latch act on the release; the consume claim is
+         * frame-wide. */
+        if (!release) continue;
+        if (b.poisoned)      { b.poisoned = false; continue; }
+        if (consume_)        continue;
+        if (ActiveOverlay()) continue;   /* navigation waits out a held layer */
+        if (b.kind == NavKind::Cycle) DoCycle(b, phys);
+        else                          DoLatch(b, phys);
+    }
+
+    /* Complete deferred exits once the view latch no longer covers them. */
+    for (uint8_t i = 0; i < num_bindings_; i++)
+    {
+        NavBinding& b = bindings_[i];
+        if (b.lingering && retained_ov_ != &b && !b.btn->Pressed())
+            ExitShift(b, phys);
+    }
+
+    /* Pot-catch on the visible page — deliberately AFTER the releases:
+     * the release frame never absorbs pot motion, so a final-millisecond
+     * nudge cannot both edit a layer and pass for a clean tap. */
     PotState* row = &states_[page_][0];
     for (uint8_t p = 0; p < num_pots_; p++)
         UpdateCatch(row[p], phys[p]);
+
+    /* Used-tracking: a pot that took hold counts; one caught at engage
+     * counts once it moves. */
+    NavBinding* ov = ActiveOverlay();
+    if (ov && !ov->used && ov->pages[0] == page_)
+    {
+        for (uint8_t p = 0; p < num_pots_; p++)
+        {
+            if (overlay_caught_mask_ & (1u << p))
+            {
+                const float d = row[p].stored - overlay_engage_[p];
+                if (d > kCatchTolerance || d < -kCatchTolerance)
+                {
+                    ov->used = true;
+                    break;
+                }
+            }
+            else if (row[p].caught)
+            {
+                ov->used = true;
+                break;
+            }
+        }
+    }
+
+    /* Same-frame contract: an unmatched claim evaporates. */
+    consume_ = false;
 }
+
+/* ── Navigation transitions ────────────────────────────────────────────── */
+
+Pager::NavBinding* Pager::ActiveOverlay()
+{
+    for (uint8_t i = 0; i < num_bindings_; i++)
+        if (bindings_[i].kind == NavKind::Shift && bindings_[i].active)
+            return &bindings_[i];
+    return nullptr;
+}
+
+const Pager::NavBinding* Pager::ActiveOverlay() const
+{
+    return const_cast<Pager*>(this)->ActiveOverlay();
+}
+
+void Pager::TryEngage(NavBinding& b, const float* phys)
+{
+    if (b.poisoned) return;
+    if (ActiveOverlay()) { b.poisoned = true; return; } /* one layer at a time */
+    if (!(b.from_mask & PageBit(page_))) return;        /* out of scope: inert */
+    if (b.pages[0] == page_) return;                    /* already showing     */
+    EngageShift(b, phys);
+}
+
+void Pager::EngageShift(NavBinding& b, const float* phys)
+{
+    b.return_page = page_;
+    b.active      = true;
+    b.used        = false;
+    b.lingering   = false;
+    page_ = b.pages[0];
+    LockPage(page_, phys);
+    SyncLatchSel(page_);
+    SnapshotOverlay();
+}
+
+void Pager::ExitShift(NavBinding& b, const float* phys)
+{
+    b.active    = false;
+    b.lingering = false;
+    if (retained_ov_ == &b) retained_ov_ = nullptr;
+    page_ = b.return_page;
+    LockPage(page_, phys);
+    /* b.used stands until the next press — HoldUsed() reads it across
+     * the release frame. */
+}
+
+void Pager::SnapshotOverlay()
+{
+    overlay_caught_mask_ = 0u;
+    for (uint8_t p = 0; p < num_pots_; p++)
+    {
+        const PotState& s = states_[page_][p];
+        if (s.caught) overlay_caught_mask_ |= static_cast<uint8_t>(1u << p);
+        overlay_engage_[p] = s.stored;
+    }
+}
+
+/* Poll-context cancel (no phys[]): the catch re-arm is owed to the next
+ * Update via relock_pending_ — safe, catch only runs in Update. */
+void Pager::AbortOverlays()
+{
+    retained_ov_ = nullptr;
+    for (uint8_t i = 0; i < num_bindings_; i++)
+    {
+        NavBinding& b = bindings_[i];
+        if (b.kind != NavKind::Shift || !b.active) continue;
+        b.active    = false;
+        b.lingering = false;
+        page_       = b.return_page;
+        relock_pending_ = true;
+    }
+}
+
+void Pager::DoCycle(NavBinding& b, const float* phys)
+{
+    /* An empty list is the classic gesture: every page, in order. */
+    const uint8_t n = b.num_pages ? b.num_pages : num_pages_;
+    const auto entry = [&](uint8_t i) -> uint8_t
+    { return b.num_pages ? b.pages[i] : i; };
+
+    int pos = -1;   /* current page's slot; a latch pair is one slot */
+    for (uint8_t i = 0; i < n && pos < 0; i++)
+        if (SameSlot(entry(i), page_)) pos = static_cast<int>(i);
+
+    /* Advance to the first entry that LEAVES the current slot — in an
+     * implicit list a latch pair appears as two entries, and the sibling
+     * resolves straight back to the remembered member. */
+    uint8_t next = entry(static_cast<uint8_t>((pos + 1) % n));
+    for (uint8_t step = 1; step <= n; step++)
+    {
+        const uint8_t cand = entry(static_cast<uint8_t>((pos + step) % n));
+        if (!SameSlot(cand, page_))
+        {
+            next = cand;
+            break;
+        }
+    }
+    Go(ResolveLatch(next), phys);
+}
+
+void Pager::DoLatch(NavBinding& b, const float* phys)
+{
+    if (!(b.from_mask & PageBit(page_))) return;
+    uint8_t member;
+    if      (page_ == b.pages[0]) member = 1u;
+    else if (page_ == b.pages[1]) member = 0u;
+    else return;                             /* outside the pair: inert */
+    Go(b.pages[member], phys);   /* SyncLatchSel records the flip */
+}
+
+void Pager::Go(uint8_t page, const float* phys)
+{
+    page_ = page;
+    /* Lock the new page so the user must catch each pot. */
+    LockPage(page_, phys);
+    SyncLatchSel(page_);
+}
+
+bool Pager::SameSlot(uint8_t entry, uint8_t cur) const
+{
+    if (entry == cur) return true;
+    for (uint8_t i = 0; i < num_bindings_; i++)
+    {
+        const NavBinding& L = bindings_[i];
+        if (L.kind != NavKind::Latch) continue;
+        const bool has_e = (L.pages[0] == entry || L.pages[1] == entry);
+        const bool has_c = (L.pages[0] == cur   || L.pages[1] == cur);
+        if (has_e && has_c) return true;
+    }
+    return false;
+}
+
+uint8_t Pager::ResolveLatch(uint8_t page) const
+{
+    for (uint8_t i = 0; i < num_bindings_; i++)
+    {
+        const NavBinding& L = bindings_[i];
+        if (L.kind != NavKind::Latch) continue;
+        if (L.pages[0] == page || L.pages[1] == page)
+            return L.pages[L.latch_sel];
+    }
+    return page;
+}
+
+void Pager::SyncLatchSel(uint8_t page)
+{
+    for (uint8_t i = 0; i < num_bindings_; i++)
+    {
+        NavBinding& L = bindings_[i];
+        if (L.kind != NavKind::Latch) continue;
+        if      (L.pages[0] == page) L.latch_sel = 0u;
+        else if (L.pages[1] == page) L.latch_sel = 1u;
+    }
+}
+
+/* ── Storage reads / writes (unchanged) ────────────────────────────────── */
 
 float Pager::Value(uint8_t pot) const
 {
@@ -108,9 +528,18 @@ void Pager::LockPage(uint8_t page, const float* phys)
 void Pager::GoToPage(uint8_t page, const float* phys)
 {
     if (page >= num_pages_) return;
-    page_ = page;
-    /* Same catch contract as the advance branch in Update(). */
-    LockPage(page_, phys);
+    /* An explicit jump cancels any layer outright — no return leg. */
+    retained_ov_ = nullptr;
+    for (uint8_t i = 0; i < num_bindings_; i++)
+    {
+        NavBinding& b = bindings_[i];
+        if (b.kind == NavKind::Shift)
+        {
+            b.active    = false;
+            b.lingering = false;
+        }
+    }
+    Go(page, phys);
 }
 
 void Pager::SetPageColor(uint8_t page, LedPanel::Rgb c)

--- a/framework/src/surface/pager.cpp
+++ b/framework/src/surface/pager.cpp
@@ -85,7 +85,15 @@ Pager& Pager::Latch(IButton& b, uint8_t page_a, uint8_t page_b)
 
 /* ── Navigation queries / handshakes ───────────────────────────────────── */
 
-void Pager::ConsumeButton() { consume_ = true; }
+void Pager::ConsumeButton()
+{
+    consume_ = true;
+    for (uint8_t i = 0; i < num_bindings_; i++)
+    {
+        NavBinding& b = bindings_[i];
+        if (b.kind != NavKind::Shift && b.btn->Pressed()) b.poisoned = true;
+    }
+}
 
 const IButton* Pager::PageButton() const
 {

--- a/tests/host/CMakeLists.txt
+++ b/tests/host/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(hostlink_tests
     hostlink_tests.cpp
     button_tests.cpp
     fs_tests.cpp
+    pager_nav_tests.cpp
     param_lock_tests.cpp
     ram_diskio.cpp
     "${SDK_ROOT}/framework/src/host_link/host_link.cpp"

--- a/tests/host/hostlink_tests.cpp
+++ b/tests/host/hostlink_tests.cpp
@@ -42,6 +42,7 @@
 
 #include "button_tests.h"
 #include "fs_tests.h"
+#include "pager_nav_tests.h"
 #include "param_lock_tests.h"
 
 using namespace alchemy;
@@ -2090,6 +2091,7 @@ int main(int argc, char** argv)
 
     RunParamLockTests(g_checks, g_failures);
     RunButtonTests(g_checks, g_failures);
+    RunPagerNavTests(g_checks, g_failures);
     RunFsTests(g_checks, g_failures);
 
     std::printf("%d checks, %d failures\n", g_checks, g_failures);

--- a/tests/host/pager_nav_tests.cpp
+++ b/tests/host/pager_nav_tests.cpp
@@ -159,6 +159,35 @@ void TestClassicCycle()
     NCHECK_EQ(pager.ActivePage(), 2u);
 }
 
+/* ── Hold-scoped consume: a claim during a hold owns that release ──── */
+
+void TestHoldClaim()
+{
+    NavRig rig;
+    Pager  pager(rig.btn[0], 3, kPots);
+
+    /* Claim while the button is held (the chord idiom): the release
+     * that ends the hold navigates nothing, however many frames later. */
+    rig.btn[0].p = true;
+    rig.Frame(pager);
+    pager.ConsumeButton();
+    rig.Frame(pager);
+    rig.Frame(pager);
+    rig.btn[0].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+
+    /* The release clears it: the next tap cycles as usual. */
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+
+    /* A claim with nothing held still evaporates. */
+    pager.ConsumeButton();
+    rig.Frame(pager);
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 2u);
+}
+
 /* ── Gate poisoning: presses under or spanning the gate stay inert ─── */
 
 void TestGatePoisoning()
@@ -872,6 +901,7 @@ void TestLockConsumeIdentity()
 int RunPagerNavTests(int& checks, int& failures)
 {
     TestClassicCycle();
+    TestHoldClaim();
     TestGatePoisoning();
     TestShiftLifecycle();
     TestCleanHoldAndPreCaught();

--- a/tests/host/pager_nav_tests.cpp
+++ b/tests/host/pager_nav_tests.cpp
@@ -1,0 +1,897 @@
+/**
+ * @file tests/host/pager_nav_tests.cpp
+ * @brief Pager navigation-binding test battery: cycle, Shift layers,
+ *        Latch pairs, poisoning, the clean-release contract, the view
+ *        latch, and the ButtonBank / ParamLock integrations.
+ */
+
+#include "pager_nav_tests.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+#include "alchemy/surface/button_bank.h"
+#include "alchemy/surface/page.h"
+#include "alchemy/surface/pager.h"
+#include "alchemy/surface/param_lock.h"
+
+using namespace alchemy;
+
+/* ── Local check harness (totals returned to main) ─────────────────── */
+
+static int s_checks   = 0;
+static int s_failures = 0;
+
+#define NCHECK(cond)                                                       \
+    do {                                                                   \
+        s_checks++;                                                        \
+        if (!(cond)) {                                                     \
+            s_failures++;                                                  \
+            std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);    \
+        }                                                                  \
+    } while (0)
+
+#define NCHECK_EQ(a, b)                                                    \
+    do {                                                                   \
+        s_checks++;                                                        \
+        const auto va = (a);                                               \
+        const auto vb = (b);                                               \
+        if (!(va == vb)) {                                                 \
+            s_failures++;                                                  \
+            std::printf("FAIL %s:%d  %s == %s  (%lld != %lld)\n",          \
+                        __FILE__, __LINE__, #a, #b,                        \
+                        (long long)va, (long long)vb);                     \
+        }                                                                  \
+    } while (0)
+
+#define NCHECK_NEAR(a, b, tol)                                             \
+    do {                                                                   \
+        s_checks++;                                                        \
+        const float va = (a);                                              \
+        const float vb = (b);                                              \
+        if (!(std::fabs(va - vb) <= (tol))) {                              \
+            s_failures++;                                                  \
+            std::printf("FAIL %s:%d  %s ~= %s  (%.6f vs %.6f)\n",          \
+                        __FILE__, __LINE__, #a, #b, va, vb);               \
+        }                                                                  \
+    } while (0)
+
+namespace {
+
+/* ── Fakes and drivers ─────────────────────────────────────────────── */
+
+constexpr uint8_t kPots = 6;
+
+struct NavBtn : IButton
+{
+    bool p = false;
+
+    bool  Pressed() const override { return p; }
+    bool  RisingEdge() override  { return false; }
+    bool  FallingEdge() override { return false; }
+    float TimeHeldMs() const override { return 0.f; }
+};
+
+struct NavRig
+{
+    NavBtn   btn[3];
+    float    phys[kPots];
+    uint32_t t = 0;
+
+    NavRig() { for (uint8_t i = 0; i < kPots; i++) phys[i] = 0.5f; }
+
+    /** One control frame: 1 ms polls, then Update — which the loop
+     *  skips while gated, as ControlLoop does. */
+    void Frame(Pager& pager, bool gated = false, uint8_t polls = 4)
+    {
+        for (uint8_t i = 0; i < polls; i++) pager.PollButtons(++t, gated);
+        if (!gated) pager.Update(phys, t);
+    }
+
+    void Tap(Pager& pager, uint8_t b)
+    {
+        btn[b].p = true;
+        Frame(pager);
+        btn[b].p = false;
+        Frame(pager);
+    }
+};
+
+bool SameRgb(LedPanel::Rgb a, LedPanel::Rgb b)
+{
+    return a.r == b.r && a.g == b.g && a.b == b.b;
+}
+
+/* ── Classic cycle: the pre-binding contract, unchanged ────────────── */
+
+void TestClassicCycle()
+{
+    NavRig rig;
+    Pager  pager(rig.btn[0], 3, kPots);
+
+    NCHECK_EQ(pager.ActivePage(), 0u);
+    NCHECK(pager.PageButton() == &rig.btn[0]);
+    NCHECK(pager.ConsumesRelease(&rig.btn[0]));
+    NCHECK(!pager.ConsumesRelease(&rig.btn[1]));
+
+    /* The press alone does nothing; the clean release advances. */
+    rig.btn[0].p = true;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+    rig.btn[0].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+
+    /* Wraps around the full pool. */
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 2u);
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+
+    /* An advance re-arms catch on the destination page. */
+    pager.SetStored(1, 0, 0.9f, rig.phys);
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+    NCHECK(!pager.Caught(0));
+    NCHECK_NEAR(pager.Value(0), 0.9f, 1e-6f);   /* uncaught: holds stored */
+    rig.phys[0] = 0.95f;                        /* crosses 0.9 */
+    rig.Frame(pager);
+    NCHECK(pager.Caught(0));
+    NCHECK_NEAR(pager.Value(0), 0.95f, 1e-6f);  /* caught: follows the pot */
+    rig.phys[0] = 0.5f;
+    rig.Frame(pager);
+
+    /* Same-frame consume suppresses exactly this release's advance. */
+    rig.btn[0].p = true;
+    rig.Frame(pager);
+    rig.btn[0].p = false;
+    pager.PollButtons(++rig.t, false);
+    pager.ConsumeButton();                      /* consumer ran this frame */
+    pager.Update(rig.phys, rig.t);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+
+    /* A stray claim (no release this frame) evaporates. */
+    pager.ConsumeButton();
+    rig.Frame(pager);
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 2u);
+}
+
+/* ── Gate poisoning: presses under or spanning the gate stay inert ─── */
+
+void TestGatePoisoning()
+{
+    NavRig rig;
+    Pager  pager(rig.btn[0], 3, kPots);
+
+    /* Pressed under the gate, released after it: no advance.  (This is
+     * the documented fix: the pre-binding pager advanced here.) */
+    rig.btn[0].p = true;
+    rig.Frame(pager, /*gated=*/true);
+    rig.Frame(pager, false);                    /* gate lifted, still held */
+    rig.btn[0].p = false;
+    rig.Frame(pager, false);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+
+    /* Pressed before the gate, released under it: dropped. */
+    rig.btn[0].p = true;
+    rig.Frame(pager, false);
+    rig.btn[0].p = false;
+    rig.Frame(pager, true);
+    rig.Frame(pager, false);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+
+    /* A clean press after the window still works. */
+    rig.Frame(pager, false);
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+
+    /* A release latched just before the gate rises is dropped —
+     * Settings closing must not fire a stale advance. */
+    rig.btn[0].p = true;
+    rig.Frame(pager, false);
+    rig.btn[0].p = false;
+    pager.PollButtons(++rig.t, false);          /* release latched...   */
+    rig.Frame(pager, true);                     /* ...then gate, no Update */
+    rig.Frame(pager, true);
+    rig.Frame(pager, false);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+}
+
+/* ── Shift: lifecycle, catch both ways, the no-smear invariant ─────── */
+
+void TestShiftLifecycle()
+{
+    NavRig rig;
+    Pager  pager(3, kPots);
+    pager.Cycle(rig.btn[0], 0, 1).Shift(rig.btn[1], 2);
+
+    NCHECK(pager.PageButton() == &rig.btn[0]);
+    NCHECK(!pager.ConsumesRelease(&rig.btn[1]));  /* shift is hold-driven */
+
+    /* Base pot 0 caught at 0.30; the layer's stored value sits at 0.80. */
+    rig.phys[0] = 0.30f;
+    pager.SetStored(0, 0, 0.30f, rig.phys);
+    pager.SetStored(2, 0, 0.80f, rig.phys);
+    rig.Frame(pager);
+    NCHECK(pager.Caught(0));
+    const float base_before = pager.Stored(0, 0);
+
+    /* Engage on press: the layer shows, catch re-armed. */
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 2u);
+    NCHECK(!pager.Caught(0));
+    NCHECK(!pager.HoldClaimed(&rig.btn[1]));
+
+    /* Approaching without crossing edits nothing. */
+    rig.phys[0] = 0.60f;
+    rig.Frame(pager);
+    NCHECK(!pager.Caught(0));
+    NCHECK_NEAR(pager.Stored(2, 0), 0.80f, 1e-6f);
+    NCHECK(!pager.HoldClaimed(&rig.btn[1]));
+
+    /* Crossing takes hold; the stored value follows; the hold is used. */
+    rig.phys[0] = 0.85f;
+    rig.Frame(pager);
+    NCHECK(pager.Caught(0));
+    rig.phys[0] = 0.90f;
+    rig.Frame(pager);
+    NCHECK_NEAR(pager.Stored(2, 0), 0.90f, 1e-6f);
+    NCHECK(pager.HoldClaimed(&rig.btn[1]));
+    NCHECK(pager.HoldUsed(rig.btn[1]));
+
+    /* The base page never smeared: bit-identical through the hold. */
+    NCHECK(pager.Stored(0, 0) == base_before);
+
+    /* Release: return page, catch re-armed against the parked pot, no
+     * value leap; HoldUsed still readable across the release frame. */
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+    NCHECK(!pager.Caught(0));
+    NCHECK(pager.Stored(0, 0) == base_before);
+    NCHECK(pager.HoldUsed(rig.btn[1]));
+
+    /* Sweep back through the base value to re-own the knob. */
+    rig.phys[0] = 0.25f;
+    rig.Frame(pager);
+    NCHECK(pager.Caught(0));
+
+    /* The layer kept the edit. */
+    NCHECK_NEAR(pager.Stored(2, 0), 0.90f, 1e-6f);
+}
+
+/* ── Clean releases, and the pre-caught pot guard ──────────────────── */
+
+void TestCleanHoldAndPreCaught()
+{
+    NavRig rig;
+    Pager  pager(2, kPots);
+    pager.Shift(rig.btn[1], 1);
+
+    /* All defaults sit under their pots: pre-caught at engage.  Touch
+     * nothing — the hold is clean. */
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    rig.Frame(pager);
+    NCHECK(!pager.HoldClaimed(&rig.btn[1]));
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK(!pager.HoldUsed(rig.btn[1]));
+    NCHECK_EQ(pager.ActivePage(), 0u);
+
+    /* A pre-caught pot that MOVES counts as used. */
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    rig.phys[2] = 0.62f;
+    rig.Frame(pager);
+    NCHECK(pager.HoldClaimed(&rig.btn[1]));
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK(pager.HoldUsed(rig.btn[1]));
+    rig.phys[2] = 0.5f;
+}
+
+/* ── Sub-frame tap: press+release between two Updates ──────────────── */
+
+void TestSubFrameTap()
+{
+    NavRig rig;
+    Pager  pager(2, kPots);
+    pager.Shift(rig.btn[1], 1);
+
+    rig.btn[1].p = true;
+    pager.PollButtons(++rig.t, false);
+    rig.btn[1].p = false;
+    pager.PollButtons(++rig.t, false);
+    pager.Update(rig.phys, rig.t);
+    NCHECK_EQ(pager.ActivePage(), 0u);          /* the layer never shows */
+    NCHECK(!pager.HoldClaimed(&rig.btn[1]));    /* and the tap is clean  */
+
+    /* A normal hold still engages afterwards. */
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+}
+
+/* ── Chord reach: two nav buttons down → navigation stands down ────── */
+
+void TestChordReach()
+{
+    NavRig rig;
+    Pager  pager(3, kPots);
+    pager.Shift(rig.btn[1], 1).Shift(rig.btn[2], 2);
+
+    /* Co-press while a layer is held: abort, both presses poisoned. */
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+    rig.btn[2].p = true;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+
+    rig.btn[2].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+
+    /* Fresh presses work again. */
+    rig.btn[2].p = true;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 2u);
+    rig.btn[2].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+}
+
+/* ── Gate rise mid-hold: the layer aborts, the press poisons ───────── */
+
+void TestGateAbortsLayer()
+{
+    NavRig rig;
+    Pager  pager(2, kPots);
+    pager.Shift(rig.btn[1], 1);
+
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+
+    /* Settings opens: the layer aborts immediately (poll context);
+     * the catch re-arm lands on the first post-gate Update. */
+    rig.Frame(pager, /*gated=*/true);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+    rig.Frame(pager, true);
+    rig.Frame(pager, false);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+
+    /* The surviving press stays poisoned until released. */
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+
+    /* And a clean press engages again. */
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+}
+
+/* ── Latch pairs + the cycle-slot resolution (the issue-#16 UI) ────── */
+
+void TestLatchAndCycleResolution()
+{
+    enum : uint8_t { kVar = 0, kRnd = 1, kRev = 2 };
+
+    NavRig rig;
+    Pager  pager(3, kPots);
+    pager.Cycle(rig.btn[0], kVar, kRev).Latch(rig.btn[2], kVar, kRnd);
+
+    NCHECK(pager.ConsumesRelease(&rig.btn[2]));
+
+    /* The pair toggles while a member is showing. */
+    rig.Tap(pager, 2);
+    NCHECK_EQ(pager.ActivePage(), kRnd);
+    rig.Tap(pager, 2);
+    NCHECK_EQ(pager.ActivePage(), kVar);
+    rig.Tap(pager, 2);
+    NCHECK_EQ(pager.ActivePage(), kRnd);
+
+    /* The pair occupies one cycle slot: from RND, B1 leaves for Reverb. */
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), kRev);
+
+    /* Off the pair the latch button is inert. */
+    rig.Tap(pager, 2);
+    NCHECK_EQ(pager.ActivePage(), kRev);
+
+    /* Cycling back lands on the REMEMBERED member. */
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), kRnd);
+}
+
+/* ── Latch pair inside an IMPLICIT cycle list must not trap the cycle ── */
+
+void TestLatchInImplicitCycle()
+{
+    NavRig rig;
+    Pager  pager(rig.btn[0], 4, kPots);          /* classic ctor: all pages */
+    pager.Latch(rig.btn[2], 2, 3);
+
+    /* The pair appears as two implicit entries; cycling must step over
+     * the sibling member instead of parking forever on the pair. */
+    rig.Tap(pager, 0);
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 2u);           /* pair, remembered = 2 */
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 0u);           /* NOT stuck on 2/3 */
+
+    /* The remembered member survives the loop. */
+    rig.Tap(pager, 2);                           /* inert off the pair */
+    rig.Tap(pager, 0);
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 2u);
+}
+
+/* ── Shift .From() scoping ─────────────────────────────────────────── */
+
+void TestShiftFromScope()
+{
+    NavRig rig;
+    Pager  pager(3, kPots);
+    pager.Cycle(rig.btn[0], 0, 1).Shift(rig.btn[1], 2).From(0);
+
+    /* In scope: engages. */
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 2u);
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+
+    /* Out of scope: inert, and the hold stays clean. */
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+    NCHECK(!pager.HoldClaimed(&rig.btn[1]));
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK(!pager.HoldUsed(rig.btn[1]));
+
+    /* A used hold must not leave HoldUsed() sticking to a later press
+     * that never engages. */
+    rig.Tap(pager, 0);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    rig.phys[0] = 0.9f;                          /* pre-caught pot moves */
+    rig.Frame(pager);
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK(pager.HoldUsed(rig.btn[1]));
+    rig.phys[0] = 0.5f;
+    rig.Tap(pager, 0);                           /* to page 1: out of scope */
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    NCHECK(!pager.HoldUsed(rig.btn[1]));         /* fresh, never engaged */
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK(!pager.HoldUsed(rig.btn[1]));
+}
+
+/* ── GoToPage outranks a held layer ────────────────────────────────── */
+
+void TestGoToPageCancelsLayer()
+{
+    NavRig rig;
+    Pager  pager(3, kPots);
+    pager.Shift(rig.btn[1], 1);
+
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+
+    pager.GoToPage(2, rig.phys);
+    NCHECK_EQ(pager.ActivePage(), 2u);
+
+    /* The cancelled hold's release has no return leg. */
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 2u);
+}
+
+/* ── A preset landing mid-hold re-arms; the layer stays engaged ────── */
+
+void TestDeserializeMidHold()
+{
+    NavRig rig;
+
+    /* Source image: known values on both pages. */
+    Pager src(2, kPots);
+    src.SetStored(0, 0, 0.20f, rig.phys);
+    src.SetStored(1, 0, 0.70f, rig.phys);
+    std::vector<uint8_t> blob(src.SerializedSize());
+    src.Serialize(blob.data());
+
+    Pager pager(2, kPots);
+    pager.Shift(rig.btn[1], 1);
+
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);
+
+    NCHECK(pager.Deserialize(blob.data()));
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);          /* still held, still showing */
+    NCHECK_NEAR(pager.Stored(1, 0), 0.70f, 1e-6f);
+    NCHECK_NEAR(pager.Stored(0, 0), 0.20f, 1e-6f);
+    NCHECK(!pager.Caught(0));                   /* re-armed against the pot */
+
+    /* The load rewrote the values but the USER edited nothing: clean. */
+    NCHECK(!pager.HoldClaimed(&rig.btn[1]));
+
+    /* Editing after the load counts as usual. */
+    rig.phys[0] = 0.72f;                        /* crosses the loaded 0.70 */
+    rig.Frame(pager);
+    NCHECK(pager.HoldClaimed(&rig.btn[1]));
+    rig.phys[0] = 0.5f;
+
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+}
+
+/* ── The view latch (RetainPage / ReleasePage) ─────────────────────── */
+
+void TestViewLatch()
+{
+    NavRig rig;
+    Pager  pager(2, kPots);
+    pager.Shift(rig.btn[1], 1);
+
+    /* Retain begins while the layer shows: its exit defers. */
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    pager.RetainPage();
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);          /* lingering */
+
+    /* Catch keeps absorbing on the lingering layer. */
+    rig.phys[1] = 0.8f;
+    rig.Frame(pager);
+    NCHECK(pager.HoldClaimed(&rig.btn[1]));     /* still claims its button */
+
+    pager.ReleasePage();
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+    NCHECK_NEAR(pager.Stored(1, 1), 0.8f, 1e-6f);
+    rig.phys[1] = 0.5f;
+    rig.Frame(pager);
+
+    /* Re-pressed during the linger: the hold resumes. */
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    pager.RetainPage();
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    pager.ReleasePage();
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);          /* held normally again */
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+
+    /* A layer engaged AFTER the retain began is not covered. */
+    pager.RetainPage();
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);          /* exits immediately */
+    pager.ReleasePage();
+
+    /* A sub-frame tap during the linger must re-linger, not leave a
+     * zombie-active layer. */
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    pager.RetainPage();
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 1u);          /* lingering */
+    rig.btn[1].p = true;
+    pager.PollButtons(++rig.t, false);
+    rig.btn[1].p = false;
+    pager.PollButtons(++rig.t, false);
+    pager.Update(rig.phys, rig.t);
+    NCHECK_EQ(pager.ActivePage(), 1u);          /* still lingering */
+    pager.ReleasePage();
+    rig.Frame(pager);
+    NCHECK_EQ(pager.ActivePage(), 0u);          /* latch drop still exits */
+}
+
+/* ── ButtonBank hold gestures shadow release-driven navigation ─────── */
+
+void TestBankHoldShadowsCycle()
+{
+    constexpr uint8_t kHw0 = 0;
+
+    NavRig rig;
+    Pager  pager(rig.btn[0], 2, kPots);
+
+    static int  s_hold_fires = 0;
+    static auto hold_fn      = +[](void*) { s_hold_fires++; };
+    s_hold_fires = 0;
+
+    VirtualButton act = VirtualButton(kHw0, "Action").Ident("act")
+                            .Hold(8, hold_fn, "Do the thing");
+    Page          pg  = Page(0);
+    pg.Buttons(act);
+
+    IButton*   refs[3] = {&rig.btn[0], &rig.btn[1], &rig.btn[2]};
+    ButtonBank bank;
+    bank.Attach(refs, 3).Pages(pg);
+    bank.AttachStorage(&pager);
+
+    auto frame = [&](uint8_t polls = 4) {
+        for (uint8_t i = 0; i < polls; i++)
+        {
+            bank.PollButtons(++rig.t, false, pager.ActivePage());
+            pager.PollButtons(rig.t, false);
+        }
+        pager.Update(rig.phys, rig.t);
+        bank.Update(rig.t);
+    };
+
+    /* The hold fires once; the much-later release advances nothing. */
+    rig.btn[0].p = true;
+    for (int i = 0; i < 5; i++) frame();        /* ≥ 8 ms held */
+    NCHECK_EQ(s_hold_fires, 1);
+    rig.btn[0].p = false;
+    frame();
+    NCHECK_EQ(pager.ActivePage(), 0u);          /* shadowed */
+
+    /* A plain tap (no gesture fired) still advances the page. */
+    rig.btn[0].p = true;
+    frame(2);
+    rig.btn[0].p = false;
+    frame();
+    NCHECK_EQ(pager.ActivePage(), 1u);
+}
+
+/* ── Indicator colors per binding ──────────────────────────────────── */
+
+void TestIndicatorColors()
+{
+    constexpr LedPanel::Rgb kRed   = {0xFF, 0x00, 0x00};
+    constexpr LedPanel::Rgb kGreen = {0x00, 0xFF, 0x00};
+    constexpr LedPanel::Rgb kBlue  = {0x00, 0x00, 0xFF};
+    constexpr LedPanel::Rgb kOff   = {0x00, 0x00, 0x00};
+
+    NavRig rig;
+    Pager  pager(3, kPots);
+    pager.Cycle(rig.btn[0], 0, 1).Shift(rig.btn[1], 2);
+    pager.SetPageColor(0, kRed);
+    pager.SetPageColor(1, kGreen);
+    pager.SetPageColor(2, kBlue);
+
+    NCHECK(SameRgb(pager.IndicatorColor(&rig.btn[0]), kRed));
+    NCHECK(SameRgb(pager.IndicatorColor(&rig.btn[1]), kOff));
+    NCHECK(SameRgb(pager.IndicatorColor(&rig.btn[2]), kOff));
+
+    rig.Tap(pager, 0);
+    NCHECK(SameRgb(pager.IndicatorColor(&rig.btn[0]), kGreen));
+
+    rig.btn[1].p = true;
+    rig.Frame(pager);
+    NCHECK(SameRgb(pager.IndicatorColor(&rig.btn[1]), kBlue));
+    rig.btn[1].p = false;
+    rig.Frame(pager);
+    NCHECK(SameRgb(pager.IndicatorColor(&rig.btn[1]), kOff));
+}
+
+/* ── ButtonBank composition: hold-to-shift + tap on one button ─────── */
+
+void TestBankTapComposition()
+{
+    constexpr uint8_t kHw1 = 1;
+
+    NavRig rig;
+    Pager  pager(2, kPots);
+    pager.Shift(rig.btn[1], 1);
+
+    VirtualButton mute = VirtualButton(kHw1, "Mute").Ident("mute").Toggle();
+    Page          pg   = Page(0);
+    pg.Buttons(mute);
+
+    IButton*   refs[3] = {&rig.btn[0], &rig.btn[1], &rig.btn[2]};
+    ButtonBank bank;
+    bank.Attach(refs, 3).Pages(pg);
+    bank.AttachStorage(&pager);
+
+    /* ControlLoop's order: bank polls before storage. */
+    auto frame = [&](uint8_t polls = 4) {
+        for (uint8_t i = 0; i < polls; i++)
+        {
+            bank.PollButtons(++rig.t, false, pager.ActivePage());
+            pager.PollButtons(rig.t, false);
+        }
+        pager.Update(rig.phys, rig.t);
+        bank.Update(rig.t);
+    };
+
+    NCHECK_EQ(bank.ZoneOf(mute), 0u);
+
+    /* Clean hold: the layer shows, nothing edits, the tap fires. */
+    rig.btn[1].p = true;
+    frame();
+    frame();
+    NCHECK_EQ(pager.ActivePage(), 1u);
+    rig.btn[1].p = false;
+    frame();
+    NCHECK_EQ(bank.ZoneOf(mute), 1u);
+    NCHECK_EQ(pager.ActivePage(), 0u);
+
+    /* Used hold: a pot edit claims the release; the tap stays quiet. */
+    rig.btn[1].p = true;
+    frame();
+    rig.phys[0] = 0.9f;                         /* pre-caught pot moves */
+    frame();
+    rig.btn[1].p = false;
+    frame();
+    NCHECK_EQ(bank.ZoneOf(mute), 1u);           /* unchanged */
+    NCHECK_EQ(pager.ActivePage(), 0u);
+    rig.phys[0] = 0.5f;
+}
+
+/* ── ParamLock: press-edge bank latch + the consume handshake ──────── */
+
+void TestLockBankLatchAndConsume()
+{
+    NavRig rig;
+    Pager  pager(2, kPots);
+    pager.Shift(rig.btn[1], 1);
+    ParamLock<static_cast<uint8_t>(2 * kPots)> locks(rig.btn[0], pager);
+
+    /* One frame in the canonical order: locks update before the pager. */
+    auto frame = [&](bool gated = false) {
+        locks.SetFrameMs(16u);
+        for (uint8_t i = 0; i < 4; i++)
+        {
+            locks.PollButtons(++rig.t, gated);
+            pager.PollButtons(rig.t, gated);
+        }
+        locks.Advance();
+        if (!gated)
+        {
+            locks.Update(rig.phys, rig.t);
+            pager.Update(rig.phys, rig.t);
+        }
+    };
+
+    /* Engage the layer, then start a lock hold on it. */
+    rig.btn[1].p = true;
+    frame();
+    NCHECK_EQ(pager.ActivePage(), 1u);
+    rig.btn[0].p = true;
+    frame();                                    /* bank latched to page 1 */
+
+    /* Release the layer button mid-hold: the view latch keeps the layer
+     * showing and its catch running. */
+    rig.btn[1].p = false;
+    frame();
+    NCHECK_EQ(pager.ActivePage(), 1u);
+
+    /* Nudge past the gesture threshold: the recording lands in the
+     * press-time bank — the layer's — not the base page's. */
+    rig.phys[0] = 0.70f;
+    frame();
+    frame();
+    NCHECK(locks.IsRecordingAtPage(1, 0));
+    NCHECK(!locks.IsRecordingAtPage(0, 0));
+
+    /* Trigger up: the deferred exit completes on the same frame. */
+    rig.btn[0].p = false;
+    frame();
+    NCHECK_EQ(pager.ActivePage(), 0u);
+    rig.phys[0] = 0.5f;
+    frame();
+
+    /* An explicit jump mid-hold cannot retarget the recording either. */
+    rig.btn[0].p = true;
+    frame();                                    /* bank latched to page 0 */
+    pager.GoToPage(1, rig.phys);
+    frame();
+    rig.phys[1] = 0.75f;
+    frame();
+    frame();
+    NCHECK(locks.IsRecordingAtPage(0, 1));
+    NCHECK(!locks.IsRecordingAtPage(1, 1));
+    rig.btn[0].p = false;
+    frame();
+    rig.phys[1] = 0.5f;
+    pager.GoToPage(0, rig.phys);
+    frame();
+}
+
+void TestLockConsumeIdentity()
+{
+    NavRig rig;
+    Pager  pager(2, kPots);
+    pager.Latch(rig.btn[0], 0, 1);              /* release-driven, on B1 */
+    ParamLock<static_cast<uint8_t>(2 * kPots)> locks(rig.btn[0], pager);
+
+    auto frame = [&] {
+        locks.SetFrameMs(16u);
+        for (uint8_t i = 0; i < 4; i++)
+        {
+            locks.PollButtons(++rig.t, false);
+            pager.PollButtons(rig.t, false);
+        }
+        locks.Advance();
+        locks.Update(rig.phys, rig.t);
+        pager.Update(rig.phys, rig.t);
+    };
+
+    /* A hold-and-nudge lock gesture consumes its release: the latch on
+     * the same button must not also toggle. */
+    rig.btn[0].p = true;
+    frame();
+    rig.phys[0] = 0.70f;
+    frame();
+    frame();
+    rig.btn[0].p = false;
+    frame();
+    NCHECK_EQ(pager.ActivePage(), 0u);          /* consumed, no toggle */
+    rig.phys[0] = 0.5f;
+    frame();
+
+    /* A clean tap on the same button is not consumed: the latch fires. */
+    rig.btn[0].p = true;
+    frame();
+    rig.btn[0].p = false;
+    frame();
+    NCHECK_EQ(pager.ActivePage(), 1u);
+}
+
+} // namespace
+
+int RunPagerNavTests(int& checks, int& failures)
+{
+    TestClassicCycle();
+    TestGatePoisoning();
+    TestShiftLifecycle();
+    TestCleanHoldAndPreCaught();
+    TestSubFrameTap();
+    TestChordReach();
+    TestGateAbortsLayer();
+    TestLatchAndCycleResolution();
+    TestLatchInImplicitCycle();
+    TestShiftFromScope();
+    TestBankHoldShadowsCycle();
+    TestGoToPageCancelsLayer();
+    TestDeserializeMidHold();
+    TestViewLatch();
+    TestIndicatorColors();
+    TestBankTapComposition();
+    TestLockBankLatchAndConsume();
+    TestLockConsumeIdentity();
+
+    std::printf("pager-nav: %d checks, %d failures\n", s_checks, s_failures);
+    checks   += s_checks;
+    failures += s_failures;
+    return s_failures == 0 ? 0 : 1;
+}

--- a/tests/host/pager_nav_tests.h
+++ b/tests/host/pager_nav_tests.h
@@ -1,0 +1,9 @@
+/**
+ * @file tests/host/pager_nav_tests.h
+ * @brief Pager navigation-binding test battery.
+ */
+
+#pragma once
+
+/** Run the pager navigation tests.  Adds to the caller's totals. */
+int RunPagerNavTests(int& checks, int& failures);


### PR DESCRIPTION
Shift layers are pages. Page navigation is declared per button on `Pager`: `.Cycle(btn, pages...)`, `.Shift(btn, page)`, `.Latch(btn, a, b)`, `.From(pages...)`. A held layer gets pot catch, presets, locks, CV routing, ring rendering, and the descriptor with no layer-specific code. The `Pager(b1, n, m)` constructor and the `'PAG0'` schema are unchanged.

Also: the clean-release contract (`Pager::HoldUsed()`, `KnobStorage::HoldClaimed()`), a scoped `ConsumeButton()` claim, Settings-gate and chord arbitration, per-button navigation indicators through `KnobStorage::IndicatorColor()`, and `ParamLock` banking its record gesture at the press edge. Guide: `docs/pages-and-layers.md`. Host tests: `tests/host/pager_nav_tests.cpp`.
