### PR TITLE
Pot conditioning: 20 Hz input filter and motion gate

### DIFF
--- a/framework/include/alchemy/control/pot_catch.h
+++ b/framework/include/alchemy/control/pot_catch.h
@@ -28,6 +28,15 @@ constexpr float    kCatchTolerance             = 0.005f;
 /** Minimum physical nudge (0..1) required to start / stop param-lock. */
 constexpr float    kParamLockGestureThreshold  = 0.03f;
 
+/** Motion gate: travel off a sleeping stored value required to wake. */
+constexpr float    kPotWakeThreshold           = 0.004f;
+
+/** Motion gate: stillness band around the awake anchor. */
+constexpr float    kPotStillBand               = 0.0015f;
+
+/** Motion gate: stillness time before an awake pot sleeps. */
+constexpr uint32_t kPotSleepMs                 = 400u;
+
 /* ── PotState ─────────────────────────────────────────────────────────── */
 
 /**
@@ -37,12 +46,19 @@ constexpr float    kParamLockGestureThreshold  = 0.03f;
  * caught       True once the physical position has caught the stored value.
  * sign_at_lock Sign of (phys - stored) at the moment catch was disabled;
  *              used for crossover detection.
+ *
+ * anchor / last_move_ms / awake — motion-gate state, used only by the
+ * timed UpdateCatch overload.
  */
 struct PotState
 {
     float stored       = 0.5f;
     bool  caught       = true;
     int   sign_at_lock = 0;
+
+    float    anchor       = 0.5f;
+    uint32_t last_move_ms = 0u;
+    bool     awake        = false;
 };
 
 
@@ -84,9 +100,12 @@ inline void InitCatch(PotState& s, float phys)
         s.caught       = false;
         s.sign_at_lock = (diff > 0.0f) ? 1 : -1;
     }
+    /* Gate parks asleep: the value holds until genuine motion. */
+    s.awake  = false;
+    s.anchor = phys;
 }
 
-/** Update catch state each UI tick. */
+/** Untimed legacy update — raw follow while caught, no motion gate. */
 inline void UpdateCatch(PotState& s, float phys)
 {
     if (s.caught)
@@ -109,6 +128,61 @@ inline void UpdateCatch(PotState& s, float phys)
         s.caught = true;
         s.stored = phys;
     }
+}
+
+/**
+ * Timed update with a motion gate.  Caught + asleep holds stored
+ * bit-exact; waking takes > kPotWakeThreshold of travel; awake tracks
+ * phys 1:1 and sleeps after kPotSleepMs inside kPotStillBand.
+ */
+inline void UpdateCatch(PotState& s, float phys, uint32_t t_ms)
+{
+    if (s.caught)
+    {
+        if (!s.awake)
+        {
+            const float d = phys - s.stored;
+            if (d > kPotWakeThreshold || d < -kPotWakeThreshold)
+            {
+                s.awake        = true;
+                s.anchor       = phys;
+                s.last_move_ms = t_ms;
+                s.stored       = phys;
+            }
+            return;
+        }
+
+        s.stored      = phys;
+        const float d = phys - s.anchor;
+        if (d > kPotStillBand || d < -kPotStillBand)
+        {
+            s.anchor       = phys;
+            s.last_move_ms = t_ms;
+        }
+        else if (t_ms - s.last_move_ms > kPotSleepMs)  /* wrap-safe */
+        {
+            s.awake = false;
+        }
+        return;
+    }
+
+    const float diff = phys - s.stored;
+    if (diff > -kCatchTolerance && diff < kCatchTolerance)
+    {
+        s.caught = true;
+        s.stored = phys;
+    }
+    else
+    {
+        const int cur_sign = (diff > 0.0f) ? 1 : -1;
+        if (s.sign_at_lock == 0 || cur_sign == s.sign_at_lock) return;
+        s.caught = true;
+        s.stored = phys;
+    }
+    /* A fresh catch means the user is on the pot. */
+    s.awake        = true;
+    s.anchor       = phys;
+    s.last_move_ms = t_ms;
 }
 
 } // namespace alchemy

