### PR TITLE
ClockFollower: fixes for fast external clocks

### DIFF
--- a/framework/include/alchemy/control/clock_follower.h
+++ b/framework/include/alchemy/control/clock_follower.h
@@ -15,9 +15,11 @@
  *     follower_.Update(now_us);
  *     clock_.Tick(now_us);
  *
- * `OnPulse` is reentrant against the poll path: a couple of word stores.
- * Safe to call from an EXTI ISR if a platform wires clock to a GPIO
- * interrupt instead of polling a CV.
+ * Phase error is measured at pulse-stamp time (anchored to
+ * `MusicalClock::LastTickUs`), so the `Update` / `Tick` order is not
+ * load-bearing.  `OnPulse` is ISR-safe against the poll path via a
+ * single-producer ring: safe from an EXTI or UART ISR, one pulse source
+ * at a time.
  */
 
 #pragma once
@@ -109,13 +111,13 @@ class ClockFollower
 
     /* ── Pulse intake ────────────────────────────────────────────────── */
 
-    /** Deposit a rising-edge timestamp (µs) for the next `Update`.  Cheap;
-     *  reentrant against the poll path.  Multiple pulses within a single
-     *  poll interval is implausible at musical tempos — the newest stamp
-     *  wins (spec §4.1). */
+    /** Deposit a rising-edge timestamp (µs).  Cheap; ISR-safe against the
+     *  poll path.  Pulses are ring-buffered so a poll delayed past a
+     *  pulse period (fast clocks + frame work) drops nothing.  Single
+     *  producer: wire one pulse source at a time. */
     void OnPulse(uint32_t stamp_us);
 
-    /** Per-poll work: consume any pending pulse, update period EMA, run
+    /** Per-poll work: drain buffered pulses, update the period EMA, run
      *  the PI controller, detect loss.  Call once per ~1 ms poll. */
     void Update(uint32_t now_us);
 
@@ -138,11 +140,13 @@ class ClockFollower
     void SetGains(float kp, float ki, float ema_alpha);
 
   private:
-    void RecomputeLimits();
-    void HandleLoss(uint32_t now_us);
-    void AnchorPhase();
-    void DeclareLock();
-    void SeedRateFromPeriod();
+    bool   ConsumePulse(uint32_t stamp_us);
+    double FracTickAt(uint32_t stamp_us) const;
+    void   RecomputeLimits();
+    void   HandleLoss(uint32_t now_us);
+    void   AnchorPhase(uint32_t stamp_us);
+    void   DeclareLock(uint32_t stamp_us);
+    void   SeedRateFromPeriod();
 
     MusicalClock* nco_;
 
@@ -157,9 +161,15 @@ class ClockFollower
     float ki_         = kClockPllKi;
     float ema_alpha_  = kClockEmaAlpha;
 
-    /* ── ISR ↔ poll handoff ─────────────────────────────────────────── */
-    volatile uint32_t pulse_stamp_us_ = 0u;
-    volatile bool     pulse_pending_  = false;
+    /* ── ISR ↔ poll handoff: SPSC ring, ISR owns head, `Update` owns
+     *    tail (free-running indices).  8 deep buys 66 ms of poll stall
+     *    at kClockBpmMax / 24 PPQN — beyond `kClockMaxTickDtUs`. ────── */
+    static constexpr uint32_t kPulseRingSize = 8u;
+    static_assert((kPulseRingSize & (kPulseRingSize - 1u)) == 0u,
+                  "free-running ring indices need a power-of-two size");
+    volatile uint32_t pulse_ring_[kPulseRingSize] = {};
+    volatile uint32_t ring_head_ = 0u;
+    volatile uint32_t ring_tail_ = 0u;
 
     /* ── State ──────────────────────────────────────────────────────── */
     bool     locked_            = false;
@@ -168,8 +178,8 @@ class ClockFollower
     uint32_t valid_pulse_count_ = 0u;
     double   period_est_us_     = 0.0;
     double   integrator_        = 0.0;
-    uint64_t last_pulse_tick_   = 0u;
-    double   last_pulse_frac_   = 0.0;
+    uint64_t last_pulse_tick_   = 0u;   /* NCO position at the last     */
+    double   last_pulse_frac_   = 0.0;  /* accepted pulse's stamp time  */
     bool     loss_announced_    = false;
 
     /* ── Validity window (µs) ───────────────────────────────────────── */

--- a/framework/include/alchemy/control/musical_clock.h
+++ b/framework/include/alchemy/control/musical_clock.h
@@ -190,6 +190,8 @@ class MusicalClock
      *  sub-tick phase error: `delta = (master - anchor_tick) + (frac - anchor_frac)`. */
     double   FracTick() const { return frac_tick_; }
 
