### PR TITLE
Builders: reject braced-list temporaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,15 @@ rings, and the descriptor for free (#16).
 - New: `docs/pages-and-layers.md` and a host test battery
   (`tests/host/pager_nav_tests.cpp`).
 
+## Builders reject braced-list temporaries (#33)
+
+- Table builders (`Selector`, `Labels`, `Colors`, `Buttons`, `Jacks`)
+  reject a braced list at compile time: it was a temporary, and the
+  retained pointer dangled.  Name the array.
+- `VirtualButton::Colors(ptr, n)` no longer defaults `n`; `.Colors(kArray)`
+  had resolved to this overload with no count, so the zone-count check
+  never ran.
+
 # Alchemy SDK v0.10.0 — 2026-08-19
 
 Modules can now ship their own documentation, and the descriptor build

--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -1,10 +1,8 @@
 # Buttons: VirtualButton + ButtonBank
 
-A button that cycles a filter mode touches five concerns: edge polling,
-persistence, HostLink description, LED feedback, and the DSP-side
-effect.  Hand-rolled, those are five separate pieces of code that must
-agree on one field id and one byte layout, and nothing checks that they
-do.  `VirtualButton` + `ButtonBank` collapse them into one declaration:
+A button that cycles a filter mode involves edge polling, persistence,
+HostLink description, LED feedback, and the DSP-side effect.
+`VirtualButton` + `ButtonBank` declare all five in one place:
 
 ```cpp
 static const char* kModes[3] = {"LP", "BP", "HP"};
@@ -27,30 +25,30 @@ int main()
 }
 ```
 
-Everything else is derived: with no declared gesture the button
-tap-cycles (two zones read as a toggle), the browser shows an editable
-"Filter" enum inside page Alpha labeled "Cycle LP / BP / HP", presets
-carry the zone, and `Bind` keeps `SetFilterMode` current on gestures
-and preset loads alike.  `flt.Zone()` is the pull-style read for code
-that prefers polling in `OnFrame`.
+Everything else is derived. With no declared gesture the button
+tap-cycles (two zones act as a toggle). The browser shows an editable
+"Filter" enum inside its page, labeled "Cycle LP / BP / HP". Presets
+carry the zone. `Bind` keeps `SetFilterMode` current on gestures and
+preset loads. `flt.Zone()` returns the current zone for code that polls
+in `OnFrame`.
 
 ## The model
 
-`VirtualButton` is the twin of `VirtualKnob`, and `ButtonBank` is its
-`Pager`: the surface that owns the state.  The declared object is pure
-description; the bank persists, dispatches, renders, and describes.
+`VirtualButton` is to `ButtonBank` what `VirtualKnob` is to `Pager`: the
+bank owns the state. The declared object is description only; the bank
+persists, dispatches, renders, and describes.
 
-One deliberate asymmetry: knob state is keyed by *(page, pot)* because
-a physical pot has a position that must be reconciled per page — that
-is what pot-catch exists for.  A button has no position, so state is
-keyed by the **VirtualButton object**.  Pages are pure dispatch scope:
+Knob state is keyed by *(page, pot)* because a physical pot's position
+must be reconciled per page; that is what pot-catch does. A button has
+no position, so its state is keyed by the **VirtualButton object**.
+Pages only scope dispatch:
 
 - The same physical button does different things on different pages by
   declaring one VirtualButton per page (`page_a.Buttons(flt)`,
-  `page_b.Buttons(wave)` — both constructed on `kButtonB3`, each with
+  `page_b.Buttons(wave)`, both constructed on `kButtonB3`, each with
   its own `.Ident()`).
-- The same object on several pages is deliberately one shared control
-  (one preset byte, rendered on each page).
+- The same object on several pages is one shared control (one preset
+  byte, rendered on each page).
 - Moving a button between pages at runtime redirects dispatch and
   never touches its state.
 
@@ -60,8 +58,8 @@ keyed by the **VirtualButton object**.  Pages are pure dispatch scope:
 
 | Declaration | Meaning |
 |---|---|
-| `VirtualButton(hw, name)` | physical button (e.g. `kButtonB1`; a bare literal `0` won't compile — use the constant) |
-| `.Ident("field.id")` | stable host id; defaults to `"b<hw>"` — required when two buttons share a hw index |
+| `VirtualButton(hw, name)` | physical button (e.g. `kButtonB1`; a bare literal `0` won't compile, use the constant) |
+| `.Ident("field.id")` | stable host id; defaults to `"b<hw>"`; required when two buttons share a hw index |
 | `.Selector(kLabels)` | N-zone state; zones + labels from one array |
 | `.Selector(n)` / `.Toggle()` | unlabeled N zones / 2 zones |
 | `.Default(z)` | factory zone (checked against N) |
@@ -76,79 +74,80 @@ keyed by the **VirtualButton object**.  Pages are pure dispatch scope:
 | `VirtualButton(ident, name)` | host-only state: persisted + editable, no gesture |
 
 Gesture callbacks and mutations run in the control-loop poll (the
-`OnPoll` context).  Preset loads apply data in `Deserialize` but defer
+`OnPoll` context). Preset loads apply data in `Deserialize` but defer
 the `Bind`/`OnChange` notifications to the next frame, coalescing
 HostLink live pushes; notifications fire only when the zone actually
 changed.
 
 ## The contract
 
-- **Edges are never stolen.**  The bank reads only `IButton::Pressed()`
-  and derives its own edges.  App code reading `RisingEdge()` directly
-  (the `kick` example) keeps every edge — and sample-accurate triggers
-  like kick's audio-callback drum trigger should *stay* on direct
-  reads; bank callbacks run at the 1 ms poll.
-- **Gestures resolve against the press-time page.**  A page change mid
+- **The bank does not consume edges.** It reads only
+  `IButton::Pressed()` and derives its own edges, so app code reading
+  `RisingEdge()` directly (as in the `kick` example) sees every edge.
+  Sample-accurate triggers, such as kick's audio-callback drum trigger,
+  should stay on direct reads; bank callbacks run at the 1 ms poll.
+- **Gestures resolve against the press-time page.** A page change mid
   hold cannot retarget the gesture.
-- **Pager shadowing is deliberate.**  A gesture fired on a button that
-  carries a release-driven navigation binding — the cycle button, a
-  latch pair's button (`KnobStorage::ConsumesRelease`) — consumes that
+- **Gestures shadow page navigation.** A gesture fired on a button that
+  carries a release-driven navigation binding (the cycle button, or a
+  latch pair's button; see `KnobStorage::ConsumesRelease`) consumes that
   release (`KnobStorage::ConsumeButton`), so a button declared on B1
-  shadows page-advance on pages that declare it — and only there.
-- **Shift layers compose with taps.**  A `Pager::Shift` hold that
+  shadows page-advance on pages that declare it, and only there.
+- **Shift holds and taps share a button.** A `Pager::Shift` hold that
   edited a parameter claims its release (`KnobStorage::HoldClaimed`)
-  and the trailing tap stays quiet; a clean hold leaves the tap free.
-  See docs/pages-and-layers.md.
-- **Don't stack holds on the ParamLock button.**  Lock recording is
+  and the trailing tap does not fire; a hold that edited nothing leaves
+  the tap free. See docs/pages-and-layers.md.
+- **Don't stack holds on the ParamLock button.** Lock recording is
   hold+knob; the two hold gestures cannot be arbitrated.
-- **Settings gates gestures, not data.**  While Settings is active
+- **Settings gates gestures, not data.** While Settings is active
   presses are inert (an in-flight press is discarded), but preset/host
-  pushes still reach `Bind` targets.  One edge: the B2+B3 enter chord
-  only claims its buttons once it *completes* (after `hold_ms`), so a
-  tap declared on B2 or B3 fires if the chord is released early — a
+  pushes still reach `Bind` targets. One exception: the B2+B3 enter
+  chord only claims its buttons once it *completes* (after `hold_ms`),
+  so a tap declared on B2 or B3 fires if the chord is released early. A
   press that spans the activation is discarded by the gate, but an
-  abandoned chord taps.  Harmless for cyclic state (one extra press
-  undoes it); put tap-critical actions on buttons outside the chord.
-- **LED precedence.**  The bank paints after the pager's page tint, so
+  abandoned chord fires the tap. Harmless for cyclic state (one extra
+  press undoes it); put tap-critical actions on buttons outside the
+  chord.
+- **LED precedence.** The bank paints after the pager's page tint, so
   a declared mode color wins on a shared button.
-- **Tables are borrowed.**  `Selector`, `Labels`, and `Colors` keep a
+- **Tables are borrowed.** `Selector`, `Labels`, and `Colors` keep a
   pointer to the array you pass, so name it with static storage; a
   braced list is rejected at compile time.
 
 ## Freeze and validity
 
-The roster — which buttons persist, in what byte order — freezes at the
+The roster (which buttons persist, in what byte order) freezes at the
 first `Presets`/descriptor walk, the same moment the rest of the blob
-layout freezes.  Declare every stateful button (via a page or
+layout freezes. Declare every stateful button (via a page or
 `Global()`) before `presets.BootLoad()`; page *membership* stays freely
 mutable afterwards.
 
 Declaration errors latch `Ok() == false` and fail the descriptor build
-("no descriptor" beats a wrong one): label/color counts that disagree
-with the zone count, `Default()` out of range, duplicate idents, fewer
-than two zones, or a stateful button first seen after freeze.  An
-`Anchor()` that names no emitted field (or the button's own id) fails
-the same way — checked at descriptor `Finish()`, since the target may
-live in a component managed later.  `DescriptorBuilder::LastError()`
-carries the reason for any of these.
+(a missing descriptor is preferable to a wrong one): label/color counts
+that disagree with the zone count, `Default()` out of range, duplicate
+idents, fewer than two zones, or a stateful button first seen after
+freeze. An `Anchor()` that names no emitted field (or the button's own
+id) fails the same way; it is checked at descriptor `Finish()`, since
+the target may live in a component managed later.
+`DescriptorBuilder::LastError()` carries the reason for any of these.
 
 The bank's `SchemaHash()` folds every cell's ident and zone count, so
 reshaping the roster (or renaming an ident) invalidates saved preset
-slots instead of misreading them.  Adding a bank to existing firmware
+slots instead of misreading them. Adding a bank to existing firmware
 is a `Manage()` addition and invalidates old slots like any other.
 
 ## HostLink
 
 The bank emits one `kind: "buttons"` component (protocol §5.5).
-Stateful buttons are ordinary 1-byte enum fields, so **any** host —
-including one that predates the kind — renders them as an editable
-group and can change them today; button-aware hosts use the `page`,
-`anchor`, and `btn` keys to draw them inside the page cards.  Momentary
-buttons emit into the component's `modal` array.
+Stateful buttons are ordinary 1-byte enum fields, so any host, including
+one that predates the kind, renders them as an editable group and can
+edit them; button-aware hosts use the `page`, `anchor`, and `btn` keys
+to draw them inside the page cards. Momentary buttons emit into the
+component's `modal` array.
 
-Modules using the bank simply never call `Host::Buttons()`, so the
-legacy root `buttons` array (§5.3) is absent — no duplicate rendering.
-The legacy array remains supported for metadata-only firmware.
+Modules using the bank do not call `Host::Buttons()`, so the legacy
+root `buttons` array (§5.3) is absent and nothing renders twice. The
+legacy array remains supported for metadata-only firmware.
 
 ## Loop-less use
 
@@ -157,11 +156,10 @@ yourself: `bank.Attach(btns, n).Pages(pg)`, then per millisecond
 `bank.PollButtons(t_ms, gated, active_page)`, per frame
 `bank.Update(t_ms)` and `bank.Render(panel, active_page, t_ms)`.
 
-## Deferred by design
+## Not implemented
 
-- **Double-tap** — recognizing it forces latency onto every plain tap
-  on that button; it will be added when a real module wants it.
+- **Double-tap.** Detecting it adds latency to every plain tap on that
+  button.
 - **External field binding** (two buttons mutating one shared field
-  with different actions) — the cell layer is already shaped for it;
-  today, declare the second button momentary and call
-  `bank.SetZone(first, z)` from its callback.
+  with different actions). Workaround: declare the second button
+  momentary and call `bank.SetZone(first, z)` from its callback.

--- a/docs/buttons.md
+++ b/docs/buttons.md
@@ -111,6 +111,9 @@ changed.
   undoes it); put tap-critical actions on buttons outside the chord.
 - **LED precedence.**  The bank paints after the pager's page tint, so
   a declared mode color wins on a shared button.
+- **Tables are borrowed.**  `Selector`, `Labels`, and `Colors` keep a
+  pointer to the array you pass, so name it with static storage; a
+  braced list is rejected at compile time.
 
 ## Freeze and validity
 

--- a/framework/include/alchemy/host_link/descriptor.h
+++ b/framework/include/alchemy/host_link/descriptor.h
@@ -33,6 +33,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 #include "alchemy/host_link/json_writer.h"
 #include "alchemy/surface/see_ref.h"
 
@@ -194,6 +195,9 @@ class DescriptorBuilder
         return Buttons(buttons, static_cast<uint8_t>(N));
     }
 
+    /* Braced lists would dangle. */
+    bool Buttons(std::initializer_list<VirtualButton>) = delete;
+
     /* ── Jacks (top-level, optional) ────────────────────────────── */
     bool Jacks(const Jack* jacks, uint8_t count);
     bool Jacks(const Jack* const* jacks, uint8_t count);
@@ -203,6 +207,9 @@ class DescriptorBuilder
     {
         return Jacks(jacks, static_cast<uint8_t>(N));
     }
+
+    /* Braced lists would dangle. */
+    bool Jacks(std::initializer_list<Jack>) = delete;
 
     /* ── Manual root block (top-level, optional) ────────────────────
      * "manual":{preamble, sections[], presets:{help}}. */

--- a/framework/include/alchemy/host_link/host.h
+++ b/framework/include/alchemy/host_link/host.h
@@ -48,6 +48,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 
 #include "alchemy/host_link/describe.h"
 #include "alchemy/host_link/host_link.h"
@@ -138,6 +139,9 @@ class Host : public HostService
         return Buttons(buttons, static_cast<uint8_t>(N));
     }
 
+    /* Braced lists would dangle. */
+    Host& Buttons(std::initializer_list<VirtualButton>) = delete;
+
     template <typename... Rest>
     Host& Buttons(const VirtualButton& first, const Rest&... rest)
     {
@@ -156,6 +160,9 @@ class Host : public HostService
     {
         return Jacks(jacks, static_cast<uint8_t>(N));
     }
+
+    /* Braced lists would dangle. */
+    Host& Jacks(std::initializer_list<Jack>) = delete;
 
     template <typename... Rest>
     Host& Jacks(const Jack& first, const Rest&... rest)

--- a/framework/include/alchemy/surface/settings.h
+++ b/framework/include/alchemy/surface/settings.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cstdint>
+#include <initializer_list>
 #include "alchemy/control/lock_types.h"      /* LockSync, LockExit */
 #include "alchemy/control/pot_catch.h"
 #include "alchemy/hw/alchemy_lab_layout.h"   /* kNumPots */
@@ -159,6 +160,9 @@ class Settings : public Serializable
         {
             return Selector(static_cast<uint8_t>(N)).Labels(labels);
         }
+
+        /* Braced lists would dangle. */
+        SelectorHandle Selector(std::initializer_list<const char*>) = delete;
 
       private:
         Settings& s_;

--- a/framework/include/alchemy/surface/settings_control.h
+++ b/framework/include/alchemy/surface/settings_control.h
@@ -24,6 +24,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 #include "alchemy/control/pot_catch.h"
 #include "alchemy/led/anims/fill.h"
 #include "alchemy/led/anims/selector.h"
@@ -307,6 +308,9 @@ class SelectorHandle
     template <size_t N>
     SelectorHandle& Labels(const char* const (&labels)[N])
     { return Labels(labels, static_cast<uint8_t>(N)); }
+
+    /* Braced lists would dangle. */
+    SelectorHandle& Labels(std::initializer_list<const char*>) = delete;
 
     /* Identity + prose — see BrightnessHandle. */
     SelectorHandle& Ident(const char* id) { if (s_) s_->ident = id; return *this; }

--- a/framework/include/alchemy/surface/virtual_button.h
+++ b/framework/include/alchemy/surface/virtual_button.h
@@ -49,6 +49,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 
 #include "alchemy/led/panel.h"   /* LedPanel::Rgb */
 #include "alchemy/surface/see_ref.h"
@@ -178,6 +179,9 @@ class VirtualButton
         return *this;
     }
 
+    /* Braced lists would dangle. */
+    VirtualButton& Selector(std::initializer_list<const char*>) = delete;
+
     /** Two-zone state (on/off). */
     constexpr VirtualButton& Toggle() { return Selector(2); }
 
@@ -202,10 +206,13 @@ class VirtualButton
         return Labels(labels, static_cast<uint8_t>(N));
     }
 