--- a/framework/src/surface/pager.cpp
+++ b/framework/src/surface/pager.cpp
@@ -216,7 +216,7 @@ void Pager::PollButtons(uint32_t /*t_ms*/, bool gated)
 
 /* ── Frame: apply pending navigation, then catch ───────────────────────── */
 
-void Pager::Update(const float* phys, uint32_t /*t_ms*/)
+void Pager::Update(const float* phys, uint32_t t_ms)
 {
     /* Lazy re-arm after a Deserialize: we now have a phys[] to lock
      * against.  A held layer stays engaged and reads as clean again. */
@@ -306,7 +306,7 @@ void Pager::Update(const float* phys, uint32_t /*t_ms*/)
      * nudge cannot both edit a layer and pass for a clean tap. */
     PotState* row = &states_[page_][0];
     for (uint8_t p = 0; p < num_pots_; p++)
-        UpdateCatch(row[p], phys[p]);
+        UpdateCatch(row[p], phys[p], t_ms);
 
     /* Used-tracking: a pot that took hold counts; one caught at engage
      * counts once it moves. */

--- a/framework/src/surface/settings.cpp
+++ b/framework/src/surface/settings.cpp
@@ -302,23 +302,23 @@ void Settings::Update(const float* phys, uint32_t t_ms)
                 break;
 
             case SettingsKind::Brightness:
-                UpdateCatch(s.pot, phys[p]);
+                UpdateCatch(s.pot, phys[p], t_ms);
                 ApplyBrightnessSlot(s);
                 break;
 
             case SettingsKind::Knob:
-                UpdateCatch(s.pot, phys[p]);
+                UpdateCatch(s.pot, phys[p], t_ms);
                 s.value = s.pot.stored;
                 break;
 
             case SettingsKind::Bipolar:
-                UpdateCatch(s.pot, phys[p]);
+                UpdateCatch(s.pot, phys[p], t_ms);
                 s.value = (s.pot.stored - 0.5f) * 2.0f;
                 break;
 
             case SettingsKind::Selector:
             {
-                UpdateCatch(s.pot, phys[p]);
+                UpdateCatch(s.pot, phys[p], t_ms);
                 float v = s.pot.stored;
                 if (v < 0.0f) v = 0.0f;
                 if (v > 1.0f) v = 1.0f;

--- a/hardware/alchemy-lab/v2/src/alchemy_lab_v2.cpp
+++ b/hardware/alchemy-lab/v2/src/alchemy_lab_v2.cpp
@@ -18,6 +18,9 @@ namespace alchemy {
 
 AlchemyLabV2* AlchemyLabV2::s_instance_ = nullptr;
 
+/* 20 Hz pot one-pole at the 1 kHz ProcessAllControls() cadence. */
+static constexpr float kPotLpCoeff = 0.1181f; /* 1 - exp(-2π·20/1000) */
+
 void AlchemyLabV2::Init(daisy::SaiHandle::Config::SampleRate sample_rate,
                         uint32_t                             block_size)
 {
@@ -50,6 +53,16 @@ void AlchemyLabV2::Init(daisy::SaiHandle::Config::SampleRate sample_rate,
     const float sr = seed.AudioCallbackRate();
     for (uint8_t i = 0; i < kNumPots; i++)
         pots[i].Init(seed.adc.GetPtr(i), sr, kPotPolarityFlipped, false, 0.0f);
+
+    /* Init's slew arg is calibrated to the audio-callback rate, so set
+     * the pot coeff directly; prime through the slew-0 pass-through so
+     * val_ starts on-position instead of converging from 0. */
+    daisy::System::Delay(2); /* first ADC scan */
+    for (uint8_t i = 0; i < kNumPots; i++)
+    {
+        pots[i].Process();
+        pots[i].SetCoeff(kPotLpCoeff);
+    }
 
     /* 3) On-MCU buttons (B1, B2) ──────────────────────────────────────── */
     for (uint8_t i = 0; i < kNumOnMcuButtons; i++)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,4 +27,9 @@ target_link_libraries(clock_follower_test PRIVATE alchemy::primitives)
 
 add_test(NAME clock_follower COMMAND clock_follower_test)
 
+add_executable(pot_gate_test pot_gate_test.cpp)
+target_link_libraries(pot_gate_test PRIVATE alchemy::primitives)
+
+add_test(NAME pot_gate COMMAND pot_gate_test)
+
 add_subdirectory(host)

--- a/tests/pot_gate_test.cpp
+++ b/tests/pot_gate_test.cpp
@@ -1,0 +1,203 @@
+/**
+ * @file pot_gate_test.cpp
+ * @brief Host tests for the pot motion gate (timed UpdateCatch).
+ */
+
+#include "alchemy/control/pot_catch.h"
+
+#include <cstdint>
+#include <cstdio>
+
+namespace {
+
+int failures = 0;
+
+#define CHECK(cond)                                                        \
+    do {                                                                    \
+        if (!(cond))                                                        \
+        {                                                                   \
+            std::printf("FAIL %s:%d  %s\n", __FILE__, __LINE__, #cond);     \
+            ++failures;                                                     \
+        }                                                                   \
+    } while (0)
+
+/* Deterministic xorshift32 → uniform in [-1, 1). */
+struct Rng
+{
+    uint32_t s = 0x1234567u;
+    float    Next()
+    {
+        s ^= s << 13;
+        s ^= s >> 17;
+        s ^= s << 5;
+        return static_cast<float>(s) / 2147483648.0f - 1.0f;
+    }
+};
+
+constexpr uint32_t kFrameMs = 16u;
+
+/* Asleep + sub-threshold noise: stored stays bit-exact for 10 s. */
+void TestHoldAsleep()
+{
+    alchemy::PotState s;
+    Rng               rng;
+    uint32_t          t = 0;
+    for (int i = 0; i < 625; i++)
+    {
+        alchemy::UpdateCatch(s, 0.5f + 3e-4f * rng.Next(), t += kFrameMs);
+        CHECK(s.stored == 0.5f);
+        CHECK(!s.awake);
+    }
+}
+
+/* A step past the threshold wakes in one call with no lost travel. */
+void TestWakeNoLostTravel()
+{
+    alchemy::PotState s;
+    const float       phys = 0.505f;
+    alchemy::UpdateCatch(s, phys, kFrameMs);
+    CHECK(s.awake);
+    CHECK(s.stored == phys);
+}
+
+/* Awake tracks phys exactly — no quantization, no filtering. */
+void TestTrackExact()
+{
+    alchemy::PotState s;
+    uint32_t          t = 0;
+    alchemy::UpdateCatch(s, 0.51f, t += kFrameMs); /* wake */
+    for (int i = 0; i < 100; i++)
+    {
+        const float phys = 0.51f + 0.003f * static_cast<float>(i);
+        alchemy::UpdateCatch(s, phys, t += kFrameMs);
+        CHECK(s.stored == phys);
+        CHECK(s.awake);
+    }
+}
+
+/* Full travel over 60 s: never sleeps mid-sweep, ends on target. */
+void TestSlowSweepStaysLive()
+{
+    alchemy::PotState s{0.0f, true, 0};
+    uint32_t          t    = 0;
+    bool              woke = false;
+    for (int i = 0; i <= 3750; i++)
+    {
+        const float phys = static_cast<float>(i) / 3750.0f;
+        alchemy::UpdateCatch(s, phys, t += kFrameMs);
+        if (s.awake) woke = true;
+        if (woke) CHECK(s.awake);
+    }
+    CHECK(woke);
+    CHECK(s.stored == 1.0f);
+}
+
+/* Stillness past kPotSleepMs sleeps; stored then freezes under noise. */
+void TestSleepThenFreeze()
+{
+    alchemy::PotState s;
+    uint32_t          t = 0;
+    alchemy::UpdateCatch(s, 0.6f, t += kFrameMs); /* wake */
+    CHECK(s.awake);
+    for (int i = 0; i < 30; i++)
+        alchemy::UpdateCatch(s, 0.6f, t += kFrameMs);
+    CHECK(!s.awake);
+
+    const float frozen = s.stored;
+    Rng         rng;
+    for (int i = 0; i < 100; i++)
+    {
+        alchemy::UpdateCatch(s, 0.6f + 3e-4f * rng.Next(), t += kFrameMs);
+        CHECK(s.stored == frozen);
+    }
+}
+
+/* Post-filter-scale noise must not block re-sleep after a wake. */
+void TestResleepUnderNoise()
+{
+    alchemy::PotState s;
+    uint32_t          t = 0;
+    alchemy::UpdateCatch(s, 0.6f, t += kFrameMs); /* wake */
+    Rng rng;
+    for (int i = 0; i < 60; i++)
+        alchemy::UpdateCatch(s, 0.6f + 1e-4f * rng.Next(), t += kFrameMs);
+    CHECK(!s.awake);
+}
+
+/* Sleep timing survives uint32 t_ms wrap-around. */
+void TestTimerWrap()
+{
+    alchemy::PotState s;
+    uint32_t          t = 0xFFFFFF00u;
+    alchemy::UpdateCatch(s, 0.7f, t); /* wake */
+    CHECK(s.awake);
+    for (int i = 0; i < 40; i++)
+    {
+        t += kFrameMs; /* wraps past 0 */
+        alchemy::UpdateCatch(s, 0.7f, t);
+    }
+    CHECK(!s.awake);
+}
+
+/* Untimed overload keeps today's semantics: raw follow, no gate. */
+void TestLegacyUntimed()
+{
+    alchemy::PotState s;
+    alchemy::UpdateCatch(s, 0.512345f);
+    CHECK(s.stored == 0.512345f);
+    alchemy::UpdateCatch(s, 0.5121f);
+    CHECK(s.stored == 0.5121f);
+
+    alchemy::PotState u{0.5f, false, 1};
+    alchemy::UpdateCatch(u, 0.6f); /* same side: still uncaught */
+    CHECK(!u.caught);
+    alchemy::UpdateCatch(u, 0.4f); /* crossover */
+    CHECK(u.caught);
+    CHECK(u.stored == 0.4f);
+}
+
+/* Proximity and crossover catches enter awake; InitCatch parks asleep. */
+void TestCatchTransitions()
+{
+    alchemy::PotState a{0.5f, false, 1};
+    alchemy::UpdateCatch(a, 0.502f, kFrameMs);
+    CHECK(a.caught);
+    CHECK(a.awake);
+
+    alchemy::PotState b{0.5f, false, 1};
+    alchemy::UpdateCatch(b, 0.4f, kFrameMs);
+    CHECK(b.caught);
+    CHECK(b.awake);
+
+    alchemy::PotState c;
+    c.stored = 0.3f;
+    alchemy::InitCatch(c, 0.3f);
+    CHECK(c.caught);
+    CHECK(!c.awake);
+    alchemy::InitCatch(c, 0.9f);
+    CHECK(!c.caught);
+    CHECK(!c.awake);
+}
+
+} // namespace
+
+int main()
+{
+    TestHoldAsleep();
+    TestWakeNoLostTravel();
+    TestTrackExact();
+    TestSlowSweepStaysLive();
+    TestSleepThenFreeze();
+    TestResleepUnderNoise();
+    TestTimerWrap();
+    TestLegacyUntimed();
+    TestCatchTransitions();
+
+    if (failures)
+    {
+        std::printf("%d failure(s)\n", failures);
+        return 1;
+    }
+    std::printf("pot_gate_test: all tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
Pots feed params unfiltered, and a pot in control copies its physical value
into the stored value every UI frame. Every pot-driven param therefore
drifts with ADC noise at idle. Log delay-time taper on echoa was bad (pitch warble on repeats). This fixes the whole pot path.

- BSP: 20 Hz one-pole on pot inputs at the 1 kHz poll cadence.
- Motion gate on the per-frame follow (new timed UpdateCatch overload):
  an idle pot holds its stored value bit-exact, waking takes 0.004 of
  travel, a moving pot tracks 1:1, and it sleeps again after 400 ms of
  stillness.