+    uint32_t LastTickUs() const { return last_us_; }
+
     /** Continuous position within the current beat, [0, 1). */
     float BeatPhase() const;
 

--- a/framework/src/control/clock_follower.cpp
+++ b/framework/src/control/clock_follower.cpp
@@ -36,7 +36,7 @@ void ClockFollower::Enable(uint32_t ext_ppqn)
     period_est_us_     = 0.0;
     integrator_        = 0.0;
     loss_announced_    = false;
-    pulse_pending_     = false;
+    ring_tail_         = ring_head_; /* discard pulses from before Enable */
 
     /* Stop the NCO and zero its rate so it does not free-run at the old
      * internal tempo while waiting for first lock (azoth
@@ -54,7 +54,6 @@ void ClockFollower::Disable()
     enabled_        = false;
     locked_         = false;
     loss_announced_ = false;
-    pulse_pending_  = false;
     if (nco_ != nullptr)
         nco_->SetSteered(false);
 }
@@ -119,48 +118,32 @@ void ClockFollower::OnReset()
 void ClockFollower::OnPulse(uint32_t stamp_us)
 {
     if (!enabled_) return;
-    /* Single-pulse mailbox: stamp first, then pending flag.  Reader
-     * (Update) checks pending → clears it → reads stamp.  A concurrent
-     * second pulse during Update overwrites stamp; the spec accepts
-     * newest-wins (§4.1).  Safe from EXTI ISR on Cortex-M7 (word stores
-     * are atomic). */
-    pulse_stamp_us_ = stamp_us;
-    pulse_pending_  = true;
+    /* SPSC: this side owns head, `Update` owns tail; the volatile head
+     * store publishes the slot (single-core, in-order vs ISR).  Full ⇒
+     * drop — a ring-length stall exceeds the loss threshold anyway. */
+    const uint32_t head = ring_head_;
+    if (head - ring_tail_ >= kPulseRingSize) return;
+    pulse_ring_[head % kPulseRingSize] = stamp_us;
+    ring_head_ = head + 1u;
 }
 