+    /* Braced lists would dangle. */
+    VirtualButton& Labels(std::initializer_list<const char*>) = delete;
+
     /** Per-zone LED colors painted by the bank while this button's page
      *  is active.  Count checked against zones at bank freeze (pass
      *  n == 0 to skip the check for a non-array source). */
-    constexpr VirtualButton& Colors(const LedPanel::Rgb* per_zone, uint8_t n = 0)
+    constexpr VirtualButton& Colors(const LedPanel::Rgb* per_zone, uint8_t n)
     {
         colors_     = per_zone;
         num_colors_ = n;
@@ -217,6 +224,9 @@ class VirtualButton
     {
         return Colors(per_zone, static_cast<uint8_t>(N));
     }
+
+    /* Braced lists would dangle. */
+    VirtualButton& Colors(std::initializer_list<LedPanel::Rgb>) = delete;
 
     /* ── Gestures (at most one tap + one hold) ───────────────────────────
      * A stateful button with no declared gesture tap-cycles by default

--- a/framework/include/alchemy/surface/virtual_knob.h
+++ b/framework/include/alchemy/surface/virtual_knob.h
@@ -30,6 +30,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 #include "alchemy/hardware_types.h"        /* ArcGeometry */
 #include "alchemy/led/anim_desc.h"         /* ParamSlot, ArcStyle, FillAnim */
 #include "alchemy/led/panel.h"             /* LedPanel, LedPanel::Rgb */
@@ -380,6 +381,9 @@ class VirtualKnob
     {
         return Labels(labels, static_cast<uint8_t>(N));
     }
+
+    /* Braced lists would dangle. */
+    VirtualKnob& Labels(std::initializer_list<const char*>) = delete;
 
     /** Raw display-hint JSON (protocol §5); overrides the derived hint. */
     VirtualKnob& Disp(const char* disp_json) { disp_json_ = disp_json; return *this; }


### PR DESCRIPTION
`.Colors({a, b})` and the Labels/Selector/Buttons/Jacks equivalents compiled and stored a pointer to an array that died at the end of the statement. Each builder now has a deleted `std::initializer_list` overload, so the call fails with "use of deleted function". Named arrays are unaffected.

Also drops the default on `Colors(ptr, n = 0)`: it was winning overload resolution for named arrays too, so `NumZoneColors()` was always 0 and the count check was dead. All in-tree tables already match.

Verified on host (build + tests), the ARM preset (all examples), and under arm-none-eabi-g++ 15 directly. No wire or schema impact.