-/* ── Per-poll work ─────────────────────────────────────────────────────── */
-
-void ClockFollower::Update(uint32_t now_us)
+/* Per-pulse intake: seeding, validity window, period EMA, lock
+ * acquisition.  True ⇒ the pulse extended the valid stream. */
+bool ClockFollower::ConsumePulse(uint32_t stamp_us)
 {
-    if (!enabled_ || nco_ == nullptr) return;
-
-    /* ── Loss detection (runs every poll, independent of pulse arrival) */
-    if (have_last_stamp_ && period_est_us_ > 0.0 && !loss_announced_)
-    {
-        const uint32_t dt_since = now_us - last_pulse_stamp_;
-        const double   thresh   = period_est_us_ * static_cast<double>(kClockLossFactor);
-        if (static_cast<double>(dt_since) > thresh)
-            HandleLoss(now_us);
-    }
-
-    /* ── Consume a pending pulse, if any */
-    if (!pulse_pending_) return;
-    pulse_pending_         = false;
-    const uint32_t stamp   = pulse_stamp_us_;
-
     if (!have_last_stamp_)
     {
-        last_pulse_stamp_  = stamp;
+        last_pulse_stamp_  = stamp_us;
         have_last_stamp_   = true;
         valid_pulse_count_ = 1u;
         loss_announced_    = false;
-        return;
+        return false;
     }
 
-    const uint32_t dt = stamp - last_pulse_stamp_;
+    const uint32_t dt = stamp_us - last_pulse_stamp_;
 
     if (dt < min_period_us_)
-        return; /* glitch — ignore */
+        return false; /* glitch — ignore */
 
     if (dt > max_period_us_)
     {
@@ -170,13 +153,12 @@ void ClockFollower::Update(uint32_t now_us)
         locked_            = false;
         loss_announced_    = false;
         valid_pulse_count_ = 1u;
-        last_pulse_stamp_  = stamp;
+        last_pulse_stamp_  = stamp_us;
         period_est_us_     = 0.0;
         integrator_        = 0.0;
-        return;
+        return false;
     }
 
-    /* ── Valid pulse ────────────────────────────────────────────────── */
     const double dt_d = static_cast<double>(dt);
     if (period_est_us_ <= 0.0)
         period_est_us_ = dt_d;
@@ -184,32 +166,72 @@ void ClockFollower::Update(uint32_t now_us)
         period_est_us_ += static_cast<double>(ema_alpha_)
                        * (dt_d - period_est_us_);
 
-    last_pulse_stamp_ = stamp;
+    last_pulse_stamp_ = stamp_us;
     ++valid_pulse_count_;
     loss_announced_   = false;
 
-    /* ── Lock acquisition ──────────────────────────────────────────── */
-    if (!locked_)
+    if (!locked_ && valid_pulse_count_ >= kClockLockPulses)
+        DeclareLock(stamp_us);
+
+    return true;
+}
+
+/* ── Per-poll work ─────────────────────────────────────────────────────── */
+
+void ClockFollower::Update(uint32_t now_us)
+{
+    if (!enabled_ || nco_ == nullptr) return;
+
+    /* ── Drain the ring (bounded by the head snapshot).  `accepted`
+     *    counts valid pulses consumed while already locked — the PI's
+     *    expected NCO travel scales with it. */
+    const uint32_t head     = ring_head_;
+    uint32_t       accepted = 0u;
+    for (uint32_t tail = ring_tail_; tail != head;)
     {
-        if (valid_pulse_count_ >= kClockLockPulses)
-            DeclareLock();
-        return; /* no PI step until locked */
+        const uint32_t stamp = pulse_ring_[tail % kPulseRingSize];
+        ring_tail_           = ++tail;
+
+        const bool was_locked = locked_;
+        if (ConsumePulse(stamp) && was_locked)
+            ++accepted;
     }
 
-    /* ── PI controller (post-lock) ─────────────────────────────────── */
+    /* ── Loss detection.  After the drain so buffered pulses count as
+     *    heard; signed because a pulse can stamp after `now_us` was
+     *    sampled at the top of the poll. */
+    if (have_last_stamp_ && period_est_us_ > 0.0 && !loss_announced_)
+    {
+        const int32_t dt_since =
+            static_cast<int32_t>(now_us - last_pulse_stamp_);
+        const double thresh =
+            period_est_us_ * static_cast<double>(kClockLossFactor);
+        if (dt_since > 0 && static_cast<double>(dt_since) > thresh)
+        {
+            HandleLoss(now_us);
+            return;
+        }
+    }
+
+    if (!locked_ || accepted == 0u)
+        return;
+
+    /* ── PI controller (post-lock).  Both ends of the phase delta are
+     *    taken at pulse-stamp time (`FracTickAt`), so drain lateness
+     *    cancels out of the phase error. */
     const double ticks_per_pulse =
         static_cast<double>(nco_->Ppqn()) / static_cast<double>(ext_ppqn_);
 
-    const uint64_t mtick = nco_->MasterTick();
-    const double   frac  = nco_->FracTick();
+    const uint64_t mtick         = nco_->MasterTick();
+    const double   frac_at_stamp = FracTickAt(last_pulse_stamp_);
 
     /* Wrap-safe even past 2^64 ticks because the unsigned subtraction
      * mods over 2^64; in practice master_tick_ tops out at ~6 trillion
      * years at 96 PPQN / 300 BPM so this is theoretical. */
-    const double delta_int  = static_cast<double>(mtick - last_pulse_tick_);
-    const double delta_frac = frac - last_pulse_frac_;
-    const double delta      = delta_int + delta_frac;
-    const double phase_err  = ticks_per_pulse - delta;
+    const double delta = static_cast<double>(mtick - last_pulse_tick_)
+                       + (frac_at_stamp - last_pulse_frac_);
+    const double phase_err =
+        static_cast<double>(accepted) * ticks_per_pulse - delta;
 
     integrator_ += phase_err;
     integrator_  = Clamp(integrator_,
@@ -230,19 +252,31 @@ void ClockFollower::Update(uint32_t now_us)
 
     nco_->SetTicksPerUs(rate_per_sec * 1e-6);
 
-    /* Update anchor for next pulse's phase-error measurement. */
+    /* Anchor for the next measurement. */
     last_pulse_tick_ = mtick;
-    last_pulse_frac_ = frac;
+    last_pulse_frac_ = frac_at_stamp;
 }
 
 /* ── State transitions ─────────────────────────────────────────────────── */
 
-void ClockFollower::DeclareLock()
+/* NCO fractional position extrapolated from the last `Tick` to a pulse
+ * stamp; exact while the rate is constant across the span. */
+double ClockFollower::FracTickAt(uint32_t stamp_us) const
+{
+    const int32_t span_us =
+        static_cast<int32_t>(stamp_us - nco_->LastTickUs());
+    return nco_->FracTick()
+         + nco_->TicksPerUs() * static_cast<double>(span_us);
+}
+
+void ClockFollower::DeclareLock(uint32_t stamp_us)
 {
     locked_ = true;
 
+    /* Anchor before seeding: the extrapolation in AnchorPhase must use
+     * the rate the NCO has been integrating with. */
+    AnchorPhase(stamp_us);
     SeedRateFromPeriod();
-    AnchorPhase();
     integrator_ = 0.0;
 
     nco_->OrPendingEvent(CLK_EV::EXT_LOCK);
@@ -260,10 +294,10 @@ void ClockFollower::SeedRateFromPeriod()
     nco_->SetTicksPerUs(rate_per_sec * 1e-6);
 }
 
-void ClockFollower::AnchorPhase()
+void ClockFollower::AnchorPhase(uint32_t stamp_us)
 {
     last_pulse_tick_ = nco_->MasterTick();
-    last_pulse_frac_ = nco_->FracTick();
+    last_pulse_frac_ = FracTickAt(stamp_us);
 }
 
 void ClockFollower::HandleLoss(uint32_t /*now_us*/)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,4 +22,9 @@ target_link_libraries(cv_input_test PRIVATE alchemy::primitives)
 
 add_test(NAME cv_input COMMAND cv_input_test)
 
+add_executable(clock_follower_test clock_follower_test.cpp)
+target_link_libraries(clock_follower_test PRIVATE alchemy::primitives)
+
+add_test(NAME clock_follower COMMAND clock_follower_test)
+
 add_subdirectory(host)

--- a/tests/clock_follower_test.cpp
+++ b/tests/clock_follower_test.cpp
@@ -1,0 +1,200 @@
+/**
+ * @file clock_follower_test.cpp
+ * @brief Host tests for ClockFollower under fast external clocks and
+ *        delayed polls: pulse ring, k-pulse PI target, stamp-time phase.
+ */
+
+#include "alchemy/control/clock_follower.h"
+#include "alchemy/control/musical_clock.h"
+
+#include <cmath>
+#include <cstdio>
+
+namespace {
+
+int failures = 0;
+
+#define CHECK(cond)                                                        \
+    do {                                                                    \
+        if (!(cond))                                                        \
+        {                                                                   \
+            std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);     \
+            ++failures;                                                     \
+        }                                                                   \
+    } while (0)
+
+constexpr double kExtPpqn = 24.0;
+
+/* Deterministic jitter source. */
+uint32_t Lcg(uint32_t& s)
+{
+    s = s * 1664525u + 1013904223u;
+    return s;
+}
+
+/* External source + poll-loop rig.  Pulses are stamped at their exact
+ * time (as an ISR would) even when the next poll runs late. */
+struct Rig
+{
+    alchemy::MusicalClock  clock;
+    alchemy::ClockFollower follower{clock};
+
+    uint32_t now_us     = 0u;
+    double   next_pulse = 1000.0;
+    double   period_us  = 0.0;
+    uint32_t events     = 0u;
+    bool     tick_first = false;
+
+    explicit Rig(double bpm)
+    {
+        SetSourceBpm(bpm);
+        follower.SetAutoStart(true);
+        follower.Enable(24u);
+    }
+
+    void SetSourceBpm(double bpm) { period_us = 60e6 / (bpm * kExtPpqn); }
+
+    void Poll()
+    {
+        while (next_pulse <= static_cast<double>(now_us))
+        {
+            follower.OnPulse(static_cast<uint32_t>(next_pulse));
+            next_pulse += period_us;
+        }
+        if (tick_first)
+        {
+            clock.Tick(now_us);
+            follower.Update(now_us);
+        }
+        else
+        {
+            follower.Update(now_us);
+            clock.Tick(now_us);
+        }
+        events |= clock.Events();
+    }
+};
+
+/* 135 BPM / 24 PPQN (~18.5 ms pulses) polled at 1 ms with a 30–45 ms
+ * frame stall every 25 polls, so drains carry 2–3 pulses.  The old
+ * single-slot mailbox dropped all but the newest and wobbled by tens of
+ * BPM; drain-time phase measurement hunted at ±3%. */
+void TestFastClockSlowPolls()
+{
+    Rig      r(135.0);
+    uint32_t seed    = 1u;
+    double   max_dev = 0.0;
+    int      poll_i  = 0;
+
+    while (r.now_us < 8000000u)
+    {
+        r.Poll();
+        if (r.now_us > 4000000u)
+        {
+            const double dev = std::fabs(static_cast<double>(r.clock.Bpm()) - 135.0);
+            if (dev > max_dev) max_dev = dev;
+        }
+        r.now_us += (++poll_i % 25 == 0) ? 30000u + Lcg(seed) % 15001u : 1000u;
+    }
+
+    CHECK(r.follower.Locked());
+    CHECK(std::fabs(r.follower.Bpm() - 135.0f) <= 0.5f);
+    CHECK(max_dev <= 0.5);
+}
+
+/* Same schedule under both Update/Tick orders: the stamp-time anchor
+ * (MusicalClock::LastTickUs) makes the wiring order non-critical. */
+void TestOrderInsensitive()
+{
+    Rig a(135.0);
+    Rig b(135.0);
+    b.tick_first = true;
+
+    uint32_t seed   = 7u;
+    int      poll_i = 0;
+    while (a.now_us < 6000000u)
+    {
+        a.Poll();
+        b.Poll();
+        const uint32_t step =
+            (++poll_i % 25 == 0) ? 30000u + Lcg(seed) % 15001u : 1000u;
+        a.now_us += step;
+        b.now_us += step;
+    }
+
+    CHECK(std::fabs(a.clock.Bpm() - 135.0f) <= 0.5f);
+    CHECK(std::fabs(b.clock.Bpm() - 135.0f) <= 0.5f);
+    CHECK(std::fabs(a.clock.Bpm() - b.clock.Bpm()) <= 0.2f);
+}
+
+/* A 230 ms stall queues 12 pulses: the ring keeps 8 and drops 4, the
+ * loss threshold trips, and the follower re-locks warm and converges. */
+void TestRingOverflowRelock()
+{
+    Rig r(135.0);
+    while (r.now_us < 2000000u) { r.Poll(); r.now_us += 1000u; }
+    CHECK(r.follower.Locked());
+    r.events = 0u;
+
+    r.now_us += 230000u; /* stall: pulses queue, no polls */
+    while (r.now_us < 6000000u) { r.Poll(); r.now_us += 1000u; }
+
+    CHECK((r.events & alchemy::CLK_EV::EXT_LOST) != 0u);
+    CHECK((r.events & alchemy::CLK_EV::EXT_LOCK) != 0u);
+    CHECK(r.follower.Locked());
+    CHECK(std::fabs(r.follower.Bpm() - 135.0f) <= 0.5f);
+    CHECK(std::fabs(r.clock.Bpm() - 135.0f) <= 0.5f);
+}
+
+/* Source steps 120 → 140 BPM; follower re-converges without unlocking. */
+void TestTempoStep()
+{
+    Rig r(120.0);
+    while (r.now_us < 3000000u) { r.Poll(); r.now_us += 1000u; }
+    CHECK(std::fabs(r.clock.Bpm() - 120.0f) <= 0.5f);
+
+    r.SetSourceBpm(140.0);
+    while (r.now_us < 9000000u) { r.Poll(); r.now_us += 1000u; }
+
+    CHECK(r.follower.Locked());
+    CHECK((r.events & alchemy::CLK_EV::EXT_LOST) == 0u);
+    CHECK(std::fabs(r.follower.Bpm() - 140.0f) <= 0.5f);
+    CHECK(std::fabs(r.clock.Bpm() - 140.0f) <= 0.5f);
+}
+
+/* A sub-millisecond double-trigger is rejected by the validity window
+ * and must not perturb the estimate. */
+void TestGlitchRejected()
+{
+    Rig r(135.0);
+    while (r.now_us < 3000000u) { r.Poll(); r.now_us += 1000u; }
+    const float before = r.follower.Bpm();
+
+    const uint32_t glitch =
+        static_cast<uint32_t>(r.next_pulse - r.period_us) + 300u;
+    r.follower.OnPulse(glitch);
+    for (int i = 0; i < 2000; ++i) { r.Poll(); r.now_us += 1000u; }
+
+    CHECK(r.follower.Locked());
+    CHECK(std::fabs(r.follower.Bpm() - before) <= 0.1f);
+    CHECK(std::fabs(r.follower.Bpm() - 135.0f) <= 0.5f);
+}
+
+} // namespace
+
+int main()
+{
+    TestFastClockSlowPolls();
+    TestOrderInsensitive();
+    TestRingOverflowRelock();
+    TestTempoStep();
+    TestGlitchRejected();
+
+    if (failures)
+    {
+        std::printf("%d failure(s)\n", failures);
+        return 1;
+    }
+    std::printf("all clock follower tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
Delayed polls against 24 PPQN dropped pulses (±20 BPM wobble) and fed drain jitter into the PI (±3% hunt). Fixes: SPSC pulse ring, k-pulse PI target, stamp-time phase anchored to new `MusicalClock::LastTickUs()`.